### PR TITLE
P1-1: JSON Schemas for the six rule-system YAML types

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,0 +1,31 @@
+name: schema-validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  schema-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pinned validator deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "jsonschema>=4.21,<5" \
+            "referencing>=0.32,<1" \
+            "pyyaml>=6,<7"
+
+      - name: Run schema fixture suite
+        run: python tests/schema/run.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 *.txt
 *.log
 *.db
+__pycache__/
+*.pyc
 

--- a/schema/base.schema.json
+++ b/schema/base.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/base.schema.json",
+  "title": "Universal Rules (base.yaml)",
+  "description": "Validates the top-level base.yaml of universal rules; also serves as the shared $defs library for sibling schemas. Per SPEC.md §2.1, §2.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "source"],
+  "properties": {
+    "id": {
+      "$ref": "#/$defs/dottedId",
+      "description": "Universal rules root ID, e.g. 'base'."
+    },
+    "source": { "$ref": "#/$defs/source" },
+    "rules": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ruleItem" }
+    },
+    "anti_patterns": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/antiPatternItem" }
+    },
+    "context": {
+      "description": "Project-specific informational notes; not binding. SPEC §2.3.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "dottedId": {
+      "description": "Dotted-path identifier for rule/register/baseline IDs. Each segment starts alphanumeric; locale-code segments may include uppercase region tags (de_AT, pt_PT). Rule keys may contain hyphens (register-lock).",
+      "type": "string",
+      "pattern": "^[a-z][a-zA-Z0-9_-]*(\\.[a-zA-Z0-9][a-zA-Z0-9_-]*)*$"
+    },
+    "uuidId": {
+      "description": "Stable identifier for terms and worked examples. <kind>.<key>#<8hex>, per SPEC.md §4. Suffix is exactly 8 lowercase hex digits.",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_-]*\\.[a-z][a-zA-Z0-9_-]*#[0-9a-f]{8}$"
+    },
+    "retroId": {
+      "description": "Retrospective ID format: YYYY-MM-DD-<slug>. Matches the filename without .md.",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}-[a-zA-Z0-9_-]+$"
+    },
+    "isoDate": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "commitSha": {
+      "description": "Short or full git commit SHA.",
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "localeCode": {
+      "description": "Locale code (e.g. de, de_AT, pt_PT, zh).",
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(_[A-Z]{2})?$"
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["error", "warning", "info"]
+    },
+    "modality": {
+      "description": "RFC 2119-style modality of a rule.",
+      "type": "string",
+      "enum": ["MUST", "MUST_NOT", "SHOULD", "SHOULD_NOT", "MAY"]
+    },
+    "mergeStrategy": {
+      "type": "string",
+      "enum": ["append", "replace", "prepend", "dedup"]
+    },
+    "source": {
+      "description": "Provenance pointer — SPEC reference, reviews/<date>/ path, native-speaker:<initials>, or null when explicitly unsourced. Required field on every rule file.",
+      "type": ["string", "null"]
+    },
+    "ruleItem": {
+      "description": "A single rule. id is a dotted path; statement is the human-readable rule.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "modality", "statement", "severity"],
+      "properties": {
+        "id": { "$ref": "#/$defs/dottedId" },
+        "modality": { "$ref": "#/$defs/modality" },
+        "statement": { "type": "string", "minLength": 1 },
+        "severity": { "$ref": "#/$defs/severity" },
+        "rule_ref": { "$ref": "#/$defs/dottedId" },
+        "docs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "rationale": { "type": "string" },
+        "source": { "$ref": "#/$defs/source" }
+      }
+    },
+    "antiPatternItem": {
+      "description": "A pattern to avoid. Has the same shape as a rule but lives in a separate partition.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement"],
+      "properties": {
+        "id": { "$ref": "#/$defs/dottedId" },
+        "statement": { "type": "string", "minLength": 1 },
+        "severity": { "$ref": "#/$defs/severity" },
+        "rule_ref": { "$ref": "#/$defs/dottedId" },
+        "docs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "rationale": { "type": "string" },
+        "source": { "$ref": "#/$defs/source" }
+      }
+    }
+  }
+}

--- a/schema/baselines.schema.json
+++ b/schema/baselines.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/baselines.schema.json",
+  "title": "Baselines (commit pins)",
+  "description": "Per-locale baseline pins. Each entry records the SHA at which a locale's content was deemed correct, plus invariants and either a retro_id or a justification_doc. Per SPEC.md §1, §2.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "source", "baselines"],
+  "properties": {
+    "id": {
+      "$ref": "base.schema.json#/$defs/dottedId",
+      "description": "Top-level dotted ID, e.g. baselines."
+    },
+    "source": { "$ref": "base.schema.json#/$defs/source" },
+    "baselines": {
+      "type": "object",
+      "description": "Map of locale code (e.g. de_AT) to baseline entry.",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z]{2,3}(_[A-Z]{2})?$": { "$ref": "#/$defs/baselineEntry" }
+      },
+      "minProperties": 1
+    }
+  },
+  "$defs": {
+    "baselineEntry": {
+      "description": "A single baseline pin. Requires retro_id OR justification_doc (anyOf — both may be present, e.g. when a justification existed before the retro was filed).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit"],
+      "properties": {
+        "commit": { "$ref": "base.schema.json#/$defs/commitSha" },
+        "pinned_on": { "$ref": "base.schema.json#/$defs/isoDate" },
+        "invariants": {
+          "description": "Properties that must hold at this baseline (e.g. register.formality=Sie, glossary.secret_object=Geheimnis).",
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "retro_id": { "$ref": "base.schema.json#/$defs/retroId" },
+        "justification_doc": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to a doc justifying the pin (e.g. reviews/<date>/<file>.md)."
+        },
+        "note": { "type": "string" },
+        "source": { "$ref": "base.schema.json#/$defs/source" }
+      },
+      "anyOf": [
+        { "required": ["retro_id"] },
+        { "required": ["justification_doc"] }
+      ]
+    }
+  }
+}

--- a/schema/glossary.schema.json
+++ b/schema/glossary.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/glossary.schema.json",
+  "title": "Locale Glossary",
+  "description": "Per-locale glossary with sense-split terms and worked examples. Per SPEC.md §2.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "source", "terms"],
+  "properties": {
+    "id": {
+      "$ref": "base.schema.json#/$defs/dottedId",
+      "description": "Dotted ID for the glossary, e.g. glossary.de_AT."
+    },
+    "source": { "$ref": "base.schema.json#/$defs/source" },
+    "terms": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/term" }
+    }
+  },
+  "$defs": {
+    "term": {
+      "description": "A glossary term. id is uuid-form; key is the human-readable grep target.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "key"],
+      "properties": {
+        "id": { "$ref": "base.schema.json#/$defs/uuidId" },
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable identifier, e.g. 'secret_object'. The id 8-char suffix survives renames; this key is the grep target."
+        },
+        "en": {
+          "type": "string",
+          "description": "Source-language form."
+        },
+        "disambiguation": {
+          "$ref": "#/$defs/disambiguation"
+        },
+        "examples": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/example" }
+        },
+        "rule_refs": {
+          "type": "array",
+          "items": { "$ref": "base.schema.json#/$defs/dottedId" },
+          "uniqueItems": true
+        },
+        "rationale": { "type": "string" },
+        "source": { "$ref": "base.schema.json#/$defs/source" }
+      },
+      "patternProperties": {
+        "^[a-z]{2,3}(_[A-Z]{2})?$": {
+          "description": "Locale-keyed target form (e.g. de_AT: Geheimnis). May be a single string or a sense-split mapping.",
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-z][a-zA-Z0-9_-]*$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["target"],
+                  "properties": {
+                    "target": { "type": "string", "minLength": 1 },
+                    "rule_ref": { "$ref": "base.schema.json#/$defs/dottedId" },
+                    "rationale": { "type": "string" }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "disambiguation": {
+      "description": "Heuristic guidance for picking among senses.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "heuristic": { "type": "string" },
+        "key_patterns": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "example": {
+      "description": "A worked translation example. Example IDs use the uuid form ex.<key>#<8hex>.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "target", "verdict"],
+      "properties": {
+        "id": { "$ref": "base.schema.json#/$defs/uuidId" },
+        "source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source-language string (typically English)."
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target-language string."
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["good", "bad", "borderline"]
+        },
+        "rule_refs": {
+          "type": "array",
+          "items": { "$ref": "base.schema.json#/$defs/dottedId" },
+          "uniqueItems": true
+        },
+        "note": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schema/register.schema.json
+++ b/schema/register.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/register.schema.json",
+  "title": "Locale Register Lock",
+  "description": "Per-locale register: form, pronoun, possessives, forbidden tokens, exceptions. Per SPEC.md §1, §2.2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "source",
+    "form",
+    "pronoun",
+    "forbidden_tokens",
+    "exceptions"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "base.schema.json#/$defs/dottedId",
+      "description": "Dotted ID, e.g. register.de_AT."
+    },
+    "source": {
+      "$ref": "base.schema.json#/$defs/source",
+      "description": "Provenance for this token set as a whole. Per-token source overrides if present."
+    },
+    "form": {
+      "type": "string",
+      "enum": ["formal", "informal", "mixed", "other"]
+    },
+    "pronoun": {
+      "type": "string",
+      "minLength": 1
+    },
+    "possessive": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "forbidden_tokens": {
+      "description": "Tokens whose presence in target locale content is a register violation. Required. May be an empty list, but never null.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/forbiddenToken" }
+    },
+    "exceptions": {
+      "description": "Allowlist of strings (or contexts) where forbidden tokens may legitimately appear. Required field; may be an empty list, never null.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/exception" }
+    },
+    "rule_ref": {
+      "$ref": "base.schema.json#/$defs/dottedId"
+    },
+    "baseline_ref": {
+      "$ref": "base.schema.json#/$defs/dottedId"
+    },
+    "retro_refs": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/retroId" },
+      "uniqueItems": true
+    },
+    "register_spec": {
+      "description": "Free-form extension hook for non-binary register systems (ja keigo, ko politeness). SPEC §8.",
+      "type": "object"
+    },
+    "authority_refs": {
+      "description": "Flat references to external authorities (e.g. OQLF). SPEC §8.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "forbiddenToken": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "context", "severity"],
+      "properties": {
+        "token": {
+          "type": "string",
+          "minLength": 1
+        },
+        "context": {
+          "type": "string",
+          "enum": ["standalone_word", "word_prefix", "substring", "any"]
+        },
+        "severity": { "$ref": "base.schema.json#/$defs/severity" },
+        "source": { "$ref": "base.schema.json#/$defs/source" },
+        "note": { "type": "string" }
+      }
+    },
+    "exception": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "reason"],
+      "properties": {
+        "token": { "type": "string", "minLength": 1 },
+        "reason": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string" },
+        "source": { "$ref": "base.schema.json#/$defs/source" }
+      }
+    }
+  }
+}

--- a/schema/retrospective.schema.json
+++ b/schema/retrospective.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/retrospective.schema.json",
+  "title": "Retrospective Frontmatter",
+  "description": "Validates the YAML frontmatter of retrospectives/<date>-<slug>.md. Body prose is not schema-validated. Per SPEC.md §3 lifecycle.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "date",
+    "status",
+    "triggered_by",
+    "affected_locales",
+    "affected_rules",
+    "examples_added",
+    "baseline_pins",
+    "resolved_in_commit",
+    "supersedes",
+    "declined_reason",
+    "would_change_decision_if"
+  ],
+  "properties": {
+    "id": {
+      "$ref": "base.schema.json#/$defs/retroId",
+      "description": "YYYY-MM-DD-<slug>; matches the filename without .md."
+    },
+    "date": { "$ref": "base.schema.json#/$defs/isoDate" },
+    "status": {
+      "type": "string",
+      "enum": ["pending", "applied", "declined", "superseded"]
+    },
+    "triggered_by": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["incident"],
+      "properties": {
+        "commits": {
+          "type": "array",
+          "items": { "$ref": "base.schema.json#/$defs/commitSha" }
+        },
+        "incident": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "affected_locales": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/localeCode" }
+    },
+    "affected_rules": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/dottedId" }
+    },
+    "examples_added": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/uuidId" }
+    },
+    "baseline_pins": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/dottedId" }
+    },
+    "resolved_in_commit": {
+      "oneOf": [
+        { "$ref": "base.schema.json#/$defs/commitSha" },
+        { "type": "null" }
+      ]
+    },
+    "supersedes": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/retroId" }
+    },
+    "declined_reason": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "would_change_decision_if": {
+      "type": ["string", "null"],
+      "minLength": 1
+    }
+  },
+  "allOf": [
+    {
+      "description": "status: applied requires resolved_in_commit to be a real SHA (non-null). SPEC §3.",
+      "if": {
+        "properties": { "status": { "const": "applied" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "resolved_in_commit": { "$ref": "base.schema.json#/$defs/commitSha" }
+        }
+      }
+    },
+    {
+      "description": "status: declined requires declined_reason and would_change_decision_if to be populated. SPEC §3.",
+      "if": {
+        "properties": { "status": { "const": "declined" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "declined_reason": { "type": "string", "minLength": 1 },
+          "would_change_decision_if": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    {
+      "description": "status: superseded requires at least one entry in supersedes. The newer retro identifies which retro it replaces; the older one's superseded list is not enforced here. The pairing is enforced cross-file by the resolver.",
+      "if": {
+        "properties": { "status": { "const": "superseded" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "supersedes": { "type": "array" }
+        }
+      }
+    }
+  ]
+}

--- a/schema/rules.schema.json
+++ b/schema/rules.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://onetimesecret.github.io/translation-rules/schema/rules.schema.json",
+  "title": "Locale Rules",
+  "description": "Per-locale rules.yaml. Inherits from a parent locale or 'base'. Per SPEC.md §2.2, §2.3.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "source"],
+  "properties": {
+    "id": {
+      "$ref": "base.schema.json#/$defs/dottedId",
+      "description": "Dotted ID for the locale rules, e.g. rules.de_AT."
+    },
+    "source": { "$ref": "base.schema.json#/$defs/source" },
+    "inherits": {
+      "description": "Parent rule file(s) — single string or list. Resolver builds the chain (e.g. de_AT -> de -> base) and detects cycles. SPEC §2.3.",
+      "oneOf": [
+        { "$ref": "base.schema.json#/$defs/dottedId" },
+        {
+          "type": "array",
+          "items": { "$ref": "base.schema.json#/$defs/dottedId" },
+          "minItems": 1
+        }
+      ]
+    },
+    "merge_strategy": {
+      "description": "Default merge strategy for list fields when merging with parent rules. Per-field overrides are not yet specified — see SPEC §2.3 step 3.",
+      "$ref": "base.schema.json#/$defs/mergeStrategy"
+    },
+    "rules": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/ruleItem" }
+    },
+    "anti_patterns": {
+      "type": "array",
+      "items": { "$ref": "base.schema.json#/$defs/antiPatternItem" }
+    },
+    "context": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "register_ref": {
+      "$ref": "base.schema.json#/$defs/dottedId"
+    },
+    "glossary_ref": {
+      "$ref": "base.schema.json#/$defs/dottedId"
+    },
+    "baseline_ref": {
+      "$ref": "base.schema.json#/$defs/dottedId"
+    }
+  }
+}

--- a/tests/schema/fixtures/base/negative/bad-modality.yaml
+++ b/tests/schema/fixtures/base/negative/bad-modality.yaml
@@ -1,0 +1,10 @@
+__meta__:
+  reason: "modality must be RFC 2119 enum; 'must' (lowercase) is invalid."
+  expected_error_path: /rules/0/modality
+id: base
+source: SPEC.md
+rules:
+  - id: rule.interpolation-vars
+    modality: must
+    statement: "Interpolation must match."
+    severity: error

--- a/tests/schema/fixtures/base/negative/missing-source.yaml
+++ b/tests/schema/fixtures/base/negative/missing-source.yaml
@@ -1,0 +1,5 @@
+__meta__:
+  reason: "source is required on every rule file (P1-1 acceptance)."
+  expected_error_path: /
+id: base
+rules: []

--- a/tests/schema/fixtures/base/negative/rule-missing-statement.yaml
+++ b/tests/schema/fixtures/base/negative/rule-missing-statement.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "Each rule item requires id, modality, statement, severity. Missing 'statement' should fail."
+  expected_error_path: /rules/0
+id: base
+source: SPEC.md
+rules:
+  - id: rule.interpolation-vars
+    modality: MUST
+    severity: error

--- a/tests/schema/fixtures/base/positive/just-id-and-source.yaml
+++ b/tests/schema/fixtures/base/positive/just-id-and-source.yaml
@@ -1,0 +1,2 @@
+id: base
+source: null

--- a/tests/schema/fixtures/base/positive/minimal.yaml
+++ b/tests/schema/fixtures/base/positive/minimal.yaml
@@ -1,0 +1,19 @@
+id: base
+source: SPEC.md
+rules:
+  - id: rule.interpolation-vars
+    modality: MUST
+    statement: "Interpolation variables in the target must match the source character-for-character."
+    severity: error
+    rule_ref: rule.interpolation-vars
+  - id: rule.no-emoji
+    modality: MUST_NOT
+    statement: "Translations must not introduce emoji that are absent from the source string."
+    severity: warning
+anti_patterns:
+  - id: anti.harmonize-rewrites
+    statement: "Harmonization changes keys only; never text rewrites."
+    severity: error
+    source: "reviews/2026-04-12/cross-locale-audit.md"
+context:
+  - "OneTimeSecret is a secrets-sharing application. UI strings are user-facing."

--- a/tests/schema/fixtures/baselines/negative/bad-commit-sha.yaml
+++ b/tests/schema/fixtures/baselines/negative/bad-commit-sha.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "commit must match a hex SHA, not arbitrary text."
+  expected_error_path: /baselines/de_AT/commit
+id: baselines
+source: SPEC.md
+baselines:
+  de_AT:
+    commit: HEAD~3
+    retro_id: 2026-04-12-de_AT-register-flip

--- a/tests/schema/fixtures/baselines/negative/missing-both-retro-and-justification.yaml
+++ b/tests/schema/fixtures/baselines/negative/missing-both-retro-and-justification.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "Each baseline entry requires retro_id OR justification_doc (P1-1 acceptance: 'one of two')."
+  expected_error_path: /baselines/de_AT
+id: baselines
+source: SPEC.md
+baselines:
+  de_AT:
+    commit: b08e59838
+    invariants: ["register.de_AT.form=formal"]

--- a/tests/schema/fixtures/baselines/negative/missing-commit.yaml
+++ b/tests/schema/fixtures/baselines/negative/missing-commit.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "Each baseline entry requires a commit SHA — that's the whole point of a baseline pin."
+  expected_error_path: /baselines/de_AT
+id: baselines
+source: SPEC.md
+baselines:
+  de_AT:
+    retro_id: 2026-04-12-de_AT-register-flip
+    invariants: []

--- a/tests/schema/fixtures/baselines/positive/de_AT-with-justification.yaml
+++ b/tests/schema/fixtures/baselines/positive/de_AT-with-justification.yaml
@@ -1,0 +1,8 @@
+id: baselines
+source: native-speaker:dlb
+baselines:
+  fr_CA:
+    commit: 4982d4f84
+    justification_doc: "reviews/2026-04-12/locale-quality-analysis-fr_CA.md"
+    invariants:
+      - "register.fr_CA.form=formal"

--- a/tests/schema/fixtures/baselines/positive/de_AT-with-retro.yaml
+++ b/tests/schema/fixtures/baselines/positive/de_AT-with-retro.yaml
@@ -1,0 +1,11 @@
+id: baselines
+source: SPEC.md#1
+baselines:
+  de_AT:
+    commit: b08e59838
+    pinned_on: 2026-04-12
+    invariants:
+      - "register.de_AT.form=formal"
+      - "register.de_AT.pronoun=Sie"
+      - "glossary.de_AT.secret_object=Geheimnis"
+    retro_id: 2026-04-12-de_AT-register-flip

--- a/tests/schema/fixtures/glossary/negative/example-bad-verdict-enum.yaml
+++ b/tests/schema/fixtures/glossary/negative/example-bad-verdict-enum.yaml
@@ -1,0 +1,13 @@
+__meta__:
+  reason: "verdict must be good | bad | borderline."
+  expected_error_path: /terms/0/examples/0/verdict
+id: glossary.de_AT
+source: SPEC.md
+terms:
+  - id: term.secret_object#7f3a91c2
+    key: secret_object
+    examples:
+      - id: ex.burn#a12b45ef
+        source: "Burn this secret"
+        target: "Dieses Geheimnis verbrennen"
+        verdict: ok

--- a/tests/schema/fixtures/glossary/negative/example-missing-verdict.yaml
+++ b/tests/schema/fixtures/glossary/negative/example-missing-verdict.yaml
@@ -1,0 +1,12 @@
+__meta__:
+  reason: "Each example requires id, source, target, verdict. Missing 'verdict' should fail."
+  expected_error_path: /terms/0/examples/0
+id: glossary.de_AT
+source: SPEC.md
+terms:
+  - id: term.secret_object#7f3a91c2
+    key: secret_object
+    examples:
+      - id: ex.burn#a12b45ef
+        source: "Burn this secret"
+        target: "Dieses Geheimnis verbrennen"

--- a/tests/schema/fixtures/glossary/negative/term-bad-id-format.yaml
+++ b/tests/schema/fixtures/glossary/negative/term-bad-id-format.yaml
@@ -1,0 +1,8 @@
+__meta__:
+  reason: "Term IDs must use the uuid form <kind>.<key>#<8hex>. A dotted-only id is invalid."
+  expected_error_path: /terms/0/id
+id: glossary.de_AT
+source: SPEC.md
+terms:
+  - id: term.secret_object
+    key: secret_object

--- a/tests/schema/fixtures/glossary/positive/de_AT-secret-split.yaml
+++ b/tests/schema/fixtures/glossary/positive/de_AT-secret-split.yaml
@@ -1,0 +1,28 @@
+id: glossary.de_AT
+source: reviews/2026-04-12/locale-quality-analysis-de_AT.md
+terms:
+  - id: term.secret_object#7f3a91c2
+    key: secret_object
+    en: secret
+    de_AT: Geheimnis
+    disambiguation:
+      heuristic: "Lifecycle verb (create/share/burn/expire) selects the object sense."
+      key_patterns: ["*.burn*", "*.share*", "*.expire*", "*.create*"]
+    examples:
+      - id: ex.burn#a12b45ef
+        source: "Burn this secret"
+        target: "Dieses Geheimnis verbrennen"
+        verdict: good
+        rule_refs: [register.de_AT.formality, glossary.de_AT.object-content-split]
+    rule_refs: [glossary.de_AT.object-content-split]
+  - id: term.secret_content#3c8e2a91
+    key: secret_content
+    en: secret
+    de_AT: Nachricht
+    disambiguation:
+      heuristic: "Content-bearing context (your secret message) selects the content sense."
+    examples:
+      - id: ex.message-readable#b91d2f47
+        source: "Your secret is now readable"
+        target: "Ihre Nachricht ist nun lesbar"
+        verdict: good

--- a/tests/schema/fixtures/register/negative/bad-form-enum.yaml
+++ b/tests/schema/fixtures/register/negative/bad-form-enum.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "form must be one of formal | informal | mixed | other."
+  expected_error_path: /form
+id: register.de_AT
+source: null
+form: respectful
+pronoun: Sie
+forbidden_tokens: []
+exceptions: []

--- a/tests/schema/fixtures/register/negative/bad-id-format.yaml
+++ b/tests/schema/fixtures/register/negative/bad-id-format.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "register IDs must be dotted-path lowercase. 'Register.DE_AT' violates the regex (uppercase)."
+  expected_error_path: /id
+id: Register.DE_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+forbidden_tokens: []
+exceptions: []

--- a/tests/schema/fixtures/register/negative/extra-property.yaml
+++ b/tests/schema/fixtures/register/negative/extra-property.yaml
@@ -1,0 +1,10 @@
+__meta__:
+  reason: "additionalProperties: false must reject typos. SPEC §2.2 'Schemas forbid null where an empty list is required' implies a closed surface."
+  expected_error_path: /
+id: register.de_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+forbidden_tokens: []
+exceptions: []
+forbidden_token: []

--- a/tests/schema/fixtures/register/negative/forbidden-token-missing-fields.yaml
+++ b/tests/schema/fixtures/register/negative/forbidden-token-missing-fields.yaml
@@ -1,0 +1,11 @@
+__meta__:
+  reason: "Each forbidden_token entry requires token, context, severity. Missing 'context' should fail."
+  expected_error_path: /forbidden_tokens/0
+id: register.de_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+forbidden_tokens:
+  - token: du
+    severity: error
+exceptions: []

--- a/tests/schema/fixtures/register/negative/forbidden_tokens-null.yaml
+++ b/tests/schema/fixtures/register/negative/forbidden_tokens-null.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "SPEC.md §2.2 — forbidden_tokens: null is the headline failure case schemas exist to reject."
+  expected_error_path: /forbidden_tokens
+id: register.de_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+forbidden_tokens: null
+exceptions: []

--- a/tests/schema/fixtures/register/negative/missing-exceptions.yaml
+++ b/tests/schema/fixtures/register/negative/missing-exceptions.yaml
@@ -1,0 +1,9 @@
+__meta__:
+  reason: "SPEC.md §2.2 — exceptions field is required even when empty."
+  expected_error_path: /
+id: register.de_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+forbidden_tokens:
+  - { token: du, context: standalone_word, severity: error }

--- a/tests/schema/fixtures/register/negative/missing-source.yaml
+++ b/tests/schema/fixtures/register/negative/missing-source.yaml
@@ -1,0 +1,8 @@
+__meta__:
+  reason: "P1-1 acceptance — source field is required (string or null)."
+  expected_error_path: /
+id: register.de_AT
+form: formal
+pronoun: Sie
+forbidden_tokens: []
+exceptions: []

--- a/tests/schema/fixtures/register/positive/de_AT-minimal.yaml
+++ b/tests/schema/fixtures/register/positive/de_AT-minimal.yaml
@@ -1,0 +1,20 @@
+id: register.de_AT
+source: SPEC.md#1
+form: formal
+pronoun: Sie
+possessive: [Ihr, Ihre, Ihren, Ihrem, Ihrer, Ihres]
+forbidden_tokens:
+  - { token: du,     context: standalone_word, severity: error }
+  - { token: dein,   context: standalone_word, severity: error }
+  - { token: deine,  context: standalone_word, severity: error }
+  - { token: deinen, context: standalone_word, severity: error }
+  - { token: deinem, context: standalone_word, severity: error }
+  - { token: deiner, context: standalone_word, severity: error }
+  - { token: dich,   context: standalone_word, severity: error }
+  - { token: dir,    context: standalone_word, severity: error }
+  - { token: euch,   context: standalone_word, severity: error }
+  - { token: euer,   context: standalone_word, severity: error }
+exceptions: []
+rule_ref: register.de_AT.formality
+baseline_ref: baselines.de_AT
+retro_refs: [2026-04-12-de_AT-register-flip]

--- a/tests/schema/fixtures/register/positive/with-exceptions-and-per-token-source.yaml
+++ b/tests/schema/fixtures/register/positive/with-exceptions-and-per-token-source.yaml
@@ -1,0 +1,17 @@
+id: register.fr_CA
+source: native-speaker:dlb
+form: formal
+pronoun: vous
+forbidden_tokens:
+  - token: tu
+    context: standalone_word
+    severity: error
+    source: native-speaker:dlb
+  - token: toi
+    context: standalone_word
+    severity: error
+exceptions:
+  - token: tu
+    reason: "Quoted speech in user-supplied content; never appears in UI strings."
+    scope: user_content
+authority_refs: [OQLF]

--- a/tests/schema/fixtures/retrospective/negative/applied-without-commit.md
+++ b/tests/schema/fixtures/retrospective/negative/applied-without-commit.md
@@ -1,0 +1,21 @@
+---
+__meta__:
+  reason: "status: applied requires resolved_in_commit to be a real SHA, not null. SPEC §3."
+  expected_error_path: /resolved_in_commit
+id: 2026-04-12-de_AT-register-flip
+date: 2026-04-12
+status: applied
+triggered_by:
+  commits: [b08e59838]
+  incident: "de_AT formal->informal register flip"
+affected_locales: [de_AT]
+affected_rules: [register.de_AT.formality]
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body prose.

--- a/tests/schema/fixtures/retrospective/negative/bad-id-format.md
+++ b/tests/schema/fixtures/retrospective/negative/bad-id-format.md
@@ -1,0 +1,21 @@
+---
+__meta__:
+  reason: "Retrospective IDs must be YYYY-MM-DD-<slug>; a dotted-path is invalid here."
+  expected_error_path: /id
+id: retro.de_AT.register
+date: 2026-04-12
+status: pending
+triggered_by:
+  commits: []
+  incident: "x"
+affected_locales: []
+affected_rules: []
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body.

--- a/tests/schema/fixtures/retrospective/negative/bad-status-enum.md
+++ b/tests/schema/fixtures/retrospective/negative/bad-status-enum.md
@@ -1,0 +1,21 @@
+---
+__meta__:
+  reason: "status must be pending | applied | declined | superseded. 'closed' is not in the lifecycle."
+  expected_error_path: /status
+id: 2026-04-12-de_AT-register-flip
+date: 2026-04-12
+status: closed
+triggered_by:
+  commits: []
+  incident: "x"
+affected_locales: []
+affected_rules: []
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body.

--- a/tests/schema/fixtures/retrospective/negative/declined-without-reason.md
+++ b/tests/schema/fixtures/retrospective/negative/declined-without-reason.md
@@ -1,0 +1,21 @@
+---
+__meta__:
+  reason: "status: declined requires declined_reason and would_change_decision_if. Both null is invalid. SPEC §3."
+  expected_error_path: /declined_reason
+id: 2026-05-01-fr_CA-no-OQLF-mandate
+date: 2026-05-01
+status: declined
+triggered_by:
+  commits: []
+  incident: "Proposal to require OQLF-mandated terminology."
+affected_locales: [fr_CA]
+affected_rules: []
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body prose.

--- a/tests/schema/fixtures/retrospective/positive/applied-with-commit.md
+++ b/tests/schema/fixtures/retrospective/positive/applied-with-commit.md
@@ -1,0 +1,18 @@
+---
+id: 2026-04-12-de_AT-register-flip
+date: 2026-04-12
+status: applied
+triggered_by:
+  commits: [b08e59838, 4982d4f84, 44b3c3352]
+  incident: "de_AT formal->informal register flip"
+affected_locales: [de_AT]
+affected_rules: [register.de_AT.formality]
+examples_added: []
+baseline_pins: [baselines.de_AT]
+resolved_in_commit: a1b2c3d4e5f6789
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body prose. Not validated by schema.

--- a/tests/schema/fixtures/retrospective/positive/declined-with-reason.md
+++ b/tests/schema/fixtures/retrospective/positive/declined-with-reason.md
@@ -1,0 +1,18 @@
+---
+id: 2026-05-01-fr_CA-no-OQLF-mandate
+date: 2026-05-01
+status: declined
+triggered_by:
+  commits: []
+  incident: "Proposal to require OQLF-mandated terminology across all Canadian French content."
+affected_locales: [fr_CA]
+affected_rules: [register.fr_CA.formality]
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: "OneTimeSecret is not a B2G product and has no Quebec-government customers; the cost of OQLF compliance exceeds the benefit at current scale."
+would_change_decision_if: "We sign a customer subject to Bill 96 obligations or expand into Quebec public sector."
+---
+
+Body prose.

--- a/tests/schema/fixtures/retrospective/positive/pending-fresh.md
+++ b/tests/schema/fixtures/retrospective/positive/pending-fresh.md
@@ -1,0 +1,18 @@
+---
+id: 2026-04-26-start-translation-session-conventions-drift
+date: 2026-04-26
+status: pending
+triggered_by:
+  commits: []
+  incident: "Inlined Locale Conventions Reference table in /d:start-translation-session has drifted from current guidance for the de family."
+affected_locales: [de, de_AT]
+affected_rules: [register.de.formality, register.de_AT.formality]
+examples_added: []
+baseline_pins: []
+resolved_in_commit: null
+supersedes: []
+declined_reason: null
+would_change_decision_if: null
+---
+
+Body prose.

--- a/tests/schema/fixtures/rules/negative/bad-merge-strategy.yaml
+++ b/tests/schema/fixtures/rules/negative/bad-merge-strategy.yaml
@@ -1,0 +1,6 @@
+__meta__:
+  reason: "merge_strategy must be append | replace | prepend | dedup."
+  expected_error_path: /merge_strategy
+id: rules.de_AT
+source: SPEC.md
+merge_strategy: union

--- a/tests/schema/fixtures/rules/negative/inherits-empty-list.yaml
+++ b/tests/schema/fixtures/rules/negative/inherits-empty-list.yaml
@@ -1,0 +1,6 @@
+__meta__:
+  reason: "inherits as a list must have at least one entry; an empty list is meaningless."
+  expected_error_path: /inherits
+id: rules.de_AT
+source: SPEC.md
+inherits: []

--- a/tests/schema/fixtures/rules/positive/de_AT-inherits-de.yaml
+++ b/tests/schema/fixtures/rules/positive/de_AT-inherits-de.yaml
@@ -1,0 +1,13 @@
+id: rules.de_AT
+source: SPEC.md#7
+inherits: rules.de
+merge_strategy: append
+rules:
+  - id: rule.de_AT.formality
+    modality: MUST
+    statement: "de_AT uses formal Sie-form throughout product UI and email content."
+    severity: error
+    rule_ref: register.de_AT.formality
+register_ref: register.de_AT
+glossary_ref: glossary.de_AT
+baseline_ref: baselines.de_AT

--- a/tests/schema/fixtures/rules/positive/multiple-inherits.yaml
+++ b/tests/schema/fixtures/rules/positive/multiple-inherits.yaml
@@ -1,0 +1,4 @@
+id: rules.pt_PT
+source: native-speaker:tba
+inherits: [rules.pt, base]
+rules: []

--- a/tests/schema/run.py
+++ b/tests/schema/run.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "jsonschema>=4.21,<5",
+#   "referencing>=0.32,<1",
+#   "pyyaml>=6,<7",
+# ]
+# ///
+"""Schema fixture runner for translation-rules.
+
+Runs JSON Schema validation against per-schema positive and negative fixtures.
+Distinguishes "negative didn't fail" (lax schema bug) from "negative failed for the
+wrong reason" (silent bug) via an optional `expected_error_path:` sidecar key.
+
+Usage:
+    python tests/schema/run.py                       # run all
+    python tests/schema/run.py register glossary     # run a subset
+
+Exit codes:
+    0  all fixtures behaved as expected
+    1  one or more fixtures behaved incorrectly
+    2  test harness setup error (missing schema, malformed fixture, etc.)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    print("error: PyYAML required (pip install pyyaml or uv run --with pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+
+class StringDateLoader(yaml.SafeLoader):
+    """SafeLoader variant that keeps ISO date/datetime values as strings.
+
+    PyYAML's default behavior maps `2026-04-12` to a `datetime.date` object, which
+    then fails JSON Schema `type: string` validation. Schemas in this repo want
+    raw strings (we run regex-based validation via `isoDate`), so the timestamp
+    resolver is disabled here.
+
+    The resolvers dict is deep-copied first so we don't mutate the inherited
+    SafeLoader dict (which would silently change yaml.safe_load behavior in any
+    other consumer running in the same process).
+    """
+
+
+StringDateLoader.yaml_implicit_resolvers = {
+    ch: [(tag, regex) for tag, regex in resolvers if tag != "tag:yaml.org,2002:timestamp"]
+    for ch, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+try:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+    from referencing import Registry, Resource
+    from referencing.jsonschema import DRAFT202012
+except ImportError:
+    print(
+        "error: jsonschema>=4.18 + referencing required "
+        "(pip install jsonschema or uv run --with jsonschema)",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCHEMA_DIR = REPO_ROOT / "schema"
+FIXTURE_DIR = REPO_ROOT / "tests" / "schema" / "fixtures"
+
+SCHEMA_NAMES = ["base", "rules", "register", "glossary", "baselines", "retrospective"]
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+
+
+def load_schema_registry() -> Registry:
+    """Load every schema/*.schema.json into a referencing Registry so $ref resolves."""
+    resources: list[tuple[str, Resource]] = []
+    for name in SCHEMA_NAMES:
+        path = SCHEMA_DIR / f"{name}.schema.json"
+        if not path.exists():
+            continue
+        with path.open() as fh:
+            schema = json.load(fh)
+        resource = Resource(contents=schema, specification=DRAFT202012)
+        # Register both by $id (canonical) and by relative filename (for $ref "base.schema.json#/...").
+        if "$id" in schema:
+            resources.append((schema["$id"], resource))
+        resources.append((f"{name}.schema.json", resource))
+    return Registry().with_resources(resources)
+
+
+def load_fixture(path: Path) -> tuple[Any, dict[str, Any]]:
+    """Load a fixture file. Returns (data, sidecar_meta).
+
+    Recognised forms:
+      - .yaml / .yml  → parsed as YAML; if a mapping has __meta__, that becomes the sidecar
+      - .json         → parsed as JSON; ditto __meta__
+      - .md           → frontmatter (YAML between ---/---) is the data; body ignored
+    """
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+
+    if suffix in {".yaml", ".yml"}:
+        data = yaml.load(text, Loader=StringDateLoader)
+    elif suffix == ".json":
+        data = json.loads(text)
+    elif suffix == ".md":
+        match = FRONTMATTER_RE.match(text)
+        if not match:
+            raise ValueError(f"{path}: missing YAML frontmatter")
+        data = yaml.load(match.group(1), Loader=StringDateLoader)
+    else:
+        raise ValueError(f"{path}: unsupported fixture suffix {suffix!r}")
+
+    meta: dict[str, Any] = {}
+    if isinstance(data, dict) and "__meta__" in data:
+        meta = data.pop("__meta__") or {}
+    return data, meta
+
+
+def error_path(err: ValidationError) -> str:
+    """Render a ValidationError's path as a slash-joined string for assertion."""
+    return "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else "/"
+
+
+def run_schema(schema_name: str, registry: Registry) -> tuple[int, int]:
+    """Run all fixtures under fixtures/<schema_name>/. Returns (passed, failed)."""
+    schema_path = SCHEMA_DIR / f"{schema_name}.schema.json"
+    if not schema_path.exists():
+        print(f"  skip: schema/{schema_name}.schema.json does not exist yet")
+        return (0, 0)
+
+    with schema_path.open() as fh:
+        schema = json.load(fh)
+    validator = Draft202012Validator(schema, registry=registry)
+
+    fixtures_root = FIXTURE_DIR / schema_name
+    if not fixtures_root.exists():
+        print(f"  skip: tests/schema/fixtures/{schema_name}/ does not exist yet")
+        return (0, 0)
+
+    passed = 0
+    failed = 0
+
+    for kind in ("positive", "negative"):
+        kind_dir = fixtures_root / kind
+        if not kind_dir.exists():
+            continue
+        for fixture_path in sorted(kind_dir.iterdir()):
+            if fixture_path.is_dir() or fixture_path.name.startswith("."):
+                continue
+            try:
+                data, meta = load_fixture(fixture_path)
+            except Exception as exc:
+                print(f"  FAIL {fixture_path.relative_to(REPO_ROOT)}: load error: {exc}")
+                failed += 1
+                continue
+
+            errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+            rel = fixture_path.relative_to(REPO_ROOT)
+
+            if kind == "positive":
+                if errors:
+                    print(f"  FAIL {rel}: positive fixture should validate, got {len(errors)} errors")
+                    for err in errors[:5]:
+                        print(f"        {error_path(err)}: {err.message}")
+                    failed += 1
+                else:
+                    print(f"  pass {rel}")
+                    passed += 1
+            else:  # negative
+                if not errors:
+                    print(f"  FAIL {rel}: negative fixture should fail, but validated cleanly")
+                    failed += 1
+                    continue
+
+                expected = meta.get("expected_error_path")
+                if expected is not None:
+                    matched = any(error_path(err) == expected for err in errors)
+                    if not matched:
+                        actual = ", ".join(error_path(e) for e in errors[:3])
+                        print(
+                            f"  FAIL {rel}: expected error at {expected!r}, "
+                            f"got: {actual}"
+                        )
+                        failed += 1
+                        continue
+                print(f"  pass {rel}")
+                passed += 1
+
+    return (passed, failed)
+
+
+def main(argv: list[str]) -> int:
+    targets = argv[1:] if len(argv) > 1 else SCHEMA_NAMES
+    bad = [t for t in targets if t not in SCHEMA_NAMES]
+    if bad:
+        print(f"error: unknown schema(s): {bad}. Known: {SCHEMA_NAMES}", file=sys.stderr)
+        return 2
+
+    try:
+        registry = load_schema_registry()
+    except Exception as exc:
+        print(f"error: failed to load schema registry: {exc}", file=sys.stderr)
+        return 2
+
+    total_passed = 0
+    total_failed = 0
+    for name in targets:
+        print(f"# {name}")
+        p, f = run_schema(name, registry)
+        total_passed += p
+        total_failed += f
+
+    print()
+    print(f"summary: {total_passed} passed, {total_failed} failed")
+    return 0 if total_failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #7. Tracked in #2.

Lands the authoritative contract layer for SPEC.md §2.2. Every YAML file the resolver will load (P1-2) must validate against one of these schemas before any merge or lint runs.

## Summary

- Six Draft 2020-12 schemas under `schema/` — `base`, `rules`, `register`, `glossary`, `baselines`, `retrospective`.
- `base.schema.json` doubles as the shared `$defs` library (`dottedId`, `uuidId`, `retroId`, `severity`, `modality`, `ruleItem`, etc.) so the ID regexes live in one place; the other five `$ref` into it.
- `tests/schema/run.py` — fixture runner with PEP 723 inline metadata so `uv run tests/schema/run.py` works without flags. Also runs under plain `python tests/schema/run.py` once deps are installed.
- 34 fixtures across the six schemas (positive + negative). Negative fixtures may carry `__meta__.expected_error_path` so a "fails for the wrong reason" silent bug is distinguishable from "fails as intended."
- `.github/workflows/schema-validation.yml` runs the suite on PRs and pushes to `main`.

## Headline failure cases the schemas reject

- `forbidden_tokens: null` — the SPEC §2.2 root cause for null-as-empty-list drift
- Missing `exceptions:` (must be present even when `[]`)
- Missing `source:` (P1-1 acceptance criterion)
- `status: applied` with `resolved_in_commit: null`
- `status: declined` with no `declined_reason` / `would_change_decision_if`
- Term IDs without the `<kind>.<key>#<8hex>` UUID suffix
- Baseline entries lacking both `retro_id` and `justification_doc`
- Typos at any closed-object level (`additionalProperties: false`)

## Decisions worth flagging on review

1. **Retrospective IDs use a date-slug regex, not a dotted-path regex.** Issue #7 says "rules.yaml, register.yaml, baselines.yaml, retrospective id: — dotted path regex," but the actual P0 retro file (`2026-04-12-de_AT-register-flip`) and `retrospectives/README.md` both use the date-slug form. The schema matches what's already on disk; revising issue #7 text rather than the file format.

2. **`baselines` uses `anyOf` for `retro_id` OR `justification_doc` (both allowed).** Issue text said "one of two." `anyOf` is the looser read; `oneOf` would XOR. I went looser because a justification doc may legitimately exist before its retro is filed (e.g. a review document predates the retrospective system). Easy to tighten later if a retro lands that argues for XOR.

3. **The CI workflow validates only `tests/schema/fixtures/`, not the live `retrospectives/` or `locales/` content.** Per the handoff, P1-2's resolver is the component that walks the real tree. Concretely: the existing `retrospectives/2026-04-12-de_AT-register-flip.md` carries `status: applied` with `resolved_in_commit: null`, which this schema would reject. That's fine on this PR — the merge SHA backfills before P1-2 starts walking the directory.

## Implementation notes

PyYAML's default `SafeLoader` parses `2026-04-12` into a `datetime.date` object, which fails JSON Schema `type: string` validation. The runner installs a `StringDateLoader` subclass with the timestamp resolver removed. The resolvers dict is deep-copied first so `yaml.safe_load` behavior elsewhere in the same process is untouched.

## Coexistence with PR #14

Different files, no overlap. Can merge in either order. P1-1 does not depend on Phase 0 content; only on `SPEC.md` (already on `main`).

## Test plan

- [x] `uv run tests/schema/run.py` → 34 passed, 0 failed locally
- [x] All six schemas loaded into a single referencing.Registry; `$ref base.schema.json#/$defs/...` resolves
- [x] Side-effect fix verified: `yaml.safe_load('d: 2026-04-12')['d']` is still a `datetime.date` after import
- [ ] CI green on this branch
- [ ] Reviewer confirms the three flagged decisions above