### PR TITLE
P1-2: Resolver skeleton + merge algorithm

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run schema fixture suite
         run: python tests/schema/run.py
+
+      - name: Run resolver inheritance fixture suite
+        run: python tests/inheritance/run.py

--- a/bin/mint-id
+++ b/bin/mint-id
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Mint or look up a stable id of the form `<kind>.<key>#<8hex>`.
+
+The id index is owned by the resolver. This CLI is read-only against
+resolver/index.json: it returns the existing id if (kind, key) is already
+registered; otherwise it computes the deterministic suffix that the resolver
+will assign on its next run. This keeps id minting offline-safe — authors do
+not need to run the full resolver to choose an id while drafting YAML.
+
+Usage:
+    bin/mint-id term secret_object
+    bin/mint-id ex burn
+    bin/mint-id rule register-lock
+
+Exit codes:
+    0  ok (prints id to stdout)
+    1  invalid kind or key
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from resolver.ids import IdError, IdIndex, mint_id  # noqa: E402
+
+USAGE = "usage: mint-id <kind> <key>"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(USAGE, file=sys.stderr)
+        return 1
+    kind, key = argv
+    try:
+        index = IdIndex.load(REPO_ROOT / "resolver" / "index.json")
+        new_id = mint_id(kind, key, index)
+    except IdError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(new_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/resolver/__init__.py
+++ b/resolver/__init__.py
@@ -1,0 +1,9 @@
+"""Translation rules resolver. SPEC.md §2.3 steps 1-4.
+
+P1-2 scope: load + schema-validate, inheritance chain, merge with provenance,
+ID resolution against an index. Lint, retro attachment, and emit are P1-3+.
+
+Submodules are imported on demand by callers — keeping this file empty avoids
+forcing every consumer (e.g. bin/mint-id, which only needs ids.py) to install
+schema-validation dependencies.
+"""

--- a/resolver/ids.py
+++ b/resolver/ids.py
@@ -1,0 +1,180 @@
+"""ID minting and lookup. SPEC.md §4.
+
+Stable ID format: `<kind>.<key>#<8hex>`. The 8-char suffix survives renames
+and file moves; the kind+key is the grep target. The resolver is the sole
+writer of `resolver/index.json`. `bin/mint-id` is read-only against the
+index — it computes a deterministic suffix and verifies (or refuses) based
+on whether `<kind>.<key>` is already registered.
+
+Determinism: `sha256(f"{kind}.{key}").hexdigest()[:8]`. If the deterministic
+suffix collides with a different `(kind, key)` already in the index, a salt
+is appended and re-hashed until unique. Re-minting an existing `(kind, key)`
+is a no-op (returns the registered id) so the operation is idempotent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+ID_RE = re.compile(r"^([a-z][a-z0-9_-]*)\.([a-z][a-zA-Z0-9_-]*)#([0-9a-f]{8})$")
+KIND_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+KEY_RE = re.compile(r"^[a-z][a-zA-Z0-9_-]*$")
+
+
+class IdError(Exception):
+    """Raised when an id is malformed, unresolvable, or collides irreconcilably."""
+
+
+@dataclass
+class IdRecord:
+    """One entry in resolver/index.json."""
+
+    id: str
+    kind: str
+    key: str
+    file: str  # repo-relative path
+    json_pointer: str  # JSONPath-style cursor inside the file
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "key": self.key,
+            "file": self.file,
+            "json_pointer": self.json_pointer,
+        }
+
+
+@dataclass
+class IdIndex:
+    """In-memory id index. Persists as resolver/index.json (sorted by id)."""
+
+    by_id: dict[str, IdRecord] = field(default_factory=dict)
+    by_kind_key: dict[tuple[str, str], IdRecord] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> "IdIndex":
+        idx = cls()
+        if not path.exists():
+            return idx
+        with path.open() as fh:
+            payload = json.load(fh)
+        for entry in payload.get("ids", []):
+            rec = IdRecord(
+                id=entry["id"],
+                kind=entry["kind"],
+                key=entry["key"],
+                file=entry.get("file", ""),
+                json_pointer=entry.get("json_pointer", ""),
+            )
+            idx.add(rec)
+        return idx
+
+    def add(self, rec: IdRecord) -> None:
+        if rec.id in self.by_id:
+            existing = self.by_id[rec.id]
+            if (existing.kind, existing.key) != (rec.kind, rec.key):
+                raise IdError(
+                    f"id collision: {rec.id} maps to {(existing.kind, existing.key)} "
+                    f"and {(rec.kind, rec.key)}"
+                )
+        self.by_id[rec.id] = rec
+        self.by_kind_key[(rec.kind, rec.key)] = rec
+
+    def lookup_id(self, id_: str) -> IdRecord | None:
+        return self.by_id.get(id_)
+
+    def lookup_kind_key(self, kind: str, key: str) -> IdRecord | None:
+        return self.by_kind_key.get((kind, key))
+
+    def dump(self, path: Path) -> None:
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "ids": [self.by_id[i].to_dict() for i in sorted(self.by_id)],
+        }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as fh:
+            json.dump(payload, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+
+
+def parse_id(id_: str) -> tuple[str, str, str]:
+    """Split `<kind>.<key>#<8hex>` into (kind, key, suffix)."""
+    m = ID_RE.match(id_)
+    if not m:
+        raise IdError(f"malformed id: {id_!r}")
+    return m.group(1), m.group(2), m.group(3)
+
+
+def deterministic_suffix(kind: str, key: str, salt: str = "") -> str:
+    """8-char hex suffix from `<kind>.<key>` (+ optional salt for collision recovery)."""
+    h = hashlib.sha256(f"{kind}.{key}{salt}".encode("utf-8")).hexdigest()
+    return h[:8]
+
+
+def mint_id(kind: str, key: str, index: IdIndex) -> str:
+    """Mint or return the existing id for (kind, key).
+
+    Idempotent: re-minting a known (kind, key) returns the registered id
+    without modifying the index. Determinism guarantees that two clean
+    runs with the same input produce the same suffix.
+    """
+    if not KIND_RE.match(kind):
+        raise IdError(f"invalid kind {kind!r}; must match {KIND_RE.pattern}")
+    if not KEY_RE.match(key):
+        raise IdError(f"invalid key {key!r}; must match {KEY_RE.pattern}")
+
+    existing = index.lookup_kind_key(kind, key)
+    if existing is not None:
+        return existing.id
+
+    salt = ""
+    attempt = 0
+    while True:
+        suffix = deterministic_suffix(kind, key, salt)
+        candidate = f"{kind}.{key}#{suffix}"
+        clash = index.lookup_id(candidate)
+        if clash is None:
+            return candidate
+        if (clash.kind, clash.key) == (kind, key):
+            return clash.id
+        attempt += 1
+        if attempt > 1024:
+            raise IdError(f"could not find collision-free suffix for {kind}.{key}")
+        salt = f":{attempt}"
+
+
+def collect_ids_from_tree(data: Any, file_path: str, kinds: Iterable[str] | None = None) -> list[IdRecord]:
+    """Walk a parsed YAML tree, returning every `id:` field whose value matches the uuid form.
+
+    Records the JSONPath cursor where each id was found. `kinds`, if given,
+    restricts which kinds are collected.
+    """
+    out: list[IdRecord] = []
+    allowed = set(kinds) if kinds else None
+    _walk(data, file_path, "", out, allowed)
+    return out
+
+
+def _walk(value: Any, file_path: str, cursor: str, out: list[IdRecord], allowed: set[str] | None) -> None:
+    if isinstance(value, dict):
+        # If this mapping itself has an `id:` of uuid form, record it.
+        raw_id = value.get("id")
+        if isinstance(raw_id, str):
+            try:
+                kind, key, _suffix = parse_id(raw_id)
+            except IdError:
+                pass  # not a uuid-form id; that's fine for dottedId rule ids
+            else:
+                if allowed is None or kind in allowed:
+                    out.append(IdRecord(id=raw_id, kind=kind, key=key, file=file_path, json_pointer=cursor or "/"))
+        for k, v in value.items():
+            _walk(v, file_path, f"{cursor}/{k}", out, allowed)
+    elif isinstance(value, list):
+        for i, sub in enumerate(value):
+            _walk(sub, file_path, f"{cursor}/{i}", out, allowed)

--- a/resolver/inheritance.py
+++ b/resolver/inheritance.py
@@ -1,0 +1,108 @@
+"""Inheritance chain resolution. SPEC.md §2.3 step 2.
+
+Only `rules.yaml` participates in inheritance. `register.yaml` and
+`glossary.yaml` are per-locale leaf files: load + validate, do not merge.
+
+Chain shape: child first, root last. de_AT → de → base.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class InheritanceError(Exception):
+    """Cycle, missing parent, or malformed inherits field."""
+
+
+@dataclass(frozen=True)
+class ChainNode:
+    """One step in an inheritance chain."""
+
+    locale: str  # "base" for the universal root
+    path: Path
+    data: dict[str, Any]
+
+
+def _coerce_inherits(raw: Any, source: Path) -> list[str]:
+    """`inherits:` may be a single string or a list. Normalise to a list."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list) and all(isinstance(x, str) for x in raw):
+        return list(raw)
+    raise InheritanceError(f"{source}: 'inherits' must be a string or list of strings, got {type(raw).__name__}")
+
+
+def _parent_locale_from_id(rule_id: str) -> str:
+    """Extract locale from a `rules.<locale>` id. Used only for error messages."""
+    parts = rule_id.split(".")
+    return parts[1] if len(parts) >= 2 else rule_id
+
+
+def _id_to_path(rule_id: str, locales_dir: Path, base_path: Path) -> Path:
+    """Map an `inherits` value (e.g. 'rules.de' or 'base') to a YAML file path."""
+    if rule_id == "base":
+        return base_path
+    if rule_id.startswith("rules."):
+        locale = rule_id[len("rules.") :]
+        return locales_dir / locale / "rules.yaml"
+    raise InheritanceError(
+        f"unsupported inherits target {rule_id!r}; expected 'base' or 'rules.<locale>'"
+    )
+
+
+def build_chain(
+    locale: str,
+    locales_dir: Path,
+    base_path: Path,
+    loader,
+) -> list[ChainNode]:
+    """Walk inherits: from `locale` up to `base`. Returns child-first chain.
+
+    `loader` is a callable Path -> dict (typically resolver.loader.load_yaml_file)
+    so that the chain builder is decoupled from the loader implementation
+    and trivially testable with in-memory fakes.
+    """
+    chain: list[ChainNode] = []
+    seen: dict[str, Path] = {}  # locale -> path that introduced it; used for cycle messages
+
+    current_id = f"rules.{locale}"
+    current_path = _id_to_path(current_id, locales_dir, base_path)
+
+    while True:
+        cur_locale = "base" if current_id == "base" else _parent_locale_from_id(current_id)
+        if cur_locale in seen:
+            cycle = " -> ".join([n.locale for n in chain] + [cur_locale])
+            raise InheritanceError(f"inheritance cycle detected: {cycle}")
+        if not current_path.exists():
+            raise InheritanceError(
+                f"inherits target not found: {current_id!r} expected at {current_path}"
+            )
+        data = loader(current_path)
+        if not isinstance(data, dict):
+            raise InheritanceError(f"{current_path}: expected mapping at top level")
+        chain.append(ChainNode(locale=cur_locale, path=current_path, data=data))
+        seen[cur_locale] = current_path
+
+        if cur_locale == "base":
+            break
+
+        inherits_raw = data.get("inherits")
+        parents = _coerce_inherits(inherits_raw, current_path)
+        if not parents:
+            # No parent declared and we are not base — implicit root is base.yaml.
+            current_id = "base"
+            current_path = base_path
+            continue
+        if len(parents) > 1:
+            raise InheritanceError(
+                f"{current_path}: multi-parent inheritance not supported in P1-2 (got {parents})"
+            )
+        current_id = parents[0]
+        current_path = _id_to_path(current_id, locales_dir, base_path)
+
+    return chain

--- a/resolver/loader.py
+++ b/resolver/loader.py
@@ -1,0 +1,75 @@
+"""YAML / Markdown-frontmatter loaders. SPEC.md §2.3 step 1.
+
+Centralises the StringDateLoader pattern from tests/schema/run.py so the
+resolver and the schema fixture runner do not diverge. The runner can switch
+to importing from here in a follow-up; for now the runner keeps its own copy
+to remain self-contained as a PEP 723 script.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class StringDateLoader(yaml.SafeLoader):
+    """SafeLoader variant that keeps ISO date/datetime values as strings.
+
+    PyYAML's default behavior maps `2026-04-12` to a `datetime.date` object,
+    which fails JSON Schema `type: string` validation. Schemas in this repo
+    validate ISO dates via the `isoDate` regex on raw strings, so the
+    timestamp resolver is disabled here.
+
+    The resolvers dict is rebuilt without the timestamp tag rather than
+    mutating the inherited SafeLoader dict — otherwise yaml.safe_load global
+    behavior would silently change for any other consumer in the same process.
+    """
+
+
+StringDateLoader.yaml_implicit_resolvers = {
+    ch: [(tag, regex) for tag, regex in resolvers if tag != "tag:yaml.org,2002:timestamp"]
+    for ch, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+
+
+class LoaderError(Exception):
+    """Raised when a file cannot be loaded as YAML or frontmatter."""
+
+
+def load_yaml_file(path: Path) -> Any:
+    """Load a YAML document, returning the parsed Python object.
+
+    Empty files return None. Multi-document YAML is rejected — every YAML in
+    this repo is a single document.
+    """
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = yaml.load(text, Loader=StringDateLoader)
+    except yaml.YAMLError as exc:
+        raise LoaderError(f"{path}: malformed YAML: {exc}") from exc
+    return data
+
+
+def load_retro_frontmatter(path: Path) -> dict[str, Any]:
+    """Load YAML frontmatter from a retrospective Markdown file.
+
+    The body prose is intentionally discarded — only frontmatter is
+    schema-validated per SPEC.md §3.
+    """
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        raise LoaderError(f"{path}: missing YAML frontmatter")
+    try:
+        data = yaml.load(match.group(1), Loader=StringDateLoader)
+    except yaml.YAMLError as exc:
+        raise LoaderError(f"{path}: malformed frontmatter: {exc}") from exc
+    if not isinstance(data, dict):
+        raise LoaderError(f"{path}: frontmatter must be a mapping")
+    return data

--- a/resolver/merge.py
+++ b/resolver/merge.py
@@ -1,0 +1,177 @@
+"""Tree merging with per-key provenance. SPEC.md §2.3 step 3.
+
+Rules:
+- maps: deep-merged (child keys win, parent keys preserved otherwise)
+- scalars: child replaces parent
+- lists: governed by `merge_strategy` (append | replace | prepend | dedup);
+  default is `replace`. The strategy is taken from the most child-specific
+  document that declares one; per-field overrides are deferred to P1-3+.
+
+Provenance is a flat dict keyed by JSONPath-style strings (e.g. `/rules/0/id`)
+mapping to the path of the file that contributed the leaf value. It is
+returned alongside the merged tree, NOT inlined into it — keeping the merged
+output a clean schema-compatible document for downstream emit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from resolver.inheritance import ChainNode
+
+DEFAULT_LIST_STRATEGY = "replace"
+VALID_LIST_STRATEGIES = ("append", "replace", "prepend", "dedup")
+
+
+class MergeError(Exception):
+    """Raised on incompatible merge (e.g. type mismatch between layers)."""
+
+
+def _merge_lists(parent: list, child: list, strategy: str) -> list:
+    if strategy == "replace":
+        return _copy_list(child)
+    if strategy == "append":
+        return _copy_list(parent) + _copy_list(child)
+    if strategy == "prepend":
+        return _copy_list(child) + _copy_list(parent)
+    if strategy == "dedup":
+        seen: set = set()
+        out: list = []
+        for item in _copy_list(parent) + _copy_list(child):
+            try:
+                key = item if isinstance(item, (str, int, float, bool, type(None))) else repr(item)
+            except Exception:
+                key = repr(item)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(item)
+        return out
+    raise MergeError(f"unknown merge strategy: {strategy!r}; valid: {VALID_LIST_STRATEGIES}")
+
+
+def _stamp_subtree(value: Any, provenance: dict[str, str], cursor: str, source: str) -> None:
+    """Stamp every leaf path under `value` with `source`."""
+    if isinstance(value, dict):
+        if not value:
+            provenance[cursor or "/"] = source
+            return
+        for key, sub in value.items():
+            _stamp_subtree(sub, provenance, f"{cursor}/{key}", source)
+    elif isinstance(value, list):
+        provenance[cursor or "/"] = source
+        for i, sub in enumerate(value):
+            _stamp_subtree(sub, provenance, f"{cursor}/{i}", source)
+    else:
+        provenance[cursor or "/"] = source
+
+
+def _merge_pair(
+    parent: Any,
+    child: Any,
+    child_source: str,
+    strategy: str,
+    provenance: dict[str, str],
+    cursor: str,
+) -> Any:
+    """Merge child into parent. Provenance is updated in place.
+
+    - parent: a value already in the accumulator (provenance already populated)
+    - child: a value from the next layer being folded in
+    - child_source: file path string for stamping new/replaced provenance
+    """
+    # Both maps: deep-merge.
+    if isinstance(parent, dict) and isinstance(child, dict):
+        out: dict[str, Any] = {}
+        # Preserve parent-only keys; their provenance is already set.
+        for key, p_val in parent.items():
+            if key not in child:
+                out[key] = p_val
+        # Merge or stamp child keys.
+        for key, c_val in child.items():
+            sub_cursor = f"{cursor}/{key}"
+            if key in parent:
+                out[key] = _merge_pair(parent[key], c_val, child_source, strategy, provenance, sub_cursor)
+            else:
+                out[key] = _copy_value(c_val)
+                _stamp_subtree(c_val, provenance, sub_cursor, child_source)
+        return out
+
+    # Both lists: strategy-driven.
+    if isinstance(parent, list) and isinstance(child, list):
+        merged = _merge_lists(parent, child, strategy)
+        # Lists are opaque under merge; stamp the list and its elements with
+        # the child as latest contributor. Element-level multi-source provenance
+        # is a P1-3 enhancement if needed.
+        _stamp_subtree(merged, provenance, cursor, child_source)
+        return merged
+
+    # Container/scalar mismatch: hard error to surface authoring bugs.
+    if isinstance(parent, (dict, list)) or isinstance(child, (dict, list)):
+        # Special case: parent missing (None) is permitted — child wins cleanly.
+        if parent is None:
+            _stamp_subtree(child, provenance, cursor, child_source)
+            return _copy_value(child)
+        raise MergeError(
+            f"type mismatch at {cursor or '/'}: parent={type(parent).__name__} "
+            f"vs child={type(child).__name__} (source: {child_source})"
+        )
+
+    # Scalars: child wins.
+    provenance[cursor or "/"] = child_source
+    return child
+
+
+def merge_chain(chain: list[ChainNode]) -> tuple[dict[str, Any], dict[str, str]]:
+    """Merge a chain produced by build_chain. Returns (merged_tree, provenance).
+
+    Chain order is child-first (de_AT, de, base). We fold from base down to
+    child so child values win on conflict.
+    """
+    if not chain:
+        raise MergeError("cannot merge empty chain")
+
+    # Strategy: most-specific declaration wins. Walk child-first; first one
+    # with `merge_strategy:` set is authoritative for the whole document.
+    strategy = DEFAULT_LIST_STRATEGY
+    for node in chain:
+        raw = node.data.get("merge_strategy")
+        if isinstance(raw, str):
+            strategy = raw
+            break
+    if strategy not in VALID_LIST_STRATEGIES:
+        raise MergeError(f"invalid merge_strategy {strategy!r}; valid: {VALID_LIST_STRATEGIES}")
+
+    # Initialise from root (base).
+    root = chain[-1]
+    merged: dict[str, Any] = _copy_value(root.data)
+    provenance: dict[str, str] = {}
+    _stamp_subtree(root.data, provenance, "", str(root.path))
+
+    # Fold parents -> child.
+    for node in reversed(chain[:-1]):
+        merged = _merge_pair(
+            merged,
+            node.data,
+            child_source=str(node.path),
+            strategy=strategy,
+            provenance=provenance,
+            cursor="",
+        )
+
+    if not isinstance(merged, dict):
+        raise MergeError("merge produced a non-mapping at the top level")
+
+    return merged, provenance
+
+
+def _copy_value(v: Any) -> Any:
+    if isinstance(v, dict):
+        return {k: _copy_value(sub) for k, sub in v.items()}
+    if isinstance(v, list):
+        return [_copy_value(sub) for sub in v]
+    return v
+
+
+def _copy_list(v: list) -> list:
+    return [_copy_value(sub) for sub in v]

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "jsonschema>=4.21,<5",
+#   "referencing>=0.32,<1",
+#   "pyyaml>=6,<7",
+# ]
+# ///
+"""Translation rules resolver. SPEC.md §2.3 steps 1-4.
+
+Pipeline:
+  1. Load + schema-validate base.yaml, locales/<locale>/*.yaml, retrospectives/*.md
+  2. Build inheritance chain for rules.yaml (de_AT -> de -> base)
+  3. Merge with provenance
+  4. Resolve every dotted/uuid/retro reference against a combined index;
+     emit resolver/index.json
+
+Usage:
+    resolver/resolve.py de_AT --validate-only
+    resolver/resolve.py de_AT --locales-dir locales --base-file base.yaml
+
+Exit codes:
+    0  success
+    1  validation/resolution error in input data
+    2  harness/setup error (missing schema, unreadable file, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+# Allow running as a script or as a module.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from resolver.ids import (
+    ID_RE,
+    IdError,
+    IdIndex,
+    IdRecord,
+    parse_id,
+)
+from resolver.inheritance import (
+    InheritanceError,
+    build_chain,
+)
+from resolver.loader import (
+    LoaderError,
+    load_retro_frontmatter,
+    load_yaml_file,
+)
+from resolver.merge import MergeError, merge_chain
+from resolver.validate import (
+    SchemaBundle,
+    ValidationFailed,
+    build_registry,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SCHEMA_DIR = REPO_ROOT / "schema"
+
+# Reference field names by shape.
+DOTTED_REF_FIELDS = {
+    "rule_ref",
+    "rule_refs",
+    "affected_rules",
+    "register_ref",
+    "glossary_ref",
+    "baseline_ref",
+    "baseline_pins",
+}
+RETRO_REF_FIELDS = {"retro_refs", "supersedes"}
+UUID_REF_FIELDS = {"examples_added"}
+
+
+@dataclass
+class CombinedIndex:
+    """Lookup for every authored id, irrespective of shape."""
+
+    by_dotted: dict[str, IdRecord] = field(default_factory=dict)
+    by_retro: dict[str, IdRecord] = field(default_factory=dict)
+    by_uuid: IdIndex = field(default_factory=IdIndex)
+
+    def add_dotted(self, rec: IdRecord) -> None:
+        existing = self.by_dotted.get(rec.id)
+        if existing is not None and existing.file != rec.file:
+            raise IdError(
+                f"duplicate dotted id {rec.id!r}: declared in {existing.file} and {rec.file}"
+            )
+        self.by_dotted[rec.id] = rec
+
+    def add_retro(self, rec: IdRecord) -> None:
+        existing = self.by_retro.get(rec.id)
+        if existing is not None and existing.file != rec.file:
+            raise IdError(
+                f"duplicate retro id {rec.id!r}: declared in {existing.file} and {rec.file}"
+            )
+        self.by_retro[rec.id] = rec
+
+    def add_uuid(self, rec: IdRecord) -> None:
+        self.by_uuid.add(rec)
+
+    def resolves(self, ref: str) -> bool:
+        if ID_RE.match(ref):
+            return self.by_uuid.lookup_id(ref) is not None
+        if _looks_like_retro_id(ref):
+            return ref in self.by_retro
+        return ref in self.by_dotted
+
+    def all_records(self) -> list[IdRecord]:
+        out: list[IdRecord] = list(self.by_dotted.values())
+        out.extend(self.by_retro.values())
+        out.extend(self.by_uuid.by_id.values())
+        return out
+
+
+def _looks_like_retro_id(value: str) -> bool:
+    parts = value.split("-", 3)
+    return len(parts) == 4 and parts[0].isdigit() and len(parts[0]) == 4
+
+
+@dataclass
+class LoadedFile:
+    path: Path
+    schema_name: str
+    data: Any
+    locale: str | None  # for per-locale leaves; None for base/baselines/retro
+
+
+@dataclass
+class ResolverInputs:
+    base_path: Path
+    locales_dir: Path
+    retros_dir: Path | None
+    schema_dir: Path
+    index_path: Path
+    project_root: Path  # paths in index.json are stored relative to this
+
+
+def _format_error(prefix: str, exc: Exception) -> str:
+    return f"{prefix}: {exc}"
+
+
+def _rel(path: Path, root: Path) -> str:
+    """Path string relative to project root if possible, else absolute."""
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _load_locale_files(
+    locale: str,
+    inputs: ResolverInputs,
+    bundle: SchemaBundle,
+) -> list[LoadedFile]:
+    """Load and validate every <locales_dir>/<locale>/*.yaml file."""
+    locale_dir = inputs.locales_dir / locale
+    out: list[LoadedFile] = []
+    if not locale_dir.exists():
+        return out
+    for path in sorted(locale_dir.iterdir()):
+        if path.suffix != ".yaml" or not path.is_file():
+            continue
+        schema_name = path.stem
+        if schema_name not in {"rules", "register", "glossary"}:
+            # Future-proof: ignore unknown leaf files in P1-2 rather than fail.
+            continue
+        data = load_yaml_file(path)
+        from resolver.validate import validate_file
+
+        validate_file(path, data, schema_name, bundle)
+        out.append(LoadedFile(path=path, schema_name=schema_name, data=data, locale=locale))
+    return out
+
+
+def _load_retros(inputs: ResolverInputs, bundle: SchemaBundle) -> list[LoadedFile]:
+    """Load + validate every retrospective frontmatter in retrospectives/."""
+    out: list[LoadedFile] = []
+    if inputs.retros_dir is None or not inputs.retros_dir.exists():
+        return out
+    for path in sorted(inputs.retros_dir.iterdir()):
+        if path.suffix != ".md" or not path.is_file() or path.name == "README.md":
+            continue
+        data = load_retro_frontmatter(path)
+        from resolver.validate import validate_file
+
+        validate_file(path, data, "retrospective", bundle)
+        out.append(LoadedFile(path=path, schema_name="retrospective", data=data, locale=None))
+    return out
+
+
+def _load_baselines(inputs: ResolverInputs, bundle: SchemaBundle) -> LoadedFile | None:
+    path = inputs.base_path.parent / "baselines.yaml"
+    if not path.exists():
+        return None
+    data = load_yaml_file(path)
+    from resolver.validate import validate_file
+
+    validate_file(path, data, "baselines", bundle)
+    return LoadedFile(path=path, schema_name="baselines", data=data, locale=None)
+
+
+def _index_dotted_ids_in_rules(data: dict[str, Any], file_path: Path, sink: CombinedIndex, root: Path) -> None:
+    """Capture top-level + nested rule/anti_pattern dotted ids."""
+    rel = _rel(file_path, root)
+    top_id = data.get("id")
+    if isinstance(top_id, str):
+        # base.yaml's top id is "base"; locale rules files use "rules.<locale>".
+        top_kind = "base" if top_id == "base" else "rules"
+        sink.add_dotted(IdRecord(id=top_id, kind=top_kind, key=top_id, file=rel, json_pointer="/id"))
+    for partition in ("rules", "anti_patterns"):
+        items = data.get(partition)
+        if not isinstance(items, list):
+            continue
+        for i, item in enumerate(items):
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                rid = item["id"]
+                sink.add_dotted(
+                    IdRecord(
+                        id=rid,
+                        kind=partition,
+                        key=rid,
+                        file=rel,
+                        json_pointer=f"/{partition}/{i}/id",
+                    )
+                )
+
+
+def _index_register(data: dict[str, Any], file_path: Path, sink: CombinedIndex, root: Path) -> None:
+    rel = _rel(file_path, root)
+    rid = data.get("id")
+    if isinstance(rid, str):
+        sink.add_dotted(IdRecord(id=rid, kind="register", key=rid, file=rel, json_pointer="/id"))
+
+
+def _index_glossary(data: dict[str, Any], file_path: Path, sink: CombinedIndex, root: Path) -> None:
+    rel = _rel(file_path, root)
+    rid = data.get("id")
+    if isinstance(rid, str):
+        sink.add_dotted(IdRecord(id=rid, kind="glossary", key=rid, file=rel, json_pointer="/id"))
+    terms = data.get("terms")
+    if not isinstance(terms, list):
+        return
+    for ti, term in enumerate(terms):
+        if not isinstance(term, dict):
+            continue
+        tid = term.get("id")
+        if isinstance(tid, str) and ID_RE.match(tid):
+            kind, key, _suf = parse_id(tid)
+            sink.add_uuid(
+                IdRecord(id=tid, kind=kind, key=key, file=rel, json_pointer=f"/terms/{ti}/id")
+            )
+        for ei, ex in enumerate(term.get("examples") or []):
+            if isinstance(ex, dict) and isinstance(ex.get("id"), str) and ID_RE.match(ex["id"]):
+                kind, key, _ = parse_id(ex["id"])
+                sink.add_uuid(
+                    IdRecord(
+                        id=ex["id"],
+                        kind=kind,
+                        key=key,
+                        file=rel,
+                        json_pointer=f"/terms/{ti}/examples/{ei}/id",
+                    )
+                )
+
+
+def _index_baselines(data: dict[str, Any], file_path: Path, sink: CombinedIndex, root: Path) -> None:
+    rel = _rel(file_path, root)
+    rid = data.get("id")
+    if isinstance(rid, str):
+        sink.add_dotted(IdRecord(id=rid, kind="baselines", key=rid, file=rel, json_pointer="/id"))
+    blocks = data.get("baselines")
+    if isinstance(blocks, dict):
+        for locale in blocks:
+            sink.add_dotted(
+                IdRecord(
+                    id=f"baselines.{locale}",
+                    kind="baselines",
+                    key=locale,
+                    file=rel,
+                    json_pointer=f"/baselines/{locale}",
+                )
+            )
+
+
+def _index_retro(data: dict[str, Any], file_path: Path, sink: CombinedIndex, root: Path) -> None:
+    rel = _rel(file_path, root)
+    rid = data.get("id")
+    if isinstance(rid, str):
+        sink.add_retro(
+            IdRecord(id=rid, kind="retrospective", key=rid, file=rel, json_pointer="/id")
+        )
+
+
+def _walk_refs(data: Any, cursor: str, out: list[tuple[str, str]]) -> None:
+    """Collect every (cursor, ref_value) for known reference fields."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            sub = f"{cursor}/{key}"
+            if key in DOTTED_REF_FIELDS or key in RETRO_REF_FIELDS or key in UUID_REF_FIELDS:
+                if isinstance(value, str):
+                    out.append((sub, value))
+                elif isinstance(value, list):
+                    for i, item in enumerate(value):
+                        if isinstance(item, str):
+                            out.append((f"{sub}/{i}", item))
+            _walk_refs(value, sub, out)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            _walk_refs(item, f"{cursor}/{i}", out)
+
+
+def _check_refs(scope: str, data: Any, index: CombinedIndex, errors: list[str]) -> None:
+    refs: list[tuple[str, str]] = []
+    _walk_refs(data, "", refs)
+    for cursor, ref in refs:
+        if not index.resolves(ref):
+            errors.append(f"{scope}: dangling reference {ref!r} at {cursor or '/'}")
+
+
+def resolve_locale(
+    locale: str,
+    inputs: ResolverInputs,
+    *,
+    validate_only: bool = False,
+) -> dict[str, Any]:
+    """Run the full P1-2 pipeline for one locale. Returns a result dict."""
+    if not inputs.base_path.exists():
+        raise FileNotFoundError(f"base file missing: {inputs.base_path}")
+    if not inputs.locales_dir.exists():
+        raise FileNotFoundError(f"locales dir missing: {inputs.locales_dir}")
+    bundle = build_registry(inputs.schema_dir)
+
+    # Step 1a: load + validate base.
+    base_data = load_yaml_file(inputs.base_path)
+    from resolver.validate import validate_file
+
+    validate_file(inputs.base_path, base_data, "base", bundle)
+
+    # Step 1b: load + validate locale leaves (rules, register, glossary).
+    locale_files = _load_locale_files(locale, inputs, bundle)
+    if not locale_files:
+        raise FileNotFoundError(f"no YAML files found under {inputs.locales_dir / locale}")
+
+    # Step 1c: parents on the inheritance chain for rules.yaml only.
+    rules_files = [f for f in locale_files if f.schema_name == "rules"]
+    if len(rules_files) > 1:
+        raise InheritanceError(f"multiple rules.yaml under {locale}")
+
+    chain_nodes = []
+    if rules_files:
+        rules_path = rules_files[0].path
+        # Pre-load+validate every parent in the chain.
+        def loader(p: Path):
+            data = load_yaml_file(p)
+            schema_name = "base" if p == inputs.base_path else "rules"
+            validate_file(p, data, schema_name, bundle)
+            return data
+
+        chain_nodes = build_chain(locale, inputs.locales_dir, inputs.base_path, loader)
+        merged_rules, provenance = merge_chain(chain_nodes)
+    else:
+        # No rules.yaml on this locale — surface a clear message; this is rare
+        # in practice (Phase 1 de_AT will have one).
+        merged_rules = base_data
+        provenance = {}
+
+    # Step 1d: baselines + retrospectives (project-wide, locale-agnostic).
+    baselines = _load_baselines(inputs, bundle)
+    retros = _load_retros(inputs, bundle)
+
+    # Step 4 prep: build the combined index.
+    index = CombinedIndex()
+    root = inputs.project_root
+    _index_dotted_ids_in_rules(base_data, inputs.base_path, index, root)
+    for f in locale_files:
+        if f.schema_name == "rules":
+            _index_dotted_ids_in_rules(f.data, f.path, index, root)
+        elif f.schema_name == "register":
+            _index_register(f.data, f.path, index, root)
+        elif f.schema_name == "glossary":
+            _index_glossary(f.data, f.path, index, root)
+    for node in chain_nodes:
+        if node.path != inputs.base_path:
+            _index_dotted_ids_in_rules(node.data, node.path, index, root)
+    if baselines is not None:
+        _index_baselines(baselines.data, baselines.path, index, root)
+    for retro in retros:
+        _index_retro(retro.data, retro.path, index, root)
+
+    # Step 4: walk merged rules + per-locale leaves + baselines + retros for refs.
+    errors: list[str] = []
+    _check_refs(f"rules ({locale})", merged_rules, index, errors)
+    for f in locale_files:
+        if f.schema_name != "rules":
+            _check_refs(f"{f.schema_name} ({locale})", f.data, index, errors)
+    if baselines is not None:
+        _check_refs("baselines", baselines.data, index, errors)
+    for retro in retros:
+        _check_refs(f"retro {retro.path.name}", retro.data, index, errors)
+
+    if errors:
+        raise ResolutionError("dangling references:\n  " + "\n  ".join(errors))
+
+    # Emit index.json (skip in validate-only mode).
+    if not validate_only:
+        idx_out = IdIndex()
+        for rec in index.all_records():
+            try:
+                idx_out.add(rec)
+            except IdError as exc:
+                # Two records sharing an id but different (kind,key) is a true
+                # error already surfaced by add_*; skip silently here.
+                _ = exc
+        idx_out.dump(inputs.index_path)
+
+    return {
+        "locale": locale,
+        "merged_rules": merged_rules,
+        "provenance": provenance,
+        "chain": [n.locale for n in chain_nodes],
+        "index_records": len(index.all_records()),
+    }
+
+
+class ResolutionError(Exception):
+    """Raised when ID resolution fails (dangling refs, etc.)."""
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="resolver/resolve.py", description=__doc__)
+    parser.add_argument("locale", help="Locale code, e.g. de_AT.")
+    parser.add_argument("--validate-only", action="store_true",
+                        help="Run pipeline but do not write resolver/index.json.")
+    parser.add_argument("--locales-dir", default="locales",
+                        help="Directory containing per-locale YAML files (default: locales).")
+    parser.add_argument("--base-file", default="base.yaml",
+                        help="Path to universal rules YAML (default: base.yaml).")
+    parser.add_argument("--retrospectives-dir", default="retrospectives",
+                        help="Directory containing retrospective .md files (default: retrospectives).")
+    parser.add_argument("--schema-dir", default=str(DEFAULT_SCHEMA_DIR),
+                        help="Directory containing JSON Schemas (default: <repo>/schema).")
+    parser.add_argument("--index-path", default="resolver/index.json",
+                        help="Path to write resolver index (default: resolver/index.json).")
+    parser.add_argument("--project-root", default=".",
+                        help="Project root for relative paths in index.json (default: .).")
+    args = parser.parse_args(argv)
+
+    inputs = ResolverInputs(
+        base_path=Path(args.base_file).resolve(),
+        locales_dir=Path(args.locales_dir).resolve(),
+        retros_dir=Path(args.retrospectives_dir).resolve()
+        if Path(args.retrospectives_dir).exists()
+        else None,
+        schema_dir=Path(args.schema_dir).resolve(),
+        index_path=Path(args.index_path).resolve(),
+        project_root=Path(args.project_root).resolve(),
+    )
+
+    try:
+        result = resolve_locale(args.locale, inputs, validate_only=args.validate_only)
+    except (LoaderError, ValidationFailed, InheritanceError, MergeError, ResolutionError, IdError) as exc:
+        print(_format_error("error", exc), file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(_format_error("setup", exc), file=sys.stderr)
+        return 2
+
+    chain_str = " -> ".join(result["chain"]) if result["chain"] else "(no chain)"
+    summary = (
+        f"resolved {args.locale}: chain={chain_str}, "
+        f"refs={result['index_records']} ids indexed"
+    )
+    if args.validate_only:
+        # Per issue #8: --validate-only prints merged tree to stdout, exits 0.
+        json.dump(result["merged_rules"], sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        print(summary, file=sys.stderr)
+    else:
+        print(summary)
+        print(f"wrote {inputs.index_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/resolver/validate.py
+++ b/resolver/validate.py
@@ -1,0 +1,88 @@
+"""Schema validation. SPEC.md §2.3 step 1.
+
+Each YAML file kind maps to exactly one schema. The mapping is centralised
+here so the CLI and any future bin/validate share it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+SCHEMA_NAMES = ("base", "rules", "register", "glossary", "baselines", "retrospective")
+
+
+class ValidationFailed(Exception):
+    """Raised when a YAML/frontmatter document fails schema validation."""
+
+    def __init__(self, path: Path, errors: list[ValidationError]) -> None:
+        self.path = path
+        self.errors = errors
+        super().__init__(self._render())
+
+    def _render(self) -> str:
+        lines = [f"{self.path}: schema validation failed ({len(self.errors)} error(s))"]
+        for err in self.errors[:10]:
+            loc = "/" + "/".join(str(p) for p in err.absolute_path) if err.absolute_path else "/"
+            lines.append(f"  {loc}: {err.message}")
+        if len(self.errors) > 10:
+            lines.append(f"  ... and {len(self.errors) - 10} more")
+        return "\n".join(lines)
+
+
+class SchemaBundle:
+    """Schema registry + per-name lookup of raw schema bodies for validator construction."""
+
+    def __init__(self, schema_dir: Path) -> None:
+        self.schema_dir = schema_dir
+        self._schemas: dict[str, dict[str, Any]] = {}
+        self.registry = self._build()
+
+    def _build(self) -> Registry:
+        resources: list[tuple[str, Resource]] = []
+        for name in SCHEMA_NAMES:
+            path = self.schema_dir / f"{name}.schema.json"
+            if not path.exists():
+                raise FileNotFoundError(f"schema missing: {path}")
+            with path.open() as fh:
+                schema = json.load(fh)
+            self._schemas[name] = schema
+            resource = Resource(contents=schema, specification=DRAFT202012)
+            if "$id" in schema:
+                resources.append((schema["$id"], resource))
+            resources.append((f"{name}.schema.json", resource))
+        return Registry().with_resources(resources)
+
+    def validator_for(self, schema_name: str) -> Draft202012Validator:
+        if schema_name not in self._schemas:
+            raise KeyError(f"unknown schema: {schema_name}")
+        return Draft202012Validator(self._schemas[schema_name], registry=self.registry)
+
+
+def build_registry(schema_dir: Path) -> SchemaBundle:
+    """Load every schema/*.schema.json into a SchemaBundle (registry + lookup)."""
+    return SchemaBundle(schema_dir)
+
+
+def validate_file(path: Path, data: Any, schema_name: str, bundle: SchemaBundle) -> None:
+    """Validate `data` against the named schema. Raises ValidationFailed on error."""
+    validator = bundle.validator_for(schema_name)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if errors:
+        raise ValidationFailed(path, errors)
+
+
+def schema_for_filename(filename: str) -> str | None:
+    """Return the schema name that governs a given filename, or None.
+
+    Naming convention: `<kind>.yaml` ⇒ `<kind>` schema. Retrospective .md
+    files are handled separately by the caller (frontmatter extraction).
+    """
+    stem = Path(filename).stem
+    return stem if stem in SCHEMA_NAMES else None

--- a/tests/inheritance/fixtures/chain-happy/base.yaml
+++ b/tests/inheritance/fixtures/chain-happy/base.yaml
@@ -1,0 +1,9 @@
+id: base
+source: SPEC.md §2.2
+rules:
+  - id: rule.universal-truth
+    modality: MUST
+    statement: Source-language strings are authoritative.
+    severity: error
+context:
+  - "Universal context line."

--- a/tests/inheritance/fixtures/chain-happy/expect.json
+++ b/tests/inheritance/fixtures/chain-happy/expect.json
@@ -1,0 +1,19 @@
+{
+  "kind": "positive",
+  "locale": "de_AT",
+  "chain": ["de_AT", "de", "base"],
+  "merged_keys": ["id", "source", "inherits", "rules", "context"],
+  "rule_ids": [
+    "rule.universal-truth",
+    "rule.de-shared",
+    "rule.de_AT.formality"
+  ],
+  "merge_strategy": "append",
+  "expect_top_id": "rules.de_AT",
+  "provenance_for": {
+    "/id": "locales/de_AT/rules.yaml",
+    "/inherits": "locales/de_AT/rules.yaml",
+    "/merge_strategy": "locales/de_AT/rules.yaml",
+    "/context/0": "base.yaml"
+  }
+}

--- a/tests/inheritance/fixtures/chain-happy/locales/de/rules.yaml
+++ b/tests/inheritance/fixtures/chain-happy/locales/de/rules.yaml
@@ -1,0 +1,8 @@
+id: rules.de
+source: tests/inheritance/fixtures/chain-happy
+inherits: base
+rules:
+  - id: rule.de-shared
+    modality: SHOULD
+    statement: Prefer Sie/Ihr in business contexts.
+    severity: warning

--- a/tests/inheritance/fixtures/chain-happy/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/chain-happy/locales/de_AT/rules.yaml
@@ -1,0 +1,9 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/chain-happy
+inherits: rules.de
+merge_strategy: append
+rules:
+  - id: rule.de_AT.formality
+    modality: MUST
+    statement: Sie/Ihr only — du/dein are forbidden tokens.
+    severity: error

--- a/tests/inheritance/fixtures/cycle/base.yaml
+++ b/tests/inheritance/fixtures/cycle/base.yaml
@@ -1,0 +1,3 @@
+id: base
+source: tests/inheritance/fixtures/cycle
+rules: []

--- a/tests/inheritance/fixtures/cycle/expect.json
+++ b/tests/inheritance/fixtures/cycle/expect.json
@@ -1,0 +1,6 @@
+{
+  "kind": "negative",
+  "locale": "de_AT",
+  "error_type": "InheritanceError",
+  "error_substring": "cycle"
+}

--- a/tests/inheritance/fixtures/cycle/locales/de/rules.yaml
+++ b/tests/inheritance/fixtures/cycle/locales/de/rules.yaml
@@ -1,0 +1,4 @@
+id: rules.de
+source: tests/inheritance/fixtures/cycle
+inherits: rules.de_AT
+rules: []

--- a/tests/inheritance/fixtures/cycle/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/cycle/locales/de_AT/rules.yaml
@@ -1,0 +1,4 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/cycle
+inherits: rules.de
+rules: []

--- a/tests/inheritance/fixtures/dangling-retro-ref/base.yaml
+++ b/tests/inheritance/fixtures/dangling-retro-ref/base.yaml
@@ -1,0 +1,3 @@
+id: base
+source: tests/inheritance/fixtures/dangling-retro-ref
+rules: []

--- a/tests/inheritance/fixtures/dangling-retro-ref/expect.json
+++ b/tests/inheritance/fixtures/dangling-retro-ref/expect.json
@@ -1,0 +1,6 @@
+{
+  "kind": "negative",
+  "locale": "de_AT",
+  "error_type": "ResolutionError",
+  "error_substring": "2099-01-01-this-retro-does-not-exist"
+}

--- a/tests/inheritance/fixtures/dangling-retro-ref/locales/de_AT/register.yaml
+++ b/tests/inheritance/fixtures/dangling-retro-ref/locales/de_AT/register.yaml
@@ -1,0 +1,8 @@
+id: register.de_AT
+source: tests/inheritance/fixtures/dangling-retro-ref
+form: formal
+pronoun: Sie
+forbidden_tokens: []
+exceptions: []
+retro_refs:
+  - 2099-01-01-this-retro-does-not-exist

--- a/tests/inheritance/fixtures/dangling-retro-ref/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/dangling-retro-ref/locales/de_AT/rules.yaml
@@ -1,0 +1,4 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/dangling-retro-ref
+inherits: base
+rules: []

--- a/tests/inheritance/fixtures/dangling-rule-ref/base.yaml
+++ b/tests/inheritance/fixtures/dangling-rule-ref/base.yaml
@@ -1,0 +1,7 @@
+id: base
+source: tests/inheritance/fixtures/dangling-rule-ref
+rules:
+  - id: rule.exists
+    modality: SHOULD
+    statement: An existing rule.
+    severity: warning

--- a/tests/inheritance/fixtures/dangling-rule-ref/expect.json
+++ b/tests/inheritance/fixtures/dangling-rule-ref/expect.json
@@ -1,0 +1,6 @@
+{
+  "kind": "negative",
+  "locale": "de_AT",
+  "error_type": "ResolutionError",
+  "error_substring": "rule.does_not_exist"
+}

--- a/tests/inheritance/fixtures/dangling-rule-ref/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/dangling-rule-ref/locales/de_AT/rules.yaml
@@ -1,0 +1,9 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/dangling-rule-ref
+inherits: base
+rules:
+  - id: rule.de_AT.cite
+    modality: MUST
+    statement: References a rule that does not exist.
+    severity: error
+    rule_ref: rule.does_not_exist

--- a/tests/inheritance/fixtures/merge-append/base.yaml
+++ b/tests/inheritance/fixtures/merge-append/base.yaml
@@ -1,0 +1,9 @@
+id: base
+source: tests/inheritance/fixtures/merge-append
+rules:
+  - id: rule.parent
+    modality: SHOULD
+    statement: Parent rule.
+    severity: warning
+context:
+  - "parent context line"

--- a/tests/inheritance/fixtures/merge-append/expect.json
+++ b/tests/inheritance/fixtures/merge-append/expect.json
@@ -1,0 +1,9 @@
+{
+  "kind": "positive",
+  "locale": "de_AT",
+  "chain": ["de_AT", "base"],
+  "merge_strategy": "append",
+  "rule_ids": ["rule.parent", "rule.child"],
+  "context_count": 2,
+  "context_first": "parent context line"
+}

--- a/tests/inheritance/fixtures/merge-append/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/merge-append/locales/de_AT/rules.yaml
@@ -1,0 +1,11 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/merge-append
+inherits: base
+merge_strategy: append
+rules:
+  - id: rule.child
+    modality: MUST
+    statement: Child rule.
+    severity: error
+context:
+  - "child context line"

--- a/tests/inheritance/fixtures/merge-dedup/base.yaml
+++ b/tests/inheritance/fixtures/merge-dedup/base.yaml
@@ -1,0 +1,6 @@
+id: base
+source: tests/inheritance/fixtures/merge-dedup
+rules: []
+context:
+  - "shared line"
+  - "parent-only line"

--- a/tests/inheritance/fixtures/merge-dedup/expect.json
+++ b/tests/inheritance/fixtures/merge-dedup/expect.json
@@ -1,0 +1,8 @@
+{
+  "kind": "positive",
+  "locale": "de_AT",
+  "chain": ["de_AT", "base"],
+  "merge_strategy": "dedup",
+  "context_count": 3,
+  "context_first": "shared line"
+}

--- a/tests/inheritance/fixtures/merge-dedup/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/merge-dedup/locales/de_AT/rules.yaml
@@ -1,0 +1,8 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/merge-dedup
+inherits: base
+merge_strategy: dedup
+rules: []
+context:
+  - "shared line"
+  - "child-only line"

--- a/tests/inheritance/fixtures/merge-prepend/base.yaml
+++ b/tests/inheritance/fixtures/merge-prepend/base.yaml
@@ -1,0 +1,7 @@
+id: base
+source: tests/inheritance/fixtures/merge-prepend
+rules:
+  - id: rule.parent
+    modality: SHOULD
+    statement: Parent rule.
+    severity: warning

--- a/tests/inheritance/fixtures/merge-prepend/expect.json
+++ b/tests/inheritance/fixtures/merge-prepend/expect.json
@@ -1,0 +1,7 @@
+{
+  "kind": "positive",
+  "locale": "de_AT",
+  "chain": ["de_AT", "base"],
+  "merge_strategy": "prepend",
+  "rule_ids": ["rule.child", "rule.parent"]
+}

--- a/tests/inheritance/fixtures/merge-prepend/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/merge-prepend/locales/de_AT/rules.yaml
@@ -1,0 +1,9 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/merge-prepend
+inherits: base
+merge_strategy: prepend
+rules:
+  - id: rule.child
+    modality: MUST
+    statement: Child rule.
+    severity: error

--- a/tests/inheritance/fixtures/merge-replace/base.yaml
+++ b/tests/inheritance/fixtures/merge-replace/base.yaml
@@ -1,0 +1,9 @@
+id: base
+source: tests/inheritance/fixtures/merge-replace
+rules:
+  - id: rule.parent
+    modality: SHOULD
+    statement: Parent rule.
+    severity: warning
+context:
+  - "parent context line"

--- a/tests/inheritance/fixtures/merge-replace/expect.json
+++ b/tests/inheritance/fixtures/merge-replace/expect.json
@@ -1,0 +1,9 @@
+{
+  "kind": "positive",
+  "locale": "de_AT",
+  "chain": ["de_AT", "base"],
+  "merge_strategy": "replace",
+  "rule_ids": ["rule.child"],
+  "context_count": 1,
+  "context_first": "child context line"
+}

--- a/tests/inheritance/fixtures/merge-replace/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/merge-replace/locales/de_AT/rules.yaml
@@ -1,0 +1,11 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/merge-replace
+inherits: base
+merge_strategy: replace
+rules:
+  - id: rule.child
+    modality: MUST
+    statement: Child rule.
+    severity: error
+context:
+  - "child context line"

--- a/tests/inheritance/fixtures/undefined-parent/base.yaml
+++ b/tests/inheritance/fixtures/undefined-parent/base.yaml
@@ -1,0 +1,3 @@
+id: base
+source: tests/inheritance/fixtures/undefined-parent
+rules: []

--- a/tests/inheritance/fixtures/undefined-parent/expect.json
+++ b/tests/inheritance/fixtures/undefined-parent/expect.json
@@ -1,0 +1,6 @@
+{
+  "kind": "negative",
+  "locale": "de_AT",
+  "error_type": "InheritanceError",
+  "error_substring": "not found"
+}

--- a/tests/inheritance/fixtures/undefined-parent/locales/de_AT/rules.yaml
+++ b/tests/inheritance/fixtures/undefined-parent/locales/de_AT/rules.yaml
@@ -1,0 +1,4 @@
+id: rules.de_AT
+source: tests/inheritance/fixtures/undefined-parent
+inherits: rules.does_not_exist
+rules: []

--- a/tests/inheritance/run.py
+++ b/tests/inheritance/run.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "jsonschema>=4.21,<5",
+#   "referencing>=0.32,<1",
+#   "pyyaml>=6,<7",
+# ]
+# ///
+"""Inheritance / merge / resolution fixture runner.
+
+Each fixture under tests/inheritance/fixtures/<name>/ is a self-contained
+project root containing base.yaml, locales/<locale>/*.yaml, and an expect.json
+sidecar describing the expected outcome.
+
+Positive expect.json shape:
+    {
+      "kind": "positive",
+      "locale": "<code>",
+      "chain": ["...", "...", "base"],            # optional
+      "rule_ids": ["...", "..."],                  # optional
+      "merge_strategy": "append",                  # optional sanity hint
+      "context_count": <n>, "context_first": "..." # optional
+    }
+
+Negative expect.json shape:
+    {
+      "kind": "negative",
+      "locale": "<code>",
+      "error_type": "InheritanceError" | "MergeError" | "ResolutionError" | ...,
+      "error_substring": "<must appear in the rendered error message>"
+    }
+
+Exit codes:
+    0 — every fixture behaved as expected
+    1 — one or more fixtures behaved incorrectly
+    2 — harness setup error
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from resolver.ids import IdError
+    from resolver.inheritance import InheritanceError
+    from resolver.loader import LoaderError
+    from resolver.merge import MergeError
+    from resolver.resolve import ResolutionError, ResolverInputs, resolve_locale
+    from resolver.validate import ValidationFailed
+except ImportError as exc:
+    print(f"setup: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+ERROR_TYPES = {
+    "InheritanceError": InheritanceError,
+    "MergeError": MergeError,
+    "ResolutionError": ResolutionError,
+    "LoaderError": LoaderError,
+    "ValidationFailed": ValidationFailed,
+    "IdError": IdError,
+}
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+SCHEMA_DIR = REPO_ROOT / "schema"
+
+
+def _build_inputs(fixture_root: Path) -> ResolverInputs:
+    retros = fixture_root / "retrospectives"
+    return ResolverInputs(
+        base_path=fixture_root / "base.yaml",
+        locales_dir=fixture_root / "locales",
+        retros_dir=retros if retros.exists() else None,
+        schema_dir=SCHEMA_DIR,
+        index_path=fixture_root / "resolver" / "index.json",
+        project_root=fixture_root,
+    )
+
+
+def _check_positive(name: str, result: dict[str, Any], expect: dict[str, Any]) -> list[str]:
+    errs: list[str] = []
+    if "chain" in expect and result["chain"] != expect["chain"]:
+        errs.append(f"chain mismatch: got {result['chain']}, expected {expect['chain']}")
+    merged = result["merged_rules"]
+    if "expect_top_id" in expect and merged.get("id") != expect["expect_top_id"]:
+        errs.append(f"top id mismatch: got {merged.get('id')!r}, expected {expect['expect_top_id']!r}")
+    if "rule_ids" in expect:
+        actual_ids = [r.get("id") for r in (merged.get("rules") or [])]
+        if actual_ids != expect["rule_ids"]:
+            errs.append(f"rule_ids mismatch: got {actual_ids}, expected {expect['rule_ids']}")
+    if "context_count" in expect:
+        ctx = merged.get("context") or []
+        if len(ctx) != expect["context_count"]:
+            errs.append(f"context count mismatch: got {len(ctx)}, expected {expect['context_count']}")
+    if "context_first" in expect:
+        ctx = merged.get("context") or []
+        if not ctx or ctx[0] != expect["context_first"]:
+            errs.append(f"context first mismatch: got {ctx[:1]!r}, expected {expect['context_first']!r}")
+    if "provenance_for" in expect:
+        prov = result.get("provenance") or {}
+        for cursor, expected_source in expect["provenance_for"].items():
+            actual = prov.get(cursor)
+            if actual is None:
+                errs.append(f"provenance missing for {cursor!r}")
+                continue
+            # Source paths are absolute in provenance; compare by suffix.
+            if not actual.endswith(expected_source):
+                errs.append(
+                    f"provenance mismatch at {cursor!r}: got {actual!r}, "
+                    f"expected suffix {expected_source!r}"
+                )
+    return errs
+
+
+def _run_fixture(name: str, fixture_root: Path) -> tuple[bool, str]:
+    expect_path = fixture_root / "expect.json"
+    if not expect_path.exists():
+        return False, "missing expect.json"
+    expect = json.loads(expect_path.read_text())
+    locale = expect["locale"]
+    kind = expect["kind"]
+    inputs = _build_inputs(fixture_root)
+
+    try:
+        result = resolve_locale(locale, inputs, validate_only=True)
+    except Exception as exc:  # noqa: BLE001
+        if kind == "positive":
+            return False, f"unexpected error: {type(exc).__name__}: {exc}"
+        # Negative case.
+        expected_type = expect.get("error_type")
+        if expected_type:
+            expected_cls = ERROR_TYPES.get(expected_type)
+            if expected_cls is None:
+                return False, f"unknown error_type {expected_type!r} in expect.json"
+            if not isinstance(exc, expected_cls):
+                return False, (
+                    f"wrong error type: got {type(exc).__name__}, expected {expected_type}"
+                )
+        substring = expect.get("error_substring")
+        if substring and substring not in str(exc):
+            return False, (
+                f"error substring not found: expected {substring!r}, got {str(exc)!r}"
+            )
+        return True, "ok (raised as expected)"
+
+    if kind == "negative":
+        return False, "expected error but pipeline completed successfully"
+    errs = _check_positive(name, result, expect)
+    if errs:
+        return False, "; ".join(errs)
+    return True, "ok"
+
+
+def main(argv: list[str]) -> int:
+    targets = argv[1:] if len(argv) > 1 else None
+    if not FIXTURES_DIR.exists():
+        print(f"setup: fixtures dir missing: {FIXTURES_DIR}", file=sys.stderr)
+        return 2
+
+    failed = 0
+    passed = 0
+    for fixture_dir in sorted(FIXTURES_DIR.iterdir()):
+        if not fixture_dir.is_dir() or fixture_dir.name.startswith("."):
+            continue
+        if targets and fixture_dir.name not in targets:
+            continue
+        ok, msg = _run_fixture(fixture_dir.name, fixture_dir)
+        marker = "pass" if ok else "FAIL"
+        print(f"  {marker} {fixture_dir.name}: {msg}")
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+
+    print()
+    print(f"summary: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #8 (pending native review of the gating Phase 0 PR).

Stacked on top of #15 (P1-1 schemas). Will be rebased onto `main` once #15 merges.

## Summary

Implements `SPEC.md §2.3 steps 1-4` and `§4` (UUID minting) per issue #8. Lint, retro attachment, and emit are P1-3+.

### `resolver/` package
- **loader.py** — `StringDateLoader` + frontmatter extraction. Lifted from `tests/schema/run.py`; runner keeps its own copy for PEP 723 self-containment, dedup tracked as follow-up.
- **validate.py** — `SchemaBundle` wraps the `referencing` Registry plus raw schema bodies, so the six P1-1 schemas drive both fixture and resolver-time validation through one path.
- **inheritance.py** — chain walker (`de_AT → de → base`), cycle detection, undefined-parent detection. Multi-parent inheritance is rejected with a clear message in P1-2.
- **merge.py** — deep-merge maps, replace scalars, list strategies (`append | replace | prepend | dedup`, default `replace`). Strategy is taken from the most child-specific document that declares one. Provenance is a flat `JSONPath → source-file` dict returned alongside the merged tree, **not** inlined into it. Element-level provenance inside list merges is intentionally coarse (whole list re-stamped with the most recent layer); refining is a P1-3 enhancement.
- **ids.py** — deterministic 8-char suffix from `sha256(<kind>.<key>)`; salt + rehash on collision against the index; idempotent re-mint of a known `(kind, key)`.
- **resolve.py** — CLI orchestrator. `--validate-only` prints the merged tree to stdout and exits 0 (matches the verbatim verification line in issue #8); full runs additionally emit `resolver/index.json`. Reference resolution covers `rule_ref`, `rule_refs`, `affected_rules`, `retro_refs`, `register_ref`, `glossary_ref`, `baseline_ref`, `baseline_pins`, `examples_added`, `supersedes` — uniform lookup against the combined index.

### `bin/mint-id`
Read-only against `resolver/index.json`. The resolver remains the sole writer of the index; `mint-id` computes the suffix the resolver will assign on its next run, so authors can mint stable ids offline without running the full pipeline.

### `tests/inheritance/`
9 self-contained fixture projects under `fixtures/<name>/` covering:
- `chain-happy` — `de_AT → de → base` happy path with provenance assertions
- `cycle` — `de` ⇄ `de_AT`, expects `InheritanceError`
- `undefined-parent` — inherits a non-existent locale
- `merge-{replace,append,prepend,dedup}` — one per strategy
- `dangling-rule-ref`, `dangling-retro-ref` — both expect `ResolutionError`

Runner asserts chain order, top-level id, rule ids in order, context ordering, and per-key provenance for scalar/parent-only paths (where stamping is granular).

### CI
`.github/workflows/schema-validation.yml` gains a second step running the inheritance suite. Same pinned dependency set as the schema fixtures step.

## Test plan
- [x] `uv run tests/schema/run.py` — 34/0 (no regression from P1-1)
- [x] `uv run tests/inheritance/run.py` — 9/0
- [x] `bin/mint-id term secret_object` — deterministic + idempotent on rerun
- [x] `bin/mint-id Term ...` — rejects invalid kind with non-zero exit
- [x] CLI `--validate-only` prints merged JSON to stdout, summary to stderr, exits 0
- [x] CLI without `--validate-only` writes `resolver/index.json` with project-relative paths

## Constraints carried forward
- Synthetic fixtures only — does not depend on PR #14 (Phase 0) content.
- No `bin/lint-register` modification (it lives on PR #14, not this branch).
- No locale YAML for non-`de_AT` locales authored.
- No `lint.py`, no `emit_*.py` — both are P1-3.

## Known limitations (deferred)
- **List-element provenance** is coarse: when merging lists, the entire merged list is stamped with the most recent layer's source. Element-level multi-source provenance is documented as a P1-3 enhancement in `merge.py`. The provenance assertion in `chain-happy/expect.json` therefore tests scalar / parent-only paths where stamping is granular.
- **Schema double-validation** for chain parents (loader pre-validates, resolver re-validates after build_chain returns). Trivial perf cost; can be deduped in a follow-up.