### PR TITLE
Document review vs retrospective distinction and cross-locale patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,6 @@ what each enforces.
 
 ## Reviews vs retrospectives
 
-**Review** = raw observation. Prose, no schema, human/agent-authored, lives in
-`reviews/<date>/`. Answers *"what did we see?"* Can be one locale or a 29-locale
-roll-up — both are reviews. Ends in a findings manifest.
-
-**Retrospective** = the decision a finding drives. Schema'd frontmatter,
-lifecycle-tracked (`pending→applied`), lives in `retrospectives/`. Answers
-*"what rule changes because of it, and is it done?"*
-
-A cross-locale roll-up file is a second review document (observation), sitting
-alongside the per-locale ones. Its job is to *name* the patterns that span
-locales; each pattern then gets one retro that the relevant per-locale manifests
-tag.
-
-Rule of thumb: **many reviews can point at one retro; one retro can be cited by
-many reviews.** Observation is many-to-one with decision. If you're recording
-what you noticed → review. If you're committing to a rule/lint change and
-tracking it to closure → retro.
+Reviews are raw observations; retrospectives are the lifecycle-tracked decisions
+findings drive. The canonical definition — including how cross-locale roll-ups
+fit — lives in [`reviews/README.md`](reviews/README.md#review-vs-retrospective).

--- a/README.md
+++ b/README.md
@@ -66,3 +66,23 @@ python resolver/resolve.py --all --lint                     # resolve every loca
 CI runs the schema, type-check, register-lint, and `_archive/` firewall gates on
 every PR. `SPEC.md` §2.4 is the authoritative, current list of those gates and
 what each enforces.
+
+## Reviews vs retrospectives
+
+**Review** = raw observation. Prose, no schema, human/agent-authored, lives in
+`reviews/<date>/`. Answers *"what did we see?"* Can be one locale or a 29-locale
+roll-up — both are reviews. Ends in a findings manifest.
+
+**Retrospective** = the decision a finding drives. Schema'd frontmatter,
+lifecycle-tracked (`pending→applied`), lives in `retrospectives/`. Answers
+*"what rule changes because of it, and is it done?"*
+
+A cross-locale roll-up file is a second review document (observation), sitting
+alongside the per-locale ones. Its job is to *name* the patterns that span
+locales; each pattern then gets one retro that the relevant per-locale manifests
+tag.
+
+Rule of thumb: **many reviews can point at one retro; one retro can be cited by
+many reviews.** Observation is many-to-one with decision. If you're recording
+what you noticed → review. If you're committing to a rule/lint change and
+tracking it to closure → retro.

--- a/reviews/README.md
+++ b/reviews/README.md
@@ -5,6 +5,26 @@ directory is the human-written input end of the feedback cycle — no schema,
 no rewriting. The machine-readable companions are retrospectives; see
 `retrospectives/README.md` for how findings become rule changes.
 
+## Review vs retrospective
+
+**Review** = raw observation. Prose, no schema, human/agent-authored, lives in
+`reviews/<date>/`. Answers *"what did we see?"* Can be one locale or a 29-locale
+roll-up — both are reviews. Ends in a findings manifest.
+
+**Retrospective** = the decision a finding drives. Schema'd frontmatter,
+lifecycle-tracked (`pending→applied`), lives in `retrospectives/`. Answers
+*"what rule changes because of it, and is it done?"*
+
+A cross-locale roll-up file is a second review document (observation), sitting
+alongside the per-locale ones. Its job is to *name* the patterns that span
+locales; each pattern then gets one retro that the relevant per-locale manifests
+tag.
+
+Rule of thumb: **many reviews can point at one retro; one retro can be cited by
+many reviews.** Observation is many-to-one with decision. If you're recording
+what you noticed → review. If you're committing to a rule/lint change and
+tracking it to closure → retro.
+
 ## Grandfather clause
 
 Documents that predate the findings-manifest gate are preserved byte-for-byte


### PR DESCRIPTION
This PR adds clarifying documentation about the conceptual distinction between reviews and retrospectives, and how cross-locale roll-up files fit into the feedback cycle.

## Summary
Added comprehensive documentation explaining the difference between reviews (raw observations) and retrospectives (lifecycle-tracked decisions), including guidance on how cross-locale roll-up files function as a second review document that names patterns across locales.

## Key changes
- **reviews/README.md**: Added new "Review vs retrospective" section that defines:
  - Reviews as raw observations (prose, no schema, human/agent-authored)
  - Retrospectives as schema'd decisions with lifecycle tracking (pending→applied)
  - The role of cross-locale roll-up files as pattern-naming review documents
  - A rule of thumb clarifying the many-to-one relationship between reviews and retrospectives
  
- **README.md**: Added brief "Reviews vs retrospectives" section that points readers to the canonical definition in `reviews/README.md`

## Notable details
The documentation establishes a clear mental model: observations (reviews) are many-to-one with decisions (retrospectives). Cross-locale roll-ups are positioned as a second review document whose purpose is to identify patterns that span locales, with each pattern then getting a single retrospective that per-locale manifests can reference.

https://claude.ai/code/session_01Ed8CKVzEJyFZ67GeEHMSja