### PR TITLE
Implement retrospective lifecycle gate (SPEC §3)

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -53,10 +53,8 @@ jobs:
         # cross-repo work (P1-4b/P1-5b) — see its body and RECOVERY-PLAN.md.
         # The waiver is per-id: any new retro left pending >7 days fails CI.
         run: |
-          DIFF_BASE=""
+          ARGS=(--grace 2026-04-26-start-translation-session-conventions-drift)
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            DIFF_BASE="--diff-base origin/${{ github.base_ref }}"
+            ARGS+=(--diff-base "origin/${{ github.base_ref }}")
           fi
-          python resolver/retro_lifecycle.py \
-            --grace 2026-04-26-start-translation-session-conventions-drift \
-            $DIFF_BASE
+          python resolver/retro_lifecycle.py "${ARGS[@]}"

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: the retro lifecycle gate diffs against the PR base
+          # ref to enforce the applied-transition check (SPEC §3).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,3 +44,19 @@ jobs:
 
       - name: Run resolver emit + lint fixture suite
         run: python tests/resolver/run.py
+
+      - name: Run retro lifecycle test suite
+        run: python tests/retro_lifecycle/run.py
+
+      - name: Retrospective lifecycle gate (SPEC §3)
+        # The one graced id is a structural retro whose closure is blocked on
+        # cross-repo work (P1-4b/P1-5b) — see its body and RECOVERY-PLAN.md.
+        # The waiver is per-id: any new retro left pending >7 days fails CI.
+        run: |
+          DIFF_BASE=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            DIFF_BASE="--diff-base origin/${{ github.base_ref }}"
+          fi
+          python resolver/retro_lifecycle.py \
+            --grace 2026-04-26-start-translation-session-conventions-drift \
+            $DIFF_BASE

--- a/P1-3-PLAN.md
+++ b/P1-3-PLAN.md
@@ -1,6 +1,6 @@
 # P1-3 Implementation Plan — Resolver lint + dual emit
 
-**Status.** Plan for review. Implements SPEC §2.3 steps 5–7 on top of P1-2 (steps 1–4, committed). No code yet.
+**Status.** Implemented and merged (PR #17/#19); see §7 for how each open question resolved. Retained as the decision record for SPEC §2.3 steps 5–7.
 
 **Why it blocks everything.** Both cross-property decisions (HANDOFF, 2026-05-29) wait on this: the guidance-source inversion is "first act of Phase 1.5, *after* P1-3 emit," and every property consumes `.resolved/<locale>.json` — which only exists once emit lands.
 
@@ -109,3 +109,25 @@ Each step is independently testable. No production YAML content is created — f
 1. **Gap A**: accept reusing `forbiddenToken.context` semantics for example/target match — and the match mode (`word_prefix` vs `substring`) decided by grepping real de/de_AT examples for tail-position compounds first?
 2. **Gap B**: fold step 5 into P1-3, or split to P1-4?
 3. **§4 hash scope**: is `.resolved/<locale>.json` hash-checked like the MD, and which `_meta` fields are masked?
+
+---
+
+## 7. Resolutions (recorded 2026-06-12, post-merge)
+
+The implementation landed before this section was written; the decisions were
+made in code and review but not recorded here. Closing the loop:
+
+1. **Gap A → `word_prefix`** (2026-05-29). The de/de_AT `good` examples were
+   checked and place sense terms in head position only — no tail/interior
+   compounds — so `word_prefix` is the safe default. Pinned at
+   `resolver/matching.py` (`DEFAULT_TARGET_MODE = "word_prefix"`); the
+   per-sense override field stays deferred per SPEC §8 until observed data
+   demands it.
+2. **Gap B → folded into P1-3.** Step 5 (attach retros, `declined_index`)
+   shipped with emit in `resolver/model.py` (`build_model`); the
+   `declined_index`-ships-empty risk never materialized.
+3. **§4 hash scope → markdown only** (Q3, 2026-05-29). The JSON is *not*
+   content-hash-checked; the app-repo gate checks
+   `_meta.source_commit == submodule SHA` only. Recorded in
+   `resolver/emit_json.py`'s module docstring. `_meta.generated_at` is
+   caller-injected, so golden tests pin it rather than masking it.

--- a/RECOVERY-PLAN.md
+++ b/RECOVERY-PLAN.md
@@ -13,7 +13,11 @@ built to make safe, and the order in which the freeze lifts.
 **Authority chain.** Every factual claim about the contamination traces to
 `reviews/2026-04-12/cross-locale-audit.md` (per-locale commits and severity)
 and `reviews/2026-04-12/locale-quality-analysis-de_AT.md` (baseline
-determination). The de_AT baseline is pinned in `baselines.yaml`.
+determination). The de_AT baseline is pinned in `baselines.yaml`. The
+coverage figures (~95% → ~81%) and the freeze itself are operational facts
+supplied by the maintainers — they are not derivable from this repo and
+should be re-confirmed against the app repo's i18n tooling before §4
+decision point 2 is acted on.
 
 ---
 
@@ -61,23 +65,34 @@ All commits below are in `onetimesecret/onetimesecret`. Layout eras:
 | da_DK | `6c1b55c16` | Medium | fix in place (brand-term swap only) | — |
 | zh | `311537d04` | Medium | fix in place (您 erosion, 消息 inflation) | — |
 
-Why de_AT's source is `f95b03f44` and **not** the immediate pre-incident state
-(`b08e59838^`): the incident was the endpoint of a five-month
-assistant→assistant drift loop. States downstream of the loop carry partial
-du-form drift even before the flip commit. `f95b03f44` is the last
-human-curated snapshot — formal *Sie* plus the Geheimnis/Nachricht split —
-and is recorded as the authoritative pin in `baselines.yaml`
-(`baselines.de_AT`). The same reasoning applies to uk's pre-reorg source.
+Why de_AT's source is `f95b03f44` and **not** a state nearer the incident:
+the incident was the endpoint of a five-month assistant→assistant drift loop,
+and `locale-quality-analysis-de_AT.md` settles the question — `f95b03f44` "is
+the last known-good human-curated de_AT content … the only defensible
+baseline," while the nearer candidate it evaluated (`e5fe5566f^`) "is
+downstream of the corrupting loop and carries partial du-form drift."
+(`baselines.yaml` pins the same commit while characterizing it as the last
+*acceptable* state rather than a curation event; the two sources agree on the
+pin, not on the wording.) For uk, the audit names `be5bdb5ca^` a usable
+revert source — clean formal Ви throughout.
 
 pt_PT and hu were essentially empty at the reorg; their usable baselines are
-the March 2026 translation pass (clean formal at `d8834a021`), which is
-already in the per-file layout — no key mapping needed, only value restore.
+the March 2026 translation pass at `d8834a021`, already in the per-file
+layout — no key mapping needed, only value restore. Note the asymmetry the
+audit records: hu's March state was clean formal *Ön*, but pt_PT's was
+"mixed você+tu leaning formal." Recovered pt_PT content therefore needs a
+**register-repair pass** (informal 2sg residue removed against its future
+`register.yaml`) on top of the restore — budget for it.
 
-**Verify before use.** Each candidate snapshot is confirmed with the marker
-counts from the audit before any values are taken from it, e.g. for de_AT:
-`Sie/Ihre` present throughout, zero du-paradigm tokens, Geheimnis ≈ 108 /
-Nachricht ≈ 65 occurrence ratio. If a snapshot fails its smoke test, stop and
-re-derive the baseline; do not improvise forward.
+**Verify before use.** Each candidate snapshot is confirmed before any values
+are taken from it: for de_AT, `Sie/Ihr*` present throughout, zero du-paradigm
+tokens, and **both** Geheimnis and Nachricht present (the split intact —
+a one-sided count means the wrong snapshot). Measure the snapshot's own
+Geheimnis/Nachricht counts at extraction time and carry them forward as the
+expected shape for step 4d; the audit's 108/65 figure was measured at
+`b08e59838^` (per-file era) and is a shape reference, not the baseline's
+expected value. If a snapshot fails its smoke test, stop and re-derive the
+baseline; do not improvise forward.
 
 ---
 
@@ -86,12 +101,12 @@ re-derive the baseline; do not improvise forward.
 Run inside a clone of `onetimesecret/onetimesecret`. Steps 1–4 are mechanical
 and agent-executable; steps 5–7 carry the human gates.
 
-**Step 1 — extract the three snapshots.**
+**Step 1 — extract the snapshots.**
 
 ```bash
 git show f95b03f44:src/locales/de_AT.json   > /tmp/deAT-baseline.json   # values
 git show be5bdb5ca^:src/locales/de_AT.json  > /tmp/deAT-reorg-flat.json # keymap aid
-git show b08e59838^ -- 'locales/content/de_AT/' # pre-incident per-file tree (keymap aid)
+# pre-incident per-file tree (keymap aid only — carries drift, do not take values):
 mkdir -p /tmp/deAT-preincident && git archive b08e59838^ locales/content/de_AT | tar -x -C /tmp/deAT-preincident
 ```
 
@@ -114,23 +129,31 @@ For every key in the *current* `locales/content/de_AT/*.json` structure:
   value left as-is for now (current value may be contaminated; queue entries
   are re-done under the new rules, not trusted).
 
-**Step 4 — mechanical validation (all must pass).**
+**Step 4 — mechanical validation (all must pass).** Paths assume the P1-4b
+layout: this repo as a submodule at `locales/translation-rules/` (per
+`.github/ISSUE_DRAFTS/p1-4b-app-repo-integration.md`; the minimal-slice
+workflow draft checks out at `.translation-rules` — adjust to whichever
+landed).
 
 ```bash
-# 4a. Register lint — the Phase 0 gate, zero tolerance:
-translation-rules/bin/lint-register de_AT 'locales/content/de_AT/*.json'
+# 4a. Register lint — the Phase 0 gate, zero tolerance, runs on the
+#     candidate content itself:
+locales/translation-rules/bin/lint-register de_AT 'locales/content/de_AT/*.json'
 
-# 4b. Resolver lint — the candidate values must satisfy the resolved model:
-python translation-rules/resolver/resolve.py de_AT --lint
+# 4b. Resolver green — regenerate the artifacts the retranslate queue and
+#     reviewers consume. Runs INSIDE the submodule (the resolver lints the
+#     rules model and embedded examples, NOT app content — content checks
+#     are 4a/4c/4d plus the P1-4b CI grep):
+(cd locales/translation-rules && python resolver/resolve.py de_AT --lint --emit=md,json)
 
 # 4c. Object/content split spot-grep (locale-quality-analysis item 3):
 #     no Nachricht as object of verbrennen/teilen/erstellen/löschen;
 #     no Geheimnis in post_reveal / encrypted_message / message_ready keys.
 
-# 4d. Marker-count smoke test against the audit's expected shape:
-#     du-paradigm = 0; Sie/Ihr* high; Geheimnis/Nachricht both present
-#     in roughly the baseline ratio (≈108/65) — a one-sided count is a
-#     red flag that the split collapsed again.
+# 4d. Marker-count smoke test: du-paradigm = 0; Sie/Ihr* high; Geheimnis and
+#     Nachricht both present in roughly the ratio measured on the baseline
+#     snapshot in §2 — a one-sided count is a red flag that the split
+#     collapsed again.
 ```
 
 **Step 5 — retranslate queue.** New keys are translated fresh by the
@@ -153,7 +176,9 @@ coverage number; the locale's freeze lifts at merge (§5).
 ## 4. Sequencing and dependencies
 
 ```
-P1-4a finish (this repo)          [done except retro lifecycle gate — wired 2026-06-12]
+P1-4a (this repo CI)              [core gates + retro lifecycle live as of
+        │                          2026-06-12; _archive/ firewall and
+        │                          embedded-docs grep still open — SPEC §2.4]
         │
 P1-4b: submodule + CI gate in app repo        [HUMAN-GATED, drafts ready:
         │                                      .github/ISSUE_DRAFTS/p1-4b-*]

--- a/RECOVERY-PLAN.md
+++ b/RECOVERY-PLAN.md
@@ -1,0 +1,225 @@
+# Recovery Plan — locale content restoration and i18n unfreeze
+
+**Purpose.** Define the process for (a) extracting the known-good historical
+translations for the locales contaminated by the 2026-04-12 harmonization
+incident, (b) landing them in the app repo behind the new mechanical gates, and
+(c) unfreezing regular i18n work, which has been stopped since the incident
+(coverage has fallen from ~95% to ~81% as untranslated en keys accumulate).
+
+**Status.** Draft for review, 2026-06-12. Companion to `SPEC.md` (the system
+design) — this document covers the one-time content recovery the system was
+built to make safe, and the order in which the freeze lifts.
+
+**Authority chain.** Every factual claim about the contamination traces to
+`reviews/2026-04-12/cross-locale-audit.md` (per-locale commits and severity)
+and `reviews/2026-04-12/locale-quality-analysis-de_AT.md` (baseline
+determination). The de_AT baseline is pinned in `baselines.yaml`.
+
+---
+
+## 1. Ground rules
+
+1. **Gate before content.** No recovery PR lands until the app-repo CI gate
+   (P1-4b) is live for the locale being recovered. The recovery PRs must be
+   the first consumers of the gate — if the gate would not have caught the
+   original incident in the recovery PR's own diff, the gate is wrong, and we
+   want to learn that on a revert, not on new translation work.
+2. **Revert + replay, not `git revert`.** The 2026-04-10 harmonize commits
+   mixed legitimate key restructuring with illegitimate text rewrites (the
+   anti-pattern now codified in `local-guides/UX-TRANSLATION-GUIDE.md`:
+   harmonize = keys only). A plain revert would undo the legitimate key work.
+   The unit of recovery is the **string value**, mapped onto the **current key
+   structure**.
+3. **Restore the split, not one side.** Per
+   `locale-quality-analysis-de_AT.md`, the mature de_AT content used a
+   semantic split: *Geheimnis* = the secret as object/container (burn, share,
+   create, destroy, expire); *Nachricht* = the revealed payload content.
+   Demanding *Geheimnis* everywhere would be as wrong as the incident's
+   *Nachricht*-everywhere. The recovered content must reproduce the split —
+   this is exactly what `locales/de_AT/glossary.yaml` now encodes.
+4. **Native-speaker gate at merge.** Mechanical checks bound the damage; they
+   do not certify quality. Each recovery PR carries a `Needs-native-review`
+   label and a stratified sample review (§4 step 6) before merge.
+
+---
+
+## 2. What to recover from (per locale)
+
+All commits below are in `onetimesecret/onetimesecret`. Layout eras:
+
+- **Single-file era** (until 2025-11-15): `src/locales/<locale>.json`, deleted
+  in the reorg commit `be5bdb5ca`.
+- **Per-file era** (current): `locales/content/<locale>/*.json`
+  (email.json, session-auth.json, …).
+
+| Locale | Contaminating commit | Severity | Recovery source | Source layout |
+|---|---|---|---|---|
+| de_AT | `b08e59838` | High | `f95b03f44:src/locales/de_AT.json` | single-file |
+| uk | `5c7d5c362` | High | `be5bdb5ca^:src/locales/uk.json` | single-file |
+| pt_PT | `3f9d8d3d2` | High | `d8834a021` (or earlier post-March pass) | per-file |
+| hu | `bea7e1b7e` | High | `d8834a021` (16 formal / 0 informal in email.json) | per-file |
+| da_DK | `6c1b55c16` | Medium | fix in place (brand-term swap only) | — |
+| zh | `311537d04` | Medium | fix in place (您 erosion, 消息 inflation) | — |
+
+Why de_AT's source is `f95b03f44` and **not** the immediate pre-incident state
+(`b08e59838^`): the incident was the endpoint of a five-month
+assistant→assistant drift loop. States downstream of the loop carry partial
+du-form drift even before the flip commit. `f95b03f44` is the last
+human-curated snapshot — formal *Sie* plus the Geheimnis/Nachricht split —
+and is recorded as the authoritative pin in `baselines.yaml`
+(`baselines.de_AT`). The same reasoning applies to uk's pre-reorg source.
+
+pt_PT and hu were essentially empty at the reorg; their usable baselines are
+the March 2026 translation pass (clean formal at `d8834a021`), which is
+already in the per-file layout — no key mapping needed, only value restore.
+
+**Verify before use.** Each candidate snapshot is confirmed with the marker
+counts from the audit before any values are taken from it, e.g. for de_AT:
+`Sie/Ihre` present throughout, zero du-paradigm tokens, Geheimnis ≈ 108 /
+Nachricht ≈ 65 occurrence ratio. If a snapshot fails its smoke test, stop and
+re-derive the baseline; do not improvise forward.
+
+---
+
+## 3. The de_AT extraction pipeline (template for the others)
+
+Run inside a clone of `onetimesecret/onetimesecret`. Steps 1–4 are mechanical
+and agent-executable; steps 5–7 carry the human gates.
+
+**Step 1 — extract the three snapshots.**
+
+```bash
+git show f95b03f44:src/locales/de_AT.json   > /tmp/deAT-baseline.json   # values
+git show be5bdb5ca^:src/locales/de_AT.json  > /tmp/deAT-reorg-flat.json # keymap aid
+git show b08e59838^ -- 'locales/content/de_AT/' # pre-incident per-file tree (keymap aid)
+mkdir -p /tmp/deAT-preincident && git archive b08e59838^ locales/content/de_AT | tar -x -C /tmp/deAT-preincident
+```
+
+**Step 2 — build the key map (flat → per-file).**
+The reorg commit `be5bdb5ca` is the Rosetta stone: it deleted the flat file
+and (with its surrounding commits) introduced the per-file layout while
+preserving values. Match flat keys to per-file keys by identical value at the
+reorg boundary; match the remainder by key-leaf name. Output:
+`keymap.de_AT.json` mapping `<flat key> → <file>:<nested key>`. Keys that
+exist today but have no flat-era ancestor go to the **retranslate queue**;
+flat-era keys with no current counterpart are dropped (retired strings).
+
+**Step 3 — generate the candidate tree.**
+For every key in the *current* `locales/content/de_AT/*.json` structure:
+
+- mapped + baseline has a value → take the `f95b03f44` value;
+- mapped but baseline value empty → take the `be5bdb5ca^` value if non-empty,
+  else retranslate queue;
+- unmapped (new since the freeze or since the reorg) → retranslate queue,
+  value left as-is for now (current value may be contaminated; queue entries
+  are re-done under the new rules, not trusted).
+
+**Step 4 — mechanical validation (all must pass).**
+
+```bash
+# 4a. Register lint — the Phase 0 gate, zero tolerance:
+translation-rules/bin/lint-register de_AT 'locales/content/de_AT/*.json'
+
+# 4b. Resolver lint — the candidate values must satisfy the resolved model:
+python translation-rules/resolver/resolve.py de_AT --lint
+
+# 4c. Object/content split spot-grep (locale-quality-analysis item 3):
+#     no Nachricht as object of verbrennen/teilen/erstellen/löschen;
+#     no Geheimnis in post_reveal / encrypted_message / message_ready keys.
+
+# 4d. Marker-count smoke test against the audit's expected shape:
+#     du-paradigm = 0; Sie/Ihr* high; Geheimnis/Nachricht both present
+#     in roughly the baseline ratio (≈108/65) — a one-sided count is a
+#     red flag that the split collapsed again.
+```
+
+**Step 5 — retranslate queue.** New keys are translated fresh by the
+translator agent consuming `locales/.resolved/de_AT.json` (the SPEC §6.1
+contract — not the legacy conventions table), in the same PR or a fast-follow,
+each pass re-running step 4.
+
+**Step 6 — native-speaker sample.** Stratified sample across files (suggest
+10% per file, minimum 10 strings, weighted toward email/session-auth where the
+damage was worst) reviewed by an AT German speaker. Findings either fix
+in-place or file a retrospective if they reveal a rule gap.
+
+**Step 7 — land it.** One PR per locale: candidate tree + keymap artifact +
+PR description linking `retrospectives/2026-04-12-de_AT-register-flip.md` and
+`baselines.de_AT`. The PR must show the P1-4b gate passing. Merge updates the
+coverage number; the locale's freeze lifts at merge (§5).
+
+---
+
+## 4. Sequencing and dependencies
+
+```
+P1-4a finish (this repo)          [done except retro lifecycle gate — wired 2026-06-12]
+        │
+P1-4b: submodule + CI gate in app repo        [HUMAN-GATED, drafts ready:
+        │                                      .github/ISSUE_DRAFTS/p1-4b-*]
+P1-5b: de_AT resolver artifacts land in app repo
+        │
+de_AT recovery PR (§3)            [first real exercise of the gate]
+        │
+unfreeze de_AT  ──────────────►  regular translation tasks resume for de_AT
+        │
+pt_PT / uk / hu:                  [each needs register.yaml FIRST —
+  register.yaml + recovery PR      knowledge-base work, BACKLOG 2026-04-23:
+        │                          audit-backed tokens + source: field +
+        │                          native-speaker confirmation]
+da_DK / zh fix-in-place PRs       [no full replay; brand-term/您 repairs]
+        │
+remaining ~28 clean locales       [unfreeze as soon as the gate is live;
+                                   they were never contaminated — the freeze
+                                   was precautionary. register.yaml authoring
+                                   proceeds in parallel waves (Phase 2)]
+```
+
+Two explicit decision points for maintainers:
+
+1. **Clean-locale unfreeze timing.** The conservative reading keeps every
+   locale frozen until its `register.yaml` exists. The pragmatic reading —
+   recommended — unfreezes clean locales once the P1-4b gate is live, because
+   (a) the audit found no damage in them, and (b) the gate plus the
+   `.resolved/<locale>.json` agent contract already removes the original
+   failure vector (prose guidance). Forbidden-token enforcement then arrives
+   per-locale as Phase 2 authoring lands.
+2. **Coverage backfill.** The 95%→81% drop is mostly *new en keys accumulated
+   during the freeze*, not destroyed translations. Backfill is therefore
+   ordinary translation work: per-locale tasks through the existing task-DB
+   workflow, agents consuming `.resolved/<locale>.json` where it exists, every
+   PR passing the gate. de_AT first as the proof, then highest-traffic locales
+   first by user impact, not alphabetically.
+
+---
+
+## 5. Per-locale unfreeze checklist
+
+A locale exits the freeze when all of:
+
+- [ ] P1-4b CI gate live in the app repo (repo-wide, once)
+- [ ] For contaminated locales: recovery PR merged (§3), with native-speaker
+      sample sign-off
+- [ ] For pt_PT/uk/hu: `locales/<locale>/register.yaml` authored in this repo
+      with audit-backed `forbidden_tokens` and a populated `source:` field
+      (BACKLOG 2026-04-23/2026-04-26 — the de_AT paradigm-gap note applies)
+- [ ] `.resolved/<locale>.json` present in the app repo **or** the locale is
+      clean and maintainers accepted decision point 1 above
+- [ ] The translator-agent entry point for the locale no longer reads the
+      legacy conventions table (closes the 2026-04-26 conventions-drift retro
+      for that locale's slice)
+
+---
+
+## 6. What this plan deliberately does not do
+
+- **No bulk re-translation of contaminated locales from scratch.** The
+  historical content is better than fresh machine output — it embodies years
+  of curation. Extraction is cheaper and safer than regeneration.
+- **No backfill of old reviews into retrospectives** (SPEC §3 stands).
+- **No Phase 2 fan-out scheduling.** That is templated after de_AT proves the
+  pattern end-to-end (clearinghouse, Phase 2 section).
+- **No new tooling in this repo for the extraction.** The keymap/candidate
+  scripts in §3 live with the app repo's locale scripts
+  (`locales/scripts/`), where they can run against real content in CI;
+  this repo stays the rules authority.

--- a/SPEC.md
+++ b/SPEC.md
@@ -154,9 +154,7 @@ The `rules`/`context`/`rationale` partition is the surface-level cue that preven
 
 ### 2.4 CI gates
 
-**Status (2026-05-30).** Most gates below are the target design, not yet wired. Implemented today in this repo: `schema-validation.yml` (schema, inheritance, resolver merge/lint/emit tests) and `lint-register.yml` (a `--dry-run` plumbing self-test plus `tests/lint-register.sh`). Everything else in this section, and every gate in the App-repo block, is **planned** — including the load-bearing one (app-repo forbidden-token grep against real content). No app-repo integration exists yet (no submodule, no content gate). Phases below depend on these landing.
-
-**This repo (planned, except the two implemented above):** schema validation; resolver tests (merge, inheritance); lint across every resolved locale; retrospective lifecycle enforcement (§4); `_archive/` firewall — file moves out of it require label approval; forbidden-token grep against embedded examples and docs.
+**Status (2026-06-12).** Implemented today in this repo: `schema-validation.yml` (schema, inheritance, resolver merge/lint/emit tests, retro lifecycle gate), `lint-register.yml` (a `--dry-run` plumbing self-test plus `tests/lint-register.sh`), `python-qc.yml` (ruff lint/format, pyright), and the §3 retrospective lifecycle gates (`resolver/retro_lifecycle.py`: 7-day orphan timeout, applied-transition diff check). Still planned in this repo: `_archive/` firewall (no top-level `_archive/` exists yet to guard); forbidden-token grep against embedded examples and docs; review findings-manifest check. Every gate in the App-repo block is **planned** — including the load-bearing one (app-repo forbidden-token grep against real content). No app-repo integration exists yet (no submodule, no content gate). Phases below depend on these landing.
 
 **App repo (planned — none built):** submodule pointer freshness on locale-content PRs; `.resolved/<locale>.json`'s `_meta.source_commit` equals submodule SHA; `forbidden_tokens` grep against `locales/content/<locale>/*.json`; `for-translators/*.md` hash matches resolver output — hand edits rejected.
 
@@ -173,7 +171,7 @@ The `rules`/`context`/`rationale` partition is the surface-level cue that preven
 
 The critical ask. Every edge labeled machine-enforced or human-in-the-loop.
 
-**Status (2026-05-30).** The `[CI-ENFORCED: ...]` and `[CI: ...]` annotations below describe the target design. None of the lifecycle gates (7-day orphan timeout, applied-transition PR check, retro→applied on merge, cross-repo lint/hash match) are wired yet — see §2.4 Status for what CI actually runs today. Read the annotations as "intended enforcement," not "current."
+**Status (2026-06-12).** The 7-day orphan timeout and the applied-transition PR check are wired (`resolver/retro_lifecycle.py`, run by `schema-validation.yml`; one pre-existing pending retro carries an explicit, per-id grace in the workflow until its cross-repo closure lands). Still not wired: retro→applied automation on merge, and the cross-repo lint/hash gates — see §2.4 Status. Read the remaining `[CI-ENFORCED: ...]` annotations accordingly.
 
 ```
             (incident signal OR scheduled audit)

--- a/SPEC.md
+++ b/SPEC.md
@@ -220,7 +220,7 @@ The critical ask. Every edge labeled machine-enforced or human-in-the-loop.
 - `pending → applied`: requires PR to also touch every ID in `affected_rules` and populate `resolved_in_commit`. CI-enforced.
 - `pending → declined`: requires `declined_reason` and `would_change_decision_if` fields. Human-gated.
 - `applied → superseded`: only via a newer retro whose `supersedes` list contains this id.
-- `pending` with no transition after 7 days blocks next main PR.
+- `pending` with no transition after 7 days blocks next main PR. A retro whose closure is blocked on work outside this repo may carry an explicit per-id waiver in the CI workflow (`--grace <retro-id>`): the overdue retro then reports as a non-fatal warning, the waiver itself is a reviewable diff, and the gate flags the waiver as stale once the retro leaves `pending`.
 
 **Declined retros stay as active guardrails** (not archived). Resolver emits per-locale decline index surfacing summaries to agents. Before an agent proposes changing a locale's register or glossary, it checks the decline index — if covered, the agent must either match a `would_change_decision_if` condition or escalate.
 

--- a/resolver/retro_lifecycle.py
+++ b/resolver/retro_lifecycle.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pyyaml>=6,<7",
+# ]
+# ///
+"""Retrospective lifecycle gate. SPEC.md §3.
+
+Two CI-enforced checks the schema cannot express:
+
+  1. pending-orphan timeout — a retro that stays `status: pending` more than
+     7 days without transition blocks the next main PR (SPEC §3: "pending with
+     no transition after 7 days blocks next main PR"). A retro id passed via
+     `--grace` is downgraded to a warning: the waiver is visible in the
+     workflow file as a reviewable diff, and applies to that id only.
+  2. applied-transition diff check — the PR that flips a retro to
+     `status: applied` must also touch every id in `affected_rules`
+     (SPEC §3: "requires PR to also touch every ID in affected_rules").
+     Enforced when `--diff-base <ref>` is given: a retro that is `applied` at
+     HEAD but not at the base ref must have, for each affected rule id, at
+     least one changed YAML file whose HEAD content contains that id.
+     Retros with empty `affected_rules` are structural (see the 2026-04-26
+     conventions-drift retro) and have nothing to touch — they pass.
+
+Field-shape requirements per status (applied needs `resolved_in_commit`,
+declined needs `declined_reason` + `would_change_decision_if`) are enforced by
+schema/retrospective.schema.json; supersede pairing is enforced cross-file by
+resolver/model.py. Neither is duplicated here.
+
+Usage:
+    resolver/retro_lifecycle.py [--retros-dir retrospectives]
+                                [--today YYYY-MM-DD]
+                                [--max-pending-days 7]
+                                [--grace <retro-id>]...
+                                [--diff-base <ref>]
+
+Exit codes:
+    0  all checks passed (warnings allowed)
+    1  lifecycle violation
+    2  harness/setup error (unreadable file, bad git ref, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import yaml  # noqa: E402
+
+from resolver.loader import (  # noqa: E402
+    FRONTMATTER_RE,
+    LoaderError,
+    StringDateLoader,
+    load_retro_frontmatter,
+)
+
+FATAL = {"error"}
+
+
+@dataclass
+class Finding:
+    check: str
+    severity: str
+    message: str
+    retro_id: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        out = {"check": self.check, "severity": self.severity, "message": self.message}
+        if self.retro_id is not None:
+            out["retro_id"] = self.retro_id
+        return out
+
+
+@dataclass
+class LifecycleResult:
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.severity in FATAL for f in self.findings)
+
+
+def check_pending_orphans(
+    retros: list[dict[str, Any]],
+    today: date,
+    grace: set[str],
+    max_pending_days: int = 7,
+) -> list[Finding]:
+    """SPEC §3 orphan timeout. Graced ids report as warnings so the waiver
+    stays visible in CI output instead of silently swallowing the overdue."""
+    findings: list[Finding] = []
+    for r in retros:
+        if r.get("status") != "pending":
+            continue
+        rid = str(r.get("id", "?"))
+        raw_date = str(r.get("date", ""))
+        try:
+            filed = date.fromisoformat(raw_date)
+        except ValueError:
+            findings.append(
+                Finding(
+                    check="pending_orphan",
+                    severity="error",
+                    message=f"unparseable date {raw_date!r}",
+                    retro_id=rid,
+                )
+            )
+            continue
+        age = (today - filed).days
+        if age <= max_pending_days:
+            continue
+        if rid in grace:
+            findings.append(
+                Finding(
+                    check="pending_orphan",
+                    severity="warning",
+                    message=(
+                        f"pending {age} days (limit {max_pending_days}); "
+                        f"graced by explicit waiver in workflow"
+                    ),
+                    retro_id=rid,
+                )
+            )
+        else:
+            findings.append(
+                Finding(
+                    check="pending_orphan",
+                    severity="error",
+                    message=(
+                        f"pending {age} days without transition "
+                        f"(limit {max_pending_days}); SPEC §3 blocks this PR"
+                    ),
+                    retro_id=rid,
+                )
+            )
+    return findings
+
+
+def check_applied_transitions(
+    head_retros: list[dict[str, Any]],
+    base_statuses: dict[str, str],
+    changed_yaml_contents: dict[str, str],
+) -> list[Finding]:
+    """SPEC §3 applied-transition check.
+
+    `base_statuses` maps retro id -> status at the diff base (absent means the
+    retro is new in this PR). `changed_yaml_contents` maps changed YAML paths
+    -> their HEAD content. A retro newly `applied` in this diff must have each
+    affected rule id present in at least one changed YAML file.
+    """
+    findings: list[Finding] = []
+    for r in head_retros:
+        if r.get("status") != "applied":
+            continue
+        rid = str(r.get("id", "?"))
+        if base_statuses.get(rid) == "applied":
+            continue  # not a transition in this diff
+        for rule_id in r.get("affected_rules") or []:
+            if not any(rule_id in text for text in changed_yaml_contents.values()):
+                findings.append(
+                    Finding(
+                        check="applied_transition",
+                        severity="error",
+                        message=(
+                            f"transition to applied does not touch "
+                            f"affected rule {rule_id!r}: no changed YAML file "
+                            f"in this diff contains it"
+                        ),
+                        retro_id=rid,
+                    )
+                )
+    return findings
+
+
+def _git(args: list[str]) -> str:
+    proc = subprocess.run(["git", *args], capture_output=True, text=True, cwd=REPO_ROOT)
+    if proc.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)}: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _base_statuses(diff_base: str, retros_dir: Path) -> dict[str, str]:
+    """Retro id -> status at the base ref, parsed from `git show`."""
+    rel = retros_dir.relative_to(REPO_ROOT)
+    listing = _git(["ls-tree", "--name-only", diff_base, f"{rel}/"])
+    statuses: dict[str, str] = {}
+    for line in listing.splitlines():
+        if not line.endswith(".md") or line.endswith("README.md"):
+            continue
+        text = _git(["show", f"{diff_base}:{line}"])
+        match = FRONTMATTER_RE.match(text)
+        if not match:
+            continue
+        data = yaml.load(match.group(1), Loader=StringDateLoader)
+        if isinstance(data, dict) and "id" in data:
+            statuses[str(data["id"])] = str(data.get("status", ""))
+    return statuses
+
+
+def _changed_yaml_contents(diff_base: str) -> dict[str, str]:
+    """Changed-vs-base YAML paths -> HEAD content (deleted files excluded)."""
+    names = _git(["diff", "--name-only", "--diff-filter=d", f"{diff_base}...HEAD"])
+    out: dict[str, str] = {}
+    for name in names.splitlines():
+        if not (name.endswith(".yaml") or name.endswith(".yml")):
+            continue
+        path = REPO_ROOT / name
+        if path.exists():
+            out[name] = path.read_text(encoding="utf-8")
+    return out
+
+
+def load_retros(retros_dir: Path) -> list[dict[str, Any]]:
+    retros: list[dict[str, Any]] = []
+    for path in sorted(retros_dir.iterdir()):
+        if path.suffix != ".md" or path.name == "README.md":
+            continue
+        retros.append(load_retro_frontmatter(path))
+    return retros
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--retros-dir", default=str(REPO_ROOT / "retrospectives"))
+    parser.add_argument("--today", default=None, help="ISO date; defaults to today")
+    parser.add_argument("--max-pending-days", type=int, default=7)
+    parser.add_argument(
+        "--grace",
+        action="append",
+        default=[],
+        metavar="RETRO_ID",
+        help="downgrade this retro's orphan timeout to a warning (repeatable)",
+    )
+    parser.add_argument(
+        "--diff-base",
+        default=None,
+        metavar="REF",
+        help="git ref to diff against for the applied-transition check",
+    )
+    args = parser.parse_args(argv)
+
+    retros_dir = Path(args.retros_dir).resolve()
+    if not retros_dir.is_dir():
+        print(f"setup: retros dir not found: {retros_dir}", file=sys.stderr)
+        return 2
+    try:
+        retros = load_retros(retros_dir)
+    except LoaderError as exc:
+        print(f"setup: {exc}", file=sys.stderr)
+        return 2
+
+    today = date.fromisoformat(args.today) if args.today else date.today()
+    result = LifecycleResult()
+    result.findings.extend(
+        check_pending_orphans(retros, today, set(args.grace), args.max_pending_days)
+    )
+
+    if args.diff_base:
+        try:
+            base_statuses = _base_statuses(args.diff_base, retros_dir)
+            changed = _changed_yaml_contents(args.diff_base)
+        except RuntimeError as exc:
+            print(f"setup: {exc}", file=sys.stderr)
+            return 2
+        result.findings.extend(
+            check_applied_transitions(retros, base_statuses, changed)
+        )
+
+    for f in result.findings:
+        stream = sys.stderr if f.severity in FATAL else sys.stdout
+        print(f"{f.severity}: [{f.check}] {f.retro_id}: {f.message}", file=stream)
+    if result.ok:
+        n = len(retros)
+        print(f"retro lifecycle: ok ({n} retro{'s' if n != 1 else ''} checked)")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/resolver/retro_lifecycle.py
+++ b/resolver/retro_lifecycle.py
@@ -18,8 +18,8 @@ Two CI-enforced checks the schema cannot express:
      `status: applied` must also touch every id in `affected_rules`
      (SPEC §3: "requires PR to also touch every ID in affected_rules").
      Enforced when `--diff-base <ref>` is given: a retro that is `applied` at
-     HEAD but not at the base ref must have, for each affected rule id, at
-     least one changed YAML file whose HEAD content contains that id.
+     HEAD but not at the merge base with <ref> must have, for each affected
+     rule id, at least one changed YAML file whose content contains that id.
      Retros with empty `affected_rules` are structural (see the 2026-04-26
      conventions-drift retro) and have nothing to touch — they pass.
 
@@ -145,6 +145,22 @@ def check_pending_orphans(
     return findings
 
 
+def check_stale_grace(retros: list[dict[str, Any]], grace: set[str]) -> list[Finding]:
+    """A grace id that matches no pending retro is stale (closed retro,
+    rename, or typo) — surface it so the waiver gets removed from the
+    workflow instead of lingering inert."""
+    pending_ids = {str(r.get("id")) for r in retros if r.get("status") == "pending"}
+    return [
+        Finding(
+            check="stale_grace",
+            severity="warning",
+            message="grace id matches no pending retro; remove the waiver",
+            retro_id=gid,
+        )
+        for gid in sorted(grace - pending_ids)
+    ]
+
+
 def check_applied_transitions(
     head_retros: list[dict[str, Any]],
     base_statuses: dict[str, str],
@@ -188,15 +204,28 @@ def _git(args: list[str]) -> str:
     return proc.stdout
 
 
-def _base_statuses(diff_base: str, retros_dir: Path) -> dict[str, str]:
-    """Retro id -> status at the base ref, parsed from `git show`."""
-    rel = retros_dir.relative_to(REPO_ROOT)
-    listing = _git(["ls-tree", "--name-only", diff_base, f"{rel}/"])
+def _merge_base(diff_base: str) -> str:
+    """The comparison point for both helpers below. Using the merge base for
+    the status read AND the diff keeps them consistent when the base branch
+    has moved since this branch diverged (on GitHub's PR merge-ref checkout
+    the merge base equals the base tip, so CI behavior is unchanged)."""
+    return _git(["merge-base", diff_base, "HEAD"]).strip()
+
+
+def _base_statuses(base_commit: str, retros_dir: Path) -> dict[str, str]:
+    """Retro id -> status at the comparison commit, parsed from `git show`."""
+    try:
+        rel = retros_dir.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"--retros-dir must be inside the repo for --diff-base: {exc}"
+        ) from exc
+    listing = _git(["ls-tree", "--name-only", "-z", base_commit, f"{rel}/"])
     statuses: dict[str, str] = {}
-    for line in listing.splitlines():
-        if not line.endswith(".md") or line.endswith("README.md"):
+    for line in listing.split("\0"):
+        if not line.endswith(".md") or Path(line).name == "README.md":
             continue
-        text = _git(["show", f"{diff_base}:{line}"])
+        text = _git(["show", f"{base_commit}:{line}"])
         match = FRONTMATTER_RE.match(text)
         if not match:
             continue
@@ -206,9 +235,10 @@ def _base_statuses(diff_base: str, retros_dir: Path) -> dict[str, str]:
     return statuses
 
 
-def _changed_yaml_contents(diff_base: str) -> dict[str, str]:
-    """Changed-vs-base YAML paths -> HEAD content (deleted files excluded)."""
-    names = _git(["diff", "--name-only", "--diff-filter=d", f"{diff_base}...HEAD"])
+def _changed_yaml_contents(base_commit: str) -> dict[str, str]:
+    """Changed-vs-base YAML paths -> their current content (HEAD in CI, the
+    working tree in dirty local runs). Deleted files excluded."""
+    names = _git(["diff", "--name-only", "--diff-filter=d", base_commit, "HEAD"])
     out: dict[str, str] = {}
     for name in names.splitlines():
         if not (name.endswith(".yaml") or name.endswith(".yml")):
@@ -258,16 +288,24 @@ def main(argv: list[str] | None = None) -> int:
         print(f"setup: {exc}", file=sys.stderr)
         return 2
 
-    today = date.fromisoformat(args.today) if args.today else date.today()
+    try:
+        today = date.fromisoformat(args.today) if args.today else date.today()
+    except ValueError as exc:
+        print(f"setup: --today: {exc}", file=sys.stderr)
+        return 2
+    grace = set(args.grace)
     result = LifecycleResult()
     result.findings.extend(
-        check_pending_orphans(retros, today, set(args.grace), args.max_pending_days)
+        check_pending_orphans(retros, today, grace, args.max_pending_days)
     )
+
+    result.findings.extend(check_stale_grace(retros, grace))
 
     if args.diff_base:
         try:
-            base_statuses = _base_statuses(args.diff_base, retros_dir)
-            changed = _changed_yaml_contents(args.diff_base)
+            base_commit = _merge_base(args.diff_base)
+            base_statuses = _base_statuses(base_commit, retros_dir)
+            changed = _changed_yaml_contents(base_commit)
         except RuntimeError as exc:
             print(f"setup: {exc}", file=sys.stderr)
             return 2

--- a/resolver/retro_lifecycle.py
+++ b/resolver/retro_lifecycle.py
@@ -115,6 +115,18 @@ def check_pending_orphans(
                 )
             )
             continue
+        if filed > today:
+            # A future date would make the retro un-ageable, silently
+            # exempting it from the timeout — treat as an authoring error.
+            findings.append(
+                Finding(
+                    check="pending_orphan",
+                    severity="error",
+                    message=f"date {raw_date!r} is in the future",
+                    retro_id=rid,
+                )
+            )
+            continue
         age = (today - filed).days
         if age <= max_pending_days:
             continue
@@ -180,7 +192,15 @@ def check_applied_transitions(
         rid = str(r.get("id", "?"))
         if base_statuses.get(rid) == "applied":
             continue  # not a transition in this diff
-        for rule_id in r.get("affected_rules") or []:
+        # This load path is not schema-validated, so normalize defensively:
+        # a scalar becomes a one-id list (never per-character iteration) and
+        # entries are coerced to str (never `int in str` TypeErrors).
+        raw_rules = r.get("affected_rules")
+        if raw_rules is None:
+            raw_rules = []
+        elif not isinstance(raw_rules, list):
+            raw_rules = [raw_rules]
+        for rule_id in (str(x) for x in raw_rules):
             if not any(rule_id in text for text in changed_yaml_contents.values()):
                 findings.append(
                     Finding(

--- a/tests/retro_lifecycle/run.py
+++ b/tests/retro_lifecycle/run.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pyyaml>=6,<7",
+# ]
+# ///
+"""Retro lifecycle gate tests. SPEC.md §3 (orphan timeout, applied transition).
+
+The two core checks are pure functions over frontmatter dicts, so cases are
+inline data rather than file fixtures — there is no load/merge behavior to
+exercise here (that is tests/schema/ and tests/resolver/ territory). The git
+plumbing in retro_lifecycle.main() is exercised end-to-end by CI itself, which
+runs the gate against the real retrospectives/ directory on every PR.
+
+Exit codes: 0 all passed · 1 a case failed · 2 harness setup error.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from resolver.retro_lifecycle import (
+        check_applied_transitions,
+        check_pending_orphans,
+    )
+except ImportError as exc:
+    print(f"setup: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+TODAY = date(2026, 6, 12)
+
+
+def _retro(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "id": "2026-06-10-example",
+        "date": "2026-06-10",
+        "status": "pending",
+        "affected_rules": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def run_cases() -> list[tuple[str, bool, str]]:
+    """Each case returns (name, passed, detail)."""
+    results: list[tuple[str, bool, str]] = []
+
+    def case(name: str, passed: bool, detail: str = "") -> None:
+        results.append((name, passed, detail))
+
+    # --- pending-orphan timeout ---
+
+    f = check_pending_orphans([_retro()], TODAY, grace=set())
+    case("fresh pending passes", f == [], f"findings={f}")
+
+    f = check_pending_orphans([_retro(date="2026-06-01")], TODAY, grace=set())
+    case(
+        "overdue pending errors",
+        len(f) == 1 and f[0].severity == "error" and f[0].check == "pending_orphan",
+        f"findings={f}",
+    )
+
+    f = check_pending_orphans(
+        [_retro(date="2026-06-01")], TODAY, grace={"2026-06-10-example"}
+    )
+    case(
+        "graced overdue pending warns (non-fatal)",
+        len(f) == 1 and f[0].severity == "warning",
+        f"findings={f}",
+    )
+
+    # Boundary: exactly max_pending_days old is not yet an orphan.
+    f = check_pending_orphans([_retro(date="2026-06-05")], TODAY, grace=set())
+    case("pending exactly 7 days passes", f == [], f"findings={f}")
+
+    f = check_pending_orphans(
+        [_retro(status="applied", date="2026-01-01")], TODAY, grace=set()
+    )
+    case("old applied retro is not an orphan", f == [], f"findings={f}")
+
+    f = check_pending_orphans([_retro(date="not-a-date")], TODAY, grace=set())
+    case(
+        "unparseable date errors",
+        len(f) == 1 and f[0].severity == "error",
+        f"findings={f}",
+    )
+
+    # --- applied-transition diff check ---
+
+    applied = _retro(status="applied", affected_rules=["register.de_AT.formality"])
+
+    f = check_applied_transitions(
+        [applied],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={
+            "locales/de_AT/register.yaml": "rule_ref: register.de_AT.formality\n"
+        },
+    )
+    case("applied transition touching its rule passes", f == [], f"findings={f}")
+
+    f = check_applied_transitions(
+        [applied],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={"base.yaml": "id: base\n"},
+    )
+    case(
+        "applied transition missing its rule errors",
+        len(f) == 1 and f[0].severity == "error" and f[0].check == "applied_transition",
+        f"findings={f}",
+    )
+
+    f = check_applied_transitions(
+        [applied],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={},
+    )
+    case(
+        "applied transition with no YAML changes errors",
+        len(f) == 1 and f[0].severity == "error",
+        f"findings={f}",
+    )
+
+    f = check_applied_transitions(
+        [applied],
+        base_statuses={"2026-06-10-example": "applied"},
+        changed_yaml_contents={},
+    )
+    case("already-applied at base is not a transition", f == [], f"findings={f}")
+
+    # New retro filed directly as applied (the 2026-04-12 bootstrap pattern):
+    # absent from base, so it IS a transition and must touch its rules.
+    f = check_applied_transitions([applied], base_statuses={}, changed_yaml_contents={})
+    case(
+        "new retro filed as applied must touch rules",
+        len(f) == 1 and f[0].severity == "error",
+        f"findings={f}",
+    )
+
+    structural = _retro(status="applied", affected_rules=[])
+    f = check_applied_transitions(
+        [structural],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={},
+    )
+    case(
+        "structural retro (empty affected_rules) passes",
+        f == [],
+        f"findings={f}",
+    )
+
+    multi = _retro(
+        status="applied",
+        affected_rules=["register.de_AT.formality", "rule.de-sie"],
+    )
+    f = check_applied_transitions(
+        [multi],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={
+            "locales/de_AT/register.yaml": "rule_ref: register.de_AT.formality\n"
+        },
+    )
+    case(
+        "every affected rule must be touched, not just one",
+        len(f) == 1 and "rule.de-sie" in f[0].message,
+        f"findings={f}",
+    )
+
+    return results
+
+
+def main() -> int:
+    results = run_cases()
+    failed = [(name, detail) for name, ok, detail in results if not ok]
+    for name, ok, detail in results:
+        print(f"{'PASS' if ok else 'FAIL'}  {name}" + ("" if ok else f"  {detail}"))
+    print(f"\n{len(results) - len(failed)}/{len(results)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/retro_lifecycle/run.py
+++ b/tests/retro_lifecycle/run.py
@@ -93,6 +93,14 @@ def run_cases() -> list[tuple[str, bool, str]]:
         f"findings={f}",
     )
 
+    # A future date must not silently exempt a pending retro from the timeout.
+    f = check_pending_orphans([_retro(date="2026-12-01")], TODAY, grace=set())
+    case(
+        "future date errors instead of bypassing the timeout",
+        len(f) == 1 and f[0].severity == "error" and "future" in f[0].message,
+        f"findings={f}",
+    )
+
     # --- stale grace waivers ---
 
     f = check_stale_grace([_retro()], grace={"2026-06-10-example"})
@@ -189,6 +197,32 @@ def run_cases() -> list[tuple[str, bool, str]]:
     case(
         "every affected rule must be touched, not just one",
         len(f) == 1 and "rule.de-sie" in f[0].message,
+        f"findings={f}",
+    )
+
+    # Frontmatter on this load path is not schema-validated: a scalar
+    # affected_rules must behave as a one-id list, not iterate per character.
+    scalar = _retro(status="applied", affected_rules="register.de_AT.formality")
+    f = check_applied_transitions(
+        [scalar],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={"base.yaml": "id: base\n"},
+    )
+    case(
+        "scalar affected_rules enforced as a single id",
+        len(f) == 1 and "register.de_AT.formality" in f[0].message,
+        f"findings={f}",
+    )
+
+    numeric = _retro(status="applied", affected_rules=[123])
+    f = check_applied_transitions(
+        [numeric],
+        base_statuses={"2026-06-10-example": "pending"},
+        changed_yaml_contents={"base.yaml": "id: 123\n"},
+    )
+    case(
+        "numeric affected_rules entries do not crash",
+        f == [],
         f"findings={f}",
     )
 

--- a/tests/retro_lifecycle/run.py
+++ b/tests/retro_lifecycle/run.py
@@ -29,6 +29,7 @@ try:
     from resolver.retro_lifecycle import (
         check_applied_transitions,
         check_pending_orphans,
+        check_stale_grace,
     )
 except ImportError as exc:
     print(f"setup: {exc}", file=sys.stderr)
@@ -89,6 +90,25 @@ def run_cases() -> list[tuple[str, bool, str]]:
     case(
         "unparseable date errors",
         len(f) == 1 and f[0].severity == "error",
+        f"findings={f}",
+    )
+
+    # --- stale grace waivers ---
+
+    f = check_stale_grace([_retro()], grace={"2026-06-10-example"})
+    case("grace matching a pending retro is not stale", f == [], f"findings={f}")
+
+    f = check_stale_grace([_retro(status="applied")], grace={"2026-06-10-example"})
+    case(
+        "grace pointing at a closed retro warns (non-fatal)",
+        len(f) == 1 and f[0].severity == "warning" and f[0].check == "stale_grace",
+        f"findings={f}",
+    )
+
+    f = check_stale_grace([_retro()], grace={"typo-id"})
+    case(
+        "grace with unknown id warns",
+        len(f) == 1 and f[0].retro_id == "typo-id",
         f"findings={f}",
     )
 


### PR DESCRIPTION
## Summary

Implements the retrospective lifecycle enforcement system specified in SPEC §3, adding two CI-enforced checks that the schema cannot express:

1. **Pending-orphan timeout**: Blocks PRs if any retrospective stays in `pending` status for more than 7 days without transitioning, with per-id grace waivers visible in workflow diffs.
2. **Applied-transition diff check**: Ensures that when a retrospective transitions to `applied` status, the PR also modifies every file containing an affected rule ID.

## Key Changes

- **`resolver/retro_lifecycle.py`** (new): Core gate implementation with three check functions:
  - `check_pending_orphans()`: Detects overdue pending retros, with grace-waiver support
  - `check_stale_grace()`: Warns when grace IDs no longer match any pending retro
  - `check_applied_transitions()`: Validates that applied-status transitions touch all affected rules via git diff analysis
  - Git integration helpers for merge-base calculation and YAML content diffing

- **`tests/retro_lifecycle/run.py`** (new): Comprehensive test suite covering:
  - Orphan timeout boundary conditions (exactly 7 days, unparseable dates)
  - Grace waiver mechanics (matching/stale/non-fatal warnings)
  - Applied-transition validation (single/multiple rules, structural retros, new vs. existing)

- **`.github/workflows/schema-validation.yml`** (modified):
  - Added `fetch-depth: 0` to checkout for full git history (required for diff-base analysis)
  - Integrated retro lifecycle test suite and gate execution
  - Gate runs with `--grace 2026-04-26` for the structural retro blocking on cross-repo work (P1-4b/P1-5b)

- **`SPEC.md`** (modified): Updated §2.4 CI gates section to reflect implemented status

- **`P1-3-PLAN.md`** (modified): Added §7 resolutions documenting post-merge decisions

- **`RECOVERY-PLAN.md`** (new): Detailed process for extracting known-good historical translations for contaminated locales and unfreezing i18n work, with per-locale sequencing and mechanical validation steps

## Implementation Details

- Exit codes: 0 (pass, warnings allowed), 1 (lifecycle violation), 2 (setup error)
- Findings are categorized by severity (`error`/`warning`) and check type; only `error` severity blocks the PR
- Applied-transition check uses git merge-base for consistency when the base branch has moved
- Retro frontmatter is parsed via existing `loader.py` utilities; no new YAML parsing logic
- Grace waivers are per-id and visible in workflow file diffs for reviewability

https://claude.ai/code/session_01Nb9XCHFS43pDpvwfeeibms