### PR TITLE
Add publish workflow and submodule-contract README (issue #10)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: publish
+
+# Tag every merge to main so the app repo (onetimesecret/onetimesecret) can pin
+# its submodule to a named resolver release. Issue #10 (P1-4a) acceptance
+# criterion: ".github/workflows/publish.yml tags main on merge."
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+# Serialize releases so two quick merges to main cannot race to mint a tag.
+concurrency:
+  group: publish-tag
+  cancel-in-progress: false
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history + tags: we count commits from the root and check
+          # whether this version's tag already exists.
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Annotated tags record a tagger, so a bare runner needs a git identity;
+      # without this, `git tag -a` aborts with "Committer identity unknown."
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version tag
+        id: version
+        run: |
+          set -euo pipefail
+          # N = total commits reachable from HEAD. main is append-only, so N is
+          # strictly monotonic and never collides. (Counting "commits since the
+          # last tag" — the original scheme — resets to 1 the moment the first
+          # tag lands, walking the version backward and colliding with v0.0.1.)
+          count=$(git rev-list --count HEAD)
+          echo "tag=v0.0.${count}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          tag="${{ steps.version.outputs.tag }}"
+          # The monotonic count can only repeat if this exact commit is being
+          # re-released (e.g. a manual workflow re-run), so an existing tag means
+          # "already released" — not "no new commits." Skip honestly.
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag ${tag} already exists; ${GITHUB_SHA} is already released. Nothing to do."
+            exit 0
+          fi
+          git tag -a "${tag}" -m "Release ${tag}
+
+          translation-rules at ${GITHUB_SHA}
+
+          Pin the app-repo submodule to this tag (or its commit) to consume a
+          named resolver release. See README.md for the submodule contract."
+          git push origin "${tag}"
+          echo "Released ${tag} (${GITHUB_SHA})."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# translation-rules
+
+Authority repo for translation guidance — the rules, registers, and glossaries
+that the companion app repo (`onetimesecret/onetimesecret`) consumes as
+generated artifacts. Its job is to prevent the change-log-as-guidance failure
+mode: only schema-validated, human-authored YAML can bind translator behavior.
+
+**Design, rationale, and the current state of every gate live in
+[`SPEC.md`](SPEC.md).** This README documents only the contract the app repo
+depends on, deliberately kept small so it does not drift from the code. For how
+a gate works or whether it is live, read `SPEC.md` (§2.4) and the resolver — not
+this file.
+
+## Consuming this repo (the app-repo contract)
+
+The app repo vendors this repo as a git submodule and commits the resolver's
+output next to it (`SPEC.md` §2.3):
+
+- `locales/guides/for-translators/<locale>.md` — human-readable guide.
+  Generated, headed `# GENERATED from translation-rules@<sha> — do not edit, do
+  not cite as source`.
+- `locales/.resolved/<locale>.json` — machine-readable model for translation
+  agents.
+
+`_meta.source_commit` in that JSON is **the translation-rules commit the
+artifacts were generated from** — the rules-repo `HEAD` at resolve time, or an
+explicit `--source-commit` override. It is *not* a copy of the app repo's
+submodule pointer (this repo cannot know its own future submodule SHA). The
+relationship runs the other way: the app-repo gate verifies
+`source_commit == submodule SHA`, which is what proves the committed artifacts
+were generated from the exact rules commit the submodule pins (`SPEC.md` §2.4).
+
+### What enforces the contract
+
+- **Live** — the register forbidden-token gate. App-repo CI
+  (`validate-register.yml`, onetimesecret/onetimesecret#3432) runs
+  `bin/lint-register` from a read-only pinned checkout of this repo against
+  `locales/content/<locale>/*.json` on every content PR. Zero tolerance.
+- **Planned** (`SPEC.md` §2.4) — submodule-pointer freshness, the
+  `source_commit == submodule SHA` check above, and a byte-for-byte hash lock on
+  the generated markdown so hand edits are rejected.
+
+Treat the planned items as not-yet-enforced: do not assume drift between rules
+and committed artifacts is caught until the `SPEC.md` §2.4 Status line says it
+is. That Status line, not this README, is the source of truth for what is wired.
+
+## Release tags
+
+`.github/workflows/publish.yml` tags every merge to `main` as `v0.0.N`, where
+`N` is the total commit count on `main` — a monotonic build number, not semver.
+The tag is a convenience pin only; the binding is always the commit SHA. Pin the
+submodule to a tag when you want a named, browsable release, or to a SHA
+otherwise.
+
+## Working in this repo
+
+```bash
+uv sync                                              # resolver + dev deps
+python resolver/resolve.py <locale> --lint --emit md,json   # resolve one locale
+python resolver/resolve.py --all --lint                     # resolve every locale
+```
+
+CI runs the schema, type-check, register-lint, and `_archive/` firewall gates on
+every PR. `SPEC.md` §2.4 is the authoritative, current list of those gates and
+what each enforces.


### PR DESCRIPTION
Closes the two issue #10 (P1-4a) acceptance criteria still open on this branch — a publish workflow that tags `main`, and a README documenting the app-repo submodule contract.

This takes the **intent** of `relaxed-faraday`'s `1addc8d` ("Add publish workflow and README") but **reconstructs the execution** rather than cherry-picking it, because that commit's `publish.yml` and 207-line README each shipped real defects.

### `publish.yml` — tag `main` on merge

Rebuilt to fix three concrete bugs in the original:

- **Monotonic versioning.** Tag is `v0.0.N` where `N` is the **total commit count on `main`** (`git rev-list --count HEAD`), not "commits since the last tag." `main` is append-only, so `N` is strictly increasing and collision-free. The original counted since the last tag, which resets to `1` the moment the first tag lands — walking the version *backward* (e.g. `v0.0.40` → next merge computes `N=1` → `v0.0.1`), then colliding with the old `v0.0.1`.
- **Honest skip reporting.** Because a monotonic count can only repeat when the *same commit* is re-released, an existing tag is reported as "already released," not the original's misleading "No new commits; skipping tag." A `concurrency` group keeps two quick merges from racing to mint a tag.
- **Git identity.** Configures a committer identity so `git tag -a` does not abort with "Committer identity unknown" on a bare runner — the original would fail outright at tag creation.

### `README.md` — submodule-consumer contract only

Scoped to the contract the app repo depends on, deliberately small so it does not become a hand-maintained doc that drifts from the code (the failure mode this repo exists to prevent). Design rationale and live-vs-planned gate status are deferred to `SPEC.md` §2.4 rather than restated.

- **Accurate `_meta.source_commit`.** Documented as *the translation-rules commit the artifacts were generated from* (rules-repo `HEAD`, or `--source-commit`), which the **app-repo gate checks equals the submodule SHA** — correcting the original's "pinned to submodule SHA," which inverted the relationship (this repo cannot know its own future submodule pointer).
- **Live vs planned.** Splits the register forbidden-token gate (live, app-repo `validate-register.yml` / #3432) from the still-planned submodule-freshness, `source_commit == submodule SHA`, and markdown hash-lock gates, matching `SPEC.md` §2.4 Status.
- Drops the original's enumeration of internal resolver files and pipeline steps, which would drift as the implementation changes.

### Notes

- Built directly on `claude/loving-clarke-sgcvny`, so the diff is exactly these two new files and there are no merge conflicts.
- `publish.yml` validated as well-formed YAML locally.

https://claude.ai/code/session_018jBp19nt5xvv3462EhTkX7

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBp19nt5xvv3462EhTkX7)_