### PR TITLE
ADR directory; French (fr/fr_CA) back-port; resolver emit path per SPEC §2.3

### DIFF
--- a/authoring/backfill-locale.md
+++ b/authoring/backfill-locale.md
@@ -1,0 +1,97 @@
+# Backfill a locale into structured rules
+
+What it takes to make `<locale>` resolved-only-ready: a non-empty
+`.resolved/<locale>.json` (register + glossary, not just `base.yaml`) that
+passes lint. Until this is done, a locale must NOT be flipped to resolved-only —
+`base.yaml` alone gives an agent no register and no terminology, which
+re-opens the register-regression class (see `retrospectives/`,
+`reviews/2026-04-12/`).
+
+**Source of truth for the content.** Lift the terminology, formality, and
+critical rules from the app repo's existing prose guide —
+`onetimesecret/locales/guides/for-translators/<locale>.md` — plus the live
+`locales/content/<locale>/*.json`. You are *transcribing* agreed knowledge
+into schema, not inventing it. Targets/examples you author are AGENT-AUTHORED
+and need native-speaker sign-off before merge (PR label; see `locales/de_AT/`).
+
+## Files to create under `locales/<locale>/`
+
+Validate against `schema/*.json`. Copy `locales/de_AT/` as the worked example.
+
+1. **`register.yaml`** — the binding register lock. Required: `id`
+   (`register.<locale>`), `source`, `form`
+   (`formal|informal|mixed|other`), `pronoun`, `forbidden_tokens` (may be `[]`,
+   never null), `exceptions` (may be `[]`, never null). Each forbidden token =
+   `{token, context, severity}`; `context` ∈
+   `standalone_word|word_prefix|substring|any`. Add `possessive`, `rule_ref`,
+   `baseline_ref`, `retro_refs` where they apply. Languages without a T/V split
+   (ja keigo, ko politeness): `form: other` + the `register_spec` extension.
+
+2. **`glossary.yaml`** — sense-split terms. Required: `id`
+   (`glossary.<locale>`), `source`, `terms`. Each term needs `id` + `key`; add
+   `en`, a locale-keyed target (`<locale>: <string>` or
+   `<locale>: {<sense>: {target, rule_ref}}`), `disambiguation`
+   (`heuristic`, `key_patterns`), `rule_refs`, and `examples`. Give every term at
+   least one `good` and one `bad` example: `{id, source, target, verdict}`,
+   `verdict` ∈ `good|bad|borderline`.
+
+3. **`rules.yaml`** — locale layer. Required: `id` (`rules.<locale>`),
+   `source`. Set `inherits` to an **existing** parent id (`base`, or a family
+   parent you also create — see below), `merge_strategy` (`append` is usual),
+   any locale-specific `rules`, and `register_ref`/`glossary_ref`/`baseline_ref`.
+
+4. **`baselines.yaml`** (append an entry, not a new file) — pin the commit where
+   content was last known-good: `{commit, pinned_on, invariants,
+   retro_id | justification_doc}`. One of `retro_id`/`justification_doc` is
+   required.
+
+5. **`docs/`** (optional) — rationale prose, referenced via `docs:`, never
+   inlined. Bare-prose forbidden tokens fail lint; wrap any mention in backticks.
+
+## IDs
+
+Mint stable ids — never hand-roll the `#<8hex>` suffix:
+
+```
+bin/mint-id term <key>     # glossary term  -> term.<key>#<8hex>
+bin/mint-id ex   <key>     # worked example -> ex.<key>#<8hex>
+bin/mint-id rule <key>     # rule           -> rule.<key>#<8hex>
+```
+
+## Inheritance
+
+`inherits` must resolve or the resolver fails. A regional variant needs its
+base-language parent to exist first: for `fr_CA`, create `locales/fr/`
+(inheriting `base`) **then** `locales/fr_CA/` inheriting `rules.fr` — mirroring
+`de_AT -> de -> base`. A standalone language inherits `base` directly.
+
+## Verify (must pass before merge)
+
+The resolver is `uv`-managed; `uv run` auto-syncs deps from the lockfile.
+
+```
+uv run resolver/resolve.py <locale> --lint --validate-only   # resolves + lints, no writes
+```
+
+Lint (SPEC §2.3 step 6) checks only `good` examples:
+- no register `forbidden_tokens` in a good example's target (unless `exceptions`-covered);
+- every good example's target contains one of its term's sense targets (word_prefix);
+- no bare-prose forbidden tokens in embedded docs.
+`bad`/`borderline` examples are exempt — they exist to demonstrate the wrong form.
+
+Then emit the committed artifacts into the app repo:
+
+```
+uv run resolver/resolve.py <locale> --lint --emit=md,json --emit-dir <path-to>/onetimesecret/locales
+# writes onetimesecret/locales/.resolved/<locale>.json + .../guides/for-translators/<locale>.md
+```
+
+## Done
+
+- `uv run resolver/resolve.py <locale> --lint` exits 0;
+- `.resolved/<locale>.json` has populated `register` and `glossary` (not just
+  base `rules`);
+- `bin/lint-register <locale> "<app>/locales/content/<locale>/*.json"` is clean;
+- native-speaker sign-off recorded on the PR.
+
+Only then is the locale eligible to flip to resolved-only.

--- a/baselines.yaml
+++ b/baselines.yaml
@@ -9,3 +9,23 @@ baselines:
       - glossary.secret_object=Geheimnis
     retro_id: 2026-04-12-de_AT-register-flip
     note: "State frozen here was acceptable: last commit before the de_AT contamination sequence began, per reviews/2026-04-12/cross-locale-audit.md. Not a curation commit."
+  fr:
+    commit: 4a64f7bda86bd35ea4786d93731018139a55cf65
+    pinned_on: 2026-06-21
+    invariants:
+      - register.formality=vous
+      - glossary.secret_object=secret
+      - glossary.passphrase=phrase secrète
+      - glossary.password=mot de passe
+      - glossary.email=e-mail
+    justification_doc: onetimesecret/locales/guides/for-translators/fr.md
+    note: "Backfill pin for the fr structured-rules layer. No retro exists; the source of truth is the app-repo French translator guide. AGENT-AUTHORED content pending native-speaker (FR) sign-off. Commit is the current branch tip at authoring time, not a curated content commit."
+  fr_CA:
+    commit: 4a64f7bda86bd35ea4786d93731018139a55cf65
+    pinned_on: 2026-06-21
+    invariants:
+      - register.formality=vous
+      - glossary.secret_object=secret
+      - glossary.email=courriel
+    justification_doc: onetimesecret/locales/guides/for-translators/fr_CA.md
+    note: "Backfill pin for the fr_CA structured-rules layer (inherits rules.fr). Delta from fr is glossary.email=courriel. No retro exists; source of truth is the app-repo Canadian French translator guide. AGENT-AUTHORED content pending native-speaker (CA) sign-off. Commit is the current branch tip at authoring time, not a curated content commit."

--- a/baselines.yaml
+++ b/baselines.yaml
@@ -29,3 +29,48 @@ baselines:
       - glossary.email=courriel
     justification_doc: onetimesecret/locales/guides/for-translators/fr_CA.md
     note: "Backfill pin for the fr_CA structured-rules layer (inherits rules.fr). Delta from fr is glossary.email=courriel. No retro exists; source of truth is the app-repo Canadian French translator guide. AGENT-AUTHORED content pending native-speaker (CA) sign-off. Commit is the current branch tip at authoring time, not a curated content commit."
+  nl:
+    commit: c9308720b09f80c49a6361ebb7f982b465398e0e
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (je)
+      - glossary.secret_object=bericht
+      - glossary.secret_adjective=beveiligd
+    justification_doc: onetimesecret/locales/guides/for-translators/nl.md
+    note: "Backfill pin for the nl structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  es:
+    commit: c9308720b09f80c49a6361ebb7f982b465398e0e
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (tú)
+      - glossary.secret_object=secreto
+      - glossary.passphrase=frase de contraseña
+    justification_doc: onetimesecret/locales/guides/for-translators/es.md
+    note: "Backfill pin for the es structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  pl:
+    commit: c9308720b09f80c49a6361ebb7f982b465398e0e
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (ty)
+      - glossary.secret_object=sekret
+      - glossary.passphrase=fraza dostępowa
+    justification_doc: onetimesecret/locales/guides/for-translators/pl.md
+    note: "Backfill pin for the pl structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  ru:
+    commit: c9308720b09f80c49a6361ebb7f982b465398e0e
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (вы)
+      - glossary.secret_object=секрет
+      - glossary.passphrase=кодов
+    justification_doc: onetimesecret/locales/guides/for-translators/ru.md
+    note: "Backfill pin for the ru structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  ja:
+    commit: c9308720b09f80c49a6361ebb7f982b465398e0e
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other ((omitted; keigo politeness carried by sentence endings — teineigo です/ます))
+      - glossary.secret_object=シークレット
+      - glossary.secret_adjective=機密
+    justification_doc: onetimesecret/locales/guides/for-translators/ja.md
+    note: "Backfill pin for the ja structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."

--- a/baselines.yaml
+++ b/baselines.yaml
@@ -74,3 +74,206 @@ baselines:
       - glossary.secret_adjective=機密
     justification_doc: onetimesecret/locales/guides/for-translators/ja.md
     note: "Backfill pin for the ja structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  ar:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other ((2nd-person address omitted as a standalone pronoun; carried by MSA masculine verb morphology — masculine default أنتَ, gender-neutral ـك suffixes))
+      - glossary.secret_object=سر
+      - glossary.secret_adjective=سري
+    justification_doc: onetimesecret/locales/guides/for-translators/ar.md
+    note: "Backfill pin for the ar structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  bg:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (Вие)
+      - glossary.secret_object=тайна
+      - glossary.passphrase=ключова фраза
+    justification_doc: onetimesecret/locales/guides/for-translators/bg.md
+    note: "Backfill pin for the bg structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  ca_ES:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (tu)
+      - glossary.secret_object=secret
+      - glossary.secret_adjective=segur
+    justification_doc: onetimesecret/locales/guides/for-translators/ca_ES.md
+    note: "Backfill pin for the ca_ES structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  cs:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (ty)
+      - glossary.secret_object=tajemství
+      - glossary.passphrase=přístupová fráze
+    justification_doc: onetimesecret/locales/guides/for-translators/cs.md
+    note: "Backfill pin for the cs structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  da_DK:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (du)
+      - glossary.secret_object=besked
+      - glossary.secret_adjective=hemmelig
+    justification_doc: onetimesecret/locales/guides/for-translators/da_DK.md
+    note: "Backfill pin for the da_DK structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  de:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (du)
+      - glossary.secret_object=Geheimnis
+      - glossary.secret_payload=Nachricht
+    justification_doc: onetimesecret/locales/guides/for-translators/de.md
+    note: "Backfill pin for the de structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  el_GR:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (εσείς)
+      - glossary.secret_object=μυστικό
+      - glossary.passphrase=φράση πρόσβασης
+    justification_doc: onetimesecret/locales/guides/for-translators/el_GR.md
+    note: "Backfill pin for the el_GR structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  eo:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (vi)
+      - glossary.secret_object=sekreto
+      - glossary.passphrase=sekreta frazo
+    justification_doc: onetimesecret/locales/guides/for-translators/eo.md
+    note: "Backfill pin for the eo structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  fr_FR:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (vous)
+    justification_doc: onetimesecret/locales/guides/for-translators/fr_FR.md
+    note: "Backfill pin for the fr_FR structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  he:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other (את/אתה (masculine default — single user addressed in masculine singular))
+      - glossary.secret_object=סוד
+      - glossary.passphrase=ביטוי סיסמה
+    justification_doc: onetimesecret/locales/guides/for-translators/he.md
+    note: "Backfill pin for the he structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  hu:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (Ön)
+      - glossary.secret_object=titok
+      - glossary.secret_adjective=biztonságos
+    justification_doc: onetimesecret/locales/guides/for-translators/hu.md
+    note: "Backfill pin for the hu structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  it_IT:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (tu)
+      - glossary.secret_object=segreto
+      - glossary.secret_adjective=sicuro
+    justification_doc: onetimesecret/locales/guides/for-translators/it_IT.md
+    note: "Backfill pin for the it_IT structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  ko:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other ((omitted; politeness carried by verb endings — 합쇼체 -습니다 / 해요체 -세요))
+      - glossary.secret_object=비밀 메시지
+      - glossary.secret_adjective=안전한
+    justification_doc: onetimesecret/locales/guides/for-translators/ko.md
+    note: "Backfill pin for the ko structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  mi_NZ:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other (koe)
+      - glossary.secret_object=karere huna
+      - glossary.secret_adjective=haumaru
+    justification_doc: onetimesecret/locales/guides/for-translators/mi_NZ.md
+    note: "Backfill pin for the mi_NZ structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  pt:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (você)
+      - glossary.secret_object=mensagem confidencial
+      - glossary.passphrase=frase secreta
+    justification_doc: onetimesecret/locales/guides/for-translators/pt.md
+    note: "Backfill pin for the pt structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  pt_BR:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (você)
+    justification_doc: onetimesecret/locales/guides/for-translators/pt_BR.md
+    note: "Backfill pin for the pt_BR structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  pt_PT:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=mixed (tu)
+      - glossary.password=palavra-passe
+      - glossary.encrypt=encriptar
+    justification_doc: onetimesecret/locales/guides/for-translators/pt_PT.md
+    note: "Backfill pin for the pt_PT structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  sl_SI:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (vi)
+      - glossary.secret_object=skrivnost
+      - glossary.passphrase=pristopna fraza
+    justification_doc: onetimesecret/locales/guides/for-translators/sl_SI.md
+    note: "Backfill pin for the sl_SI structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  sv_SE:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=informal (du)
+      - glossary.secret_object=hemlighet
+      - glossary.passphrase=lösenfras
+    justification_doc: onetimesecret/locales/guides/for-translators/sv_SE.md
+    note: "Backfill pin for the sv_SE structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  tr:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (siz)
+      - glossary.secret_object=gizli mesaj
+      - glossary.passphrase=güvenlik ifadesi
+    justification_doc: onetimesecret/locales/guides/for-translators/tr.md
+    note: "Backfill pin for the tr structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  uk:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (ви)
+      - glossary.secret_object=таємниц
+      - glossary.passphrase=парольн
+    justification_doc: onetimesecret/locales/guides/for-translators/uk.md
+    note: "Backfill pin for the uk structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  vi:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=other (bạn)
+      - glossary.secret_object=bí mật
+      - glossary.secret_adjective=an toàn
+    justification_doc: onetimesecret/locales/guides/for-translators/vi.md
+    note: "Backfill pin for the vi structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."
+  zh:
+    commit: 93857dde460770a9abcc63e1655b4c4ac9e13133
+    pinned_on: 2026-06-22
+    invariants:
+      - register.form=formal (您)
+      - glossary.secret_object=内容
+      - glossary.secret_adjective=加密的
+    justification_doc: onetimesecret/locales/guides/for-translators/zh.md
+    note: "Backfill pin for the zh structured-rules layer. No retro exists; source of truth is the app-repo translator guide. AGENT-AUTHORED content pending native-speaker sign-off. Commit is the branch tip at authoring time, not a curated content commit."

--- a/docs/architecture/decision-records/README.md
+++ b/docs/architecture/decision-records/README.md
@@ -1,0 +1,56 @@
+## Architecture Decision Records (ADRs)
+
+Documents that capture important architectural decisions in the
+translation-rules authority — the schema contract, the resolver, the quality
+gates, and the artifacts consumed by the app repo — along with their context
+and consequences. They are a best practice for technical documentation in
+open-source projects.
+
+**Lifecycle:**
+- Proposed: Under discussion
+- Accepted: Decision approved and implemented
+- Deprecated: No longer relevant but kept for history
+- Superseded: Replaced by a newer ADR (reference the new one)
+
+### Keys to Success
+
+- **Be courteous**: ADRs should be readable in 2-3 minutes, so focus on why. The decision itself is less important than the reasoning.
+- **Avoid formulaic sections**: Don't force content into rigid templates. If your core argument is complete in Context and Decision, stop there. Skip sections that merely reorganize the same points.
+- **Combine related content**: Merge rationale directly into the Decision section. Trade-offs are optional—only include them when they add genuine insight.
+- **Immutable**: Once accepted, don't edit the decision; that's like re-writing history. Use Implementation Notes or create another ADR to supersede.
+- **Numbered sequentially**: Makes referencing easy (`ADR-001`, `ADR-002`, etc.)
+- **One decision per ADR**: Don't bundle multiple choices together
+
+### Implementation Notes Section
+
+Optional addenda for clarifications and execution details. Use it for:
+
+- **Clarifications**: Technical details or edge cases discovered during implementation
+- **Rollout timelines**: When the decision will be implemented relative to when it was accepted
+- **Migration notes**: How to transition from the old state to the new one
+
+This section is mutable. Each note should be dated and titled.
+
+### When to Write ADRs
+
+Write ADRs for decisions that:
+- Are expensive to reverse or constrain future options
+- Affect both this repo and the consuming app repo (e.g. the resolved-artifact contract, the cross-repo gate mechanism)
+- Establish patterns for others (schema shape, resolver pipeline semantics, retrospective lifecycle)
+- Resolve technical debates
+
+Don't write ADRs for:
+- Trivial or easily reversible
+- Implementation details within a single module
+- Non-contentious or standard practice decisions
+
+This repo already records several such decisions inline (e.g. SPEC.md §2.4
+"read-only pinned checkout, not a submodule"; §2.3 "artifacts committed to the
+app repo, not CI-generated-only"). New cross-cutting decisions belong here as
+numbered records; existing inline ones can be promoted to ADRs when next
+revisited.
+
+### Filename & Numbering
+
+`adr-NNN-kebab-slug.md`, numbered sequentially, slug derived from the title.
+`adr-000.md` is the template — copy it to start a new record.

--- a/docs/architecture/decision-records/adr-000.md
+++ b/docs/architecture/decision-records/adr-000.md
@@ -1,0 +1,42 @@
+---
+id: 000
+status: accepted
+title: ADR-000: [Short Title]
+---
+
+<!-- Filename: adr-NNN-kebab-slug.md (slug derived from title) -->
+
+<!-- Required sections: Status, Date, Context, Decision -->
+
+## Status
+[Proposed | Accepted | Deprecated | Superseded]
+
+## Date
+YYYY-MM-DD
+
+## Context
+What is the issue we're facing? What factors are driving this decision?
+What constraints exist (technical, business, time, resources)?
+
+## Decision
+What are we going to do? Be specific and concrete.
+
+Why this approach? Include the core rationale here—don't save it for later sections.
+
+<!-- Optional sections below — include only when they add value -->
+
+## Trade-offs
+- **We lose**: What capability or benefit are we giving up?
+- **We gain**: What do we get in return?
+- **Performance/Cost/Risk**: Any notable impacts?
+
+## Consequences
+### Positive
+### Negative
+### Neutral
+
+## Implementation Notes
+[Clarifications, rollout timelines, and implementation details that don't change the core decision. Each note should be dated.]
+
+### [Note Title] (YYYY-MM-DD)
+[Implementation details, clarifications, or context that helps with execution]

--- a/docs/architecture/decision-records/adr-001-glossary-inheritance.md
+++ b/docs/architecture/decision-records/adr-001-glossary-inheritance.md
@@ -1,0 +1,55 @@
+---
+id: 001
+status: accepted
+title: ADR-001: Glossary inheritance along the rules chain
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-22
+
+## Context
+The resolver merges `rules.yaml` along the inheritance chain (e.g. `fr_CA → fr → base`) but, until this ADR, treated `glossary.yaml` as a per-locale leaf file: load + validate, never merge. Register followed the same per-locale-leaf pattern.
+
+That was incidental, not designed. Greptile #29-1 surfaced it: `locales/fr_CA/glossary.yaml` was authored delta-only (just the `courriel` override of `email`), expecting the rest of fr's terminology — `mot de passe`, `phrase secrète`, `brûler`, `lien`, `chiffré` — to flow through. The emitted `.resolved/fr_CA.json` instead contained only the two terms fr_CA had restated locally, while inherited `rule_ref`s still pointed at the missing terms. Translators or downstream consumers reading the resolved artifact would see incomplete terminology guidance with refs that look fine but resolve to nothing in the local view.
+
+The pre-fix workaround was to restate every parent term in each child glossary. That scales badly: ~30 regional variants are on the back-port roadmap (fr_FR, fr_BE, fr_CH; de_DE, de_CH; es_ES, es_MX, es_AR, ...). Each restate is a place the terms can silently drift from the parent.
+
+## Decision
+**Glossaries merge along the same inheritance chain as rules, with term-`key` override.** A child term replaces the parent term of the same `key` wholesale; terms the child omits are inherited unchanged. The merged glossary keeps the child's `id` and `source` (downstream consumers attribute the artifact to the locale being resolved), with the union of all chain terms under `terms:`.
+
+**Register stays self-contained (per-locale).** Registers are short, locale-defining, and carry forbidden-token lists tuned to that locale's morphology (e.g. fr blocks `t'` / `t’` elisions specifically — meaningless for de). Merging would create false sharing and would not avoid meaningful duplication.
+
+Why term-`key` and not term-`id`: the `key` is the human-readable grep target ("email", "passphrase"); the `id` is uuid-suffixed and survives renames. Inheritance is over what the term *means*, not over which file declared it. fr_CA's `term.email_ca#287480a5` overriding fr's `term.email#8c4fb076` is correct — both have `key: email`.
+
+Why wholesale term replacement and not sense-level merge: the term is the smallest unit of cross-locale meaning. A child that overrides one sense almost certainly wants its own examples and `rule_ref`s for the others too; partial-sense merges would be an attractive nuisance.
+
+## Trade-offs
+- **We lose**: A locale can no longer silently keep a term-name in sync with its parent by restating it. If a parent renames a term's `key`, the child either inherits the new key or has to update.
+- **We gain**: Delta-only child glossaries scale linearly with the number of locale-specific differences, not with the total terminology surface. The fr_CA glossary drops from 2 terms to 1.
+
+## Consequences
+### Positive
+- The ~30 regional variants on the back-port roadmap can be authored as deltas without restating their parent's terminology.
+- Inherited `rule_ref`s in the merged glossary are validated against the same combined index as the locale's own refs, so a missing parent rule fails fast at resolve time.
+
+### Negative
+- Renaming a term's `key` in a parent locale is a chain-wide change: any child that intended to override the old key inherits the new one instead. Mitigated by lint at resolve time (the override never silently disappears — it just stops being an override) and by the rules-vs-glossary split: a rename is unusual.
+
+### Neutral
+- Register and rules continue to use different mechanisms (per-locale leaf vs. chain-merge); the asymmetry is now documented rather than incidental.
+- Term `id` collisions across parent and child are harmless: the term-merge dedups by `key`, and `IdIndex.add` only errors on same-id/different-`(kind, key)` records, which a deterministic id minted from a stable `(kind, key)` cannot produce.
+
+## Implementation Notes
+
+### Resolver wiring (2026-06-22)
+`resolver/merge.py` adds `merge_glossary_terms(glossaries_child_first)`, called from `resolver/resolve.py:resolve_locale` after the rules chain is built. The function walks the chain child-first (locale leaf, then each ancestor's `glossary.yaml` if present, skipping `base`), dedups by `key`, and emits a glossary headed by the child's `id` / `source`. `_check_refs` validates the merged glossary instead of the leaf so inherited terms' refs are checked. The returned `result["glossary"]` is the merged view; `build_model` continues to consume it unchanged.
+
+No glossary indexing change was needed: `_check_refs` validates `*_ref` fields, not `id` definitions. Inherited terms' `rule_ref`s already point at rules in the chain (which are indexed via `_index_dotted_ids_in_rules` over `chain_nodes`).
+
+### Known limitation: inherited term/example ids are not in the uuid index (2026-06-22)
+`_index_glossary` runs only on the locale's own (leaf) glossary, so a parent term's `id` and its examples' `id`s do not enter the combined uuid index. This is invisible today because the only uuid-shaped reference field is `examples_added` (used by retrospectives) and no current YAML references an inherited example. A future retro that did `examples_added: [<an inherited example id>]` would dangle even though the example is present in the merged glossary view. The fix, if that case arises, is to also call `_index_glossary` on each ancestor glossary during the chain walk; deferred until there is a consumer, to keep this change contained. (Duplicate term `id`s across parent/child are harmless either way — they share `(kind, key)`, which `IdIndex.add` permits.)
+
+Fixture coverage: `tests/resolver/fixtures/de-de_AT/locales/de/glossary.yaml` introduces a parent-only `link` term (inherited) plus a duplicate-key `secret_object` (overridden by de_AT), so the de-de_AT golden exercises both cases.

--- a/locales/ar/glossary.yaml
+++ b/locales/ar/glossary.yaml
@@ -1,0 +1,215 @@
+id: glossary.ar
+source: onetimesecret/locales/guides/for-translators/ar.md
+# Sense-split of the core domain terminology from the Arabic translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/ar.md §Core
+# Terminology, §Account-Related Terms, §Special Considerations), grounded against
+# the live app content in onetimesecret/locales/content/ar/*.json. Targets and
+# worked examples are AGENT-AUTHORED and require native-speaker (AR) sign-off
+# before merge — see PR label.
+#
+# RTL / CLITIC TOKENIZATION NOTE: SPEC §2.3 lint check 2 requires every `good`
+# example's target to contain a sense target in `word_prefix` mode (left word
+# boundary, any suffix). Arabic words are space-separated so word_prefix works,
+# BUT the definite article ال and the clitics و/ب/ل/ك attach as prefixes with no
+# space, and Arabic letters are word chars (isalnum). So a bare citation form
+# (سر) does NOT match inside السر (the ل left-neighbour blocks the prefix). Each
+# `good` example below therefore places its sense target at a word boundary: the
+# bare form where the example uses the indefinite (سر, سري, تشفير, مشفر), or the
+# ال-prefixed form as the sense target where the natural phrase is definite
+# (الرابط, البريد الإلكتروني). Every good example uses MSA + masculine-default
+# address and is verified clean; each bad example demonstrates a wrong form
+# (dialect/colloquial register, feminine address, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render consistently as سر (state-secret to business usage), never a literal alternative."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    ar:
+      noun:
+        target: سر
+        rule_ref: rule.ar-secret-sirr
+    rule_refs: [rule.register-lock, rule.terminology-consistency, rule.ar-secret-sirr]
+    examples:
+      - id: ex.secret-ar-good#8b8e9f9a
+        source: "Create a secret and share it securely."
+        target: "أنشئ سراً جديداً وشاركه بأمان."
+        verdict: good
+        note: "MSA masculine imperative أنشئ; core term سر in head position (سراً = سر + indefinite suffix, word_prefix match). Grounded in live إنشاء السر / مشاركة سر."
+        rule_refs: [rule.register-lock, rule.ar-secret-sirr]
+      - id: ex.secret-ar-bad#15c07d9e
+        source: "Create a secret and share it securely."
+        target: "اعمل سيكريت وشاركه."
+        verdict: bad
+        note: "Colloquial اعمل ('do/make', dialectal) plus the transliteration سيكريت instead of the glossary term سر — violates rule.ar-register-msa and rule.ar-secret-sirr."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secret
+    disambiguation:
+      heuristic: "The adjective / state sense — 'secret' or 'secure' as a descriptor of a link, message, or storage. Render as سري (secret) or آمن (secure); reserve the noun سر for the product entity."
+      key_patterns: ["*secure*", "*secured*", "*.protect*", "*secret_link*"]
+    ar:
+      adjective:
+        target: سري
+        rule_ref: rule.ar-secret-sirr
+      secure:
+        target: آمن
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adj-ar-good#79cfea86
+        source: "Share a secure, secret link that works once."
+        target: "شارك رابطاً سرياً آمناً مرة واحدة فقط."
+        verdict: good
+        note: "Adjective سري (سرياً) and آمن (آمناً) both in word-boundary position; MSA masculine imperative شارك. Grounded in live روابط آمنة / الرابط السري."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.secret-adj-ar-bad#a3b42fcc
+        source: "Share a secure, secret link that works once."
+        target: "شاركي رابط سري آمن."
+        verdict: bad
+        note: "Feminine imperative شاركي (verb + ـي) — the non-default feminine address forbidden by rule.ar-address-masculine."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose / protect-a-secret and view-a-secret contexts signal this sense. Compound term عبارة المرور."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    ar:
+      noun:
+        target: عبارة المرور
+        rule_ref: rule.ar-passphrase-password
+    rule_refs: [rule.register-lock, rule.ar-passphrase-password]
+    examples:
+      - id: ex.passphrase-ar-good#d05796a6
+        source: "Enter the passphrase to view this secret."
+        target: "أدخل عبارة المرور لعرض هذا السر."
+        verdict: good
+        note: "Grounded in live أدخل عبارة المرور هنا; MSA masculine imperative أدخل; عبارة المرور (secret protection), not كلمة المرور, in head position."
+        rule_refs: [rule.register-lock, rule.ar-passphrase-password]
+      - id: ex.passphrase-ar-bad#d2a8ac1a
+        source: "Enter the passphrase to view this secret."
+        target: "أدخل كلمة المرور لعرض هذا السر."
+        verdict: bad
+        note: "Uses كلمة المرور (account credential) where عبارة المرور (secret protection) is meant — violates rule.ar-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Standard term كلمة المرور."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    ar:
+      noun:
+        target: كلمة المرور
+        rule_ref: rule.ar-passphrase-password
+    rule_refs: [rule.register-lock, rule.ar-passphrase-password]
+    examples:
+      - id: ex.password-ar-good#a2b33525
+        source: "Enter your password to sign in."
+        target: "أدخل كلمة المرور لتسجيل الدخول."
+        verdict: good
+        note: "Grounded in live تسجيل الدخول بكلمة المرور; MSA masculine imperative أدخل; account term كلمة المرور in head position."
+        rule_refs: [rule.register-lock, rule.ar-passphrase-password]
+      - id: ex.password-ar-bad#8bb34a0b
+        source: "Enter your password to sign in."
+        target: "دخّل الباسوورد عشان تسجل."
+        verdict: bad
+        note: "Colloquial دخّل + عشان (dialectal 'so that') and the transliteration الباسوورد instead of كلمة المرور — violates rule.ar-register-msa and rule.ar-passphrase-password."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently deleting a secret before it is viewed. Rendered as حذف نهائياً (final deletion), not a literal 'burn' (حرق). تم الحذف نهائياً for the resulting burned state."
+      key_patterns: ["*burn*", "*.destroy*", "*permanently_deleted*"]
+    ar:
+      action:
+        target: حذف نهائياً
+        rule_ref: rule.ar-burn-final-deletion
+      state:
+        target: تم الحذف نهائياً
+        rule_ref: rule.ar-burn-final-deletion
+    rule_refs: [rule.register-lock, rule.ar-burn-final-deletion]
+    examples:
+      - id: ex.burn-ar-good#e7a88b0a
+        source: "A burned secret cannot be recovered."
+        target: "تم الحذف نهائياً ولا يمكن استعادة السر."
+        verdict: good
+        note: "State form تم الحذف نهائياً in head position (grounded in live web.secrets.permanently_deleted = تم الحذف نهائياً); MSA declarative status voice."
+        rule_refs: [rule.register-lock, rule.ar-burn-final-deletion]
+      - id: ex.burn-ar-bad#32a14a8e
+        source: "A burned secret cannot be recovered."
+        target: "السر اللي اتحرق مش هترجعه."
+        verdict: bad
+        note: "Egyptian-dialect اللي / اتحرق / مش / هترجعه (literal 'burned' حرق, not حذف نهائياً) — violates rule.ar-register-msa and rule.ar-burn-final-deletion."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Rendered as رابط (الرابط with the definite article); keep DNS/URL acronyms in Latin script."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    ar:
+      noun:
+        target: الرابط
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-ar-good#039b97e8
+        source: "Copy the link to share it securely."
+        target: "انسخ الرابط لمشاركته بأمان."
+        verdict: good
+        note: "Sense target الرابط (definite, with ال-) at a word boundary — bare رابط would NOT match inside الرابط (the ل clitic blocks word_prefix). MSA masculine imperative انسخ. Grounded in live الرابط السري."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.link-ar-bad#e924b748
+        source: "Copy the link to share it securely."
+        target: "انسخي اللينك عشان تشاركيه."
+        verdict: bad
+        note: "Feminine imperatives انسخي/تشاركيه (forbidden non-default address) + dialectal عشان + transliteration اللينك instead of الرابط — violates rule.ar-address-masculine and rule.ar-register-msa."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; تشفير for the verbal-noun / action, مشفّر / مشفر for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    ar:
+      action:
+        target: تشفير
+        rule_ref: rule.terminology-consistency
+      state:
+        target: مشفر
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-ar-good#809cd2fe
+        source: "This message is encrypted with your passphrase."
+        target: "هذه الرسالة مشفرة بعبارة المرور الخاصة بك."
+        verdict: good
+        note: "State مشفر (مشفرة) at a word boundary; MSA declarative voice; عبارة المرور (secret protection). Verbatim-grounded in live web.receipt.this_msg_is_encrypted."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-ar-bad#733c7a4c
+        source: "This message is encrypted with your passphrase."
+        target: "الرسالة دي متشفرة بكلمة المرور بتاعتك."
+        verdict: bad
+        note: "Egyptian-dialect دي / بتاعتك (forbidden register) AND كلمة المرور (account credential) where عبارة المرور is meant — violates rule.ar-register-msa and rule.ar-passphrase-password."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Rendered as البريد الإلكتروني (with the definite article)."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    ar:
+      noun:
+        target: البريد الإلكتروني
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-ar-good#a223699d
+        source: "Enter the email address to send the secret."
+        target: "أدخل البريد الإلكتروني لإرسال السر."
+        verdict: good
+        note: "Sense target البريد الإلكتروني (definite) at a word boundary — the suffixed بريدك would not match the citation form. MSA masculine imperative أدخل. Grounded in live البريد الإلكتروني (×58)."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.email-ar-bad#502767b7
+        source: "Enter the email address to send the secret."
+        target: "أدخلي الإيميل بتاعك عشان تبعتي السر."
+        verdict: bad
+        note: "Feminine imperatives أدخلي/تبعتي (forbidden non-default address) + dialectal بتاعك/عشان + transliteration الإيميل instead of البريد الإلكتروني — violates rule.ar-address-masculine and rule.ar-register-msa."

--- a/locales/ar/register.yaml
+++ b/locales/ar/register.yaml
@@ -1,0 +1,103 @@
+id: register.ar
+source: onetimesecret/locales/guides/for-translators/ar.md
+# Arabic is NOT a T/V (pronoun politeness) split. The two register dimensions the
+# app actually locks are: (a) variety — Modern Standard Arabic (الفصحى / MSA),
+# never a regional dialect; and (b) the grammatical GENDER of 2nd-person address.
+# Both are grounded in the live app content (onetimesecret/locales/content/ar/*.json,
+# 2022 strings) and agree with the prose guide (§3 Cultural Adaptation, §5 Voice
+# and Tone, §"Modern Standard Arabic"): "Use Modern Standard Arabic (MSA) for
+# professional and technical content" and "Use formal second person with
+# appropriate verb forms".
+#
+# GENDER DECISION (AGENT-AUTHORED — needs native AR sign-off). The live UI
+# addresses the user with MASCULINE 2nd-person verb morphology as the default,
+# and uses undiacritized pronoun suffixes that read for either gender. Evidence:
+#   - Imperatives are unambiguously masculine across the corpus: أدخل (×22),
+#     اختر (×19), تأكد (×17), شارك (×36), أرسل (×13), انسخ (×6), سجّل/سجل,
+#     تحقق (×65). The FEMININE imperative would add a ـي suffix (أدخلي, اختاري,
+#     شاركي …) — there are ZERO feminine imperatives anywhere in the 2022 strings.
+#   - Pronoun suffixes use the bare ـك form (بريدك "your email", حسابك "your
+#     account", بياناتك). In undiacritized Arabic ـك is written identically for
+#     masculine (ـكَ) and feminine (ـكِ), so the suffixed forms are effectively
+#     gender-neutral in writing; only the verb morphology disambiguates, and it
+#     is masculine.
+# => gender_policy: masculine_default (with gender-neutral undiacritized suffixes).
+# This is the common convention for Arabic software UIs; a reviewer may instead
+# prefer fully gender-neutral phrasing (nominal style, e.g. "الرجاء إدخال…"
+# instead of "أدخل…") — flagged for sign-off.
+#
+# form: other — MSA-vs-dialect + address-gender is not formal|informal|mixed in
+#               the European T/V sense; it is closest to the ja keigo pilot's
+#               non-binary `register_spec` shape, so we use `other` + register_spec.
+# pronoun:    — short descriptive string; address is carried by masculine verb
+#               morphology, not a standalone pronoun (Arabic usually omits أنتَ).
+#
+# forbidden_tokens — DELIBERATELY EMPTY. The natural register violations are
+# dialectal/colloquial markers (مش، شو، وين، عايز، ليش، هلق، دلوقتي …) and
+# feminine-address verb forms, but NONE of them can be tokenized without false
+# positives, the hard lesson from the ja/es pilots:
+#   - مش (47 raw hits) is only ever a substring of valid MSA words: المشاركة,
+#     مشفر, مشكلة, مشاهدات …; شو (5) inside عشوائي/منشورات; وين (12) inside
+#     تكوين/عناوين; هاد (3) inside شهادة; كدا (1) inside متأكداً. As substrings
+#     they false-positive massively; even as standalone_word they are one
+#     diacritic/space away from valid text and risk future regressions.
+#   - feminine address can only be detected by verb morphology (the ـي suffix),
+#     not by a fixed token, and a ـي suffix collides with countless valid words.
+# So the dialect/gender ban lives in `register_spec.forbidden` + the rules
+# (rule.ar-register-msa, rule.ar-address-masculine) instead of forbidden_tokens.
+# SPEC §2.3 lint scans only `good` examples; all good examples here are MSA and
+# masculine-address and were verified clean.
+#
+# AGENT-AUTHORED; requires native-speaker (AR) sign-off — see PR label.
+form: other
+pronoun: "(2nd-person address omitted as a standalone pronoun; carried by MSA masculine verb morphology — masculine default أنتَ, gender-neutral ـك suffixes)"
+forbidden_tokens: []
+exceptions: []
+rule_ref: rule.ar-register-msa
+# register_spec — the FREE-FORM extension where the real MSA + gender policy
+# lives (the part that cannot be reduced to safe tokens). Mirrors the ja keigo
+# pilot's shape: variety/level, the affirmed target forms, the forbidden dialect
+# forms (not tokenizable), and a voice_by_context map from the prose guide.
+register_spec:
+  variety: MSA
+  variety_native: الفصحى
+  description: "Modern Standard Arabic (الفصحى) throughout product UI and email content; regional dialects are forbidden. Not a pronoun T/V split."
+  gender_policy: masculine_default
+  gender_notes: >-
+    2nd-person address uses masculine verb morphology as the default (أدخل,
+    اختر, تأكد — never the feminine ـي forms أدخلي/اختاري). Pronoun suffixes use
+    the undiacritized ـك form (بريدك, حسابك), which reads for either gender in
+    writing. Confirmed by the live content: masculine imperatives are pervasive,
+    feminine imperatives have zero occurrences across 2022 strings.
+  forbidden:
+    dialect_markers: [مش, شو, وين, عايز, عاوز, بدك, ليش, هلق, دلوقتي, علشان, عشان, بتاع, فين, كده, إيه]
+    feminine_address_forms: ["feminine imperatives (verb + ـي): أدخلي, اختاري, شاركي, أرسلي, تحققي …", "explicit feminine suffix ـكِ"]
+    note: >-
+      These are register violations but are NOT in forbidden_tokens because each
+      is a substring of valid MSA words (مش⊂المشاركة/مشفر, شو⊂عشوائي, وين⊂تكوين,
+      كده/إيه fragments) or detectable only by morphology (feminine ـي suffix);
+      tokenizing them would false-positive on valid content. Enforced by
+      rule.ar-register-msa and rule.ar-address-masculine.
+  voice_by_context:
+    buttons_and_actions: "Masculine imperative verbs (أدخل, أرسل, انسخ) or action verbal-nouns (مشاركة, إرسال, إلغاء) — concise MSA label form."
+    status_and_notifications: "Passive / completed-action MSA forms (تم الإنشاء, تم الحذف نهائياً, مشفّر) — declarative, not colloquial."
+    explanatory_text: "Declarative MSA sentences, formal and professional yet clear."
+  rtl_notes: >-
+    Arabic is RTL but the resolver matches on character boundaries (isalnum), and
+    Arabic words are space-separated, so word_prefix works. The clitic article
+    ال and prepositional clitics (و، ب، ل، ك) attach as prefixes with NO space,
+    so a bare citation form (سر) does NOT match inside السر under word_prefix
+    (ل is a word char). Glossary sense targets are chosen as the form that begins
+    a word in the good example (e.g. الرابط / البريد الإلكتروني with ال-, or سر
+    indefinite at a word boundary).
+  notes: >-
+    MSA + masculine-default address is the locked register. Dialect and
+    feminine-address forms are forbidden via the rules + this spec rather than
+    forbidden_tokens, because none can be safely matched as a token. The
+    masculine-default decision is AGENT-AUTHORED and the main item for AR
+    native-speaker sign-off.
+# baseline_ref: baselines.ar is intentionally omitted — no `baselines.ar` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
+# carry `baseline_ref: baselines.ar`.

--- a/locales/ar/register.yaml
+++ b/locales/ar/register.yaml
@@ -96,8 +96,4 @@ register_spec:
     forbidden_tokens, because none can be safely matched as a token. The
     masculine-default decision is AGENT-AUTHORED and the main item for AR
     native-speaker sign-off.
-# baseline_ref: baselines.ar is intentionally omitted — no `baselines.ar` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
-# carry `baseline_ref: baselines.ar`.
+baseline_ref: baselines.ar

--- a/locales/ar/rules.yaml
+++ b/locales/ar/rules.yaml
@@ -44,5 +44,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ar
 glossary_ref: glossary.ar
-# a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.ar

--- a/locales/ar/rules.yaml
+++ b/locales/ar/rules.yaml
@@ -1,0 +1,48 @@
+id: rules.ar
+source: onetimesecret/locales/guides/for-translators/ar.md
+inherits: base
+merge_strategy: append
+# Arabic locale layer, inheriting base directly (standalone language, no regional
+# parent). Carries the Arabic-wide conventions transcribed from the translator
+# guide (onetimesecret/locales/guides/for-translators/ar.md) and grounded in the
+# live ar content: the MSA (الفصحى) register lock, the masculine-default 2nd-person
+# address, the عبارة المرور (passphrase) vs كلمة المرور (password) distinction,
+# the burn -> حذف نهائياً terminology choice, and the سر core-concept term.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live ar content;
+# requires native-speaker (AR) sign-off before merge — see PR label.
+rules:
+  - id: rule.ar-register-msa
+    modality: MUST
+    statement: "Arabic content uses Modern Standard Arabic (الفصحى / MSA) throughout product UI and email content; regional dialects are forbidden. Dialectal markers (e.g. مش، شو، وين، عايز، ليش، دلوقتي، علشان) must not appear as colloquial vocabulary. They are not register forbidden_tokens because each is a substring of valid MSA words (مش⊂المشاركة/مشفر, شو⊂عشوائي, وين⊂تكوين) and cannot be tokenized without false positives."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ar-address-masculine
+    modality: MUST
+    statement: "2nd-person direct address uses masculine verb morphology as the default (أدخل، اختر، تأكد، شارك), consistent with the live UI; the feminine imperative forms (verb + ـي: أدخلي، اختاري، شاركي) are not used. Pronoun suffixes use the undiacritized ـك form (بريدك، حسابك), which reads for either gender. AGENT-AUTHORED default; a reviewer may instead choose fully gender-neutral nominal phrasing."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ar-passphrase-password
+    modality: MUST
+    statement: "Keep كلمة المرور (account login / authentication credential) distinct from عبارة المرور (protection of an individual secret); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ar-burn-final-deletion
+    modality: MUST
+    statement: "Translate burn / burned as حذف نهائياً (final deletion), not a literal 'burn' (حرق), per the agreed Arabic terminology; the burned status is تم الحذف نهائياً. Do not vary across strings."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ar-secret-sirr
+    modality: MUST
+    statement: "Render the core product concept 'secret' (the noun) consistently as سر; use the adjective sense سري / آمن for 'secret/secure' as a descriptor. Do not vary the core term across strings."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.ar-acronyms-latin
+    modality: SHOULD
+    statement: "Keep DNS, URL, CNAME and similar technical acronyms in Latin script as universally used; surrounding Arabic grammar adapts around them (per guide §4 Technical Accuracy)."
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.ar
+glossary_ref: glossary.ar
+# baseline_ref: baselines.ar intentionally omitted (no baselines.ar entry yet);
+# a reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/ar/rules.yaml
+++ b/locales/ar/rules.yaml
@@ -44,5 +44,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ar
 glossary_ref: glossary.ar
-# baseline_ref: baselines.ar intentionally omitted (no baselines.ar entry yet);
 # a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.ar

--- a/locales/bg/glossary.yaml
+++ b/locales/bg/glossary.yaml
@@ -1,0 +1,208 @@
+id: glossary.bg
+source: onetimesecret/locales/guides/for-translators/bg.md
+# Sense-split of the core domain terminology from the Bulgarian translator guide
+# (## Глосар terminology tables, ## Специални съображения, and the Bulgarian
+# Translation Notes), grounded against the live app content in
+# onetimesecret/locales/content/bg/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (BG) sign-off before merge — see PR
+# label. Each `good` example uses the locked FORMAL "Вие" register (ваш/вашия/
+# вашата possessives, 2nd-plural verb forms) and contains its term's sense
+# target; each `bad` example demonstrates a forbidden form — the informal "ти"
+# register (твоя/твоята possessives, теб, можеш) — or the wrong term. Bulgarian
+# nouns inflect for the definite article (тайна → тайната) but have no case on
+# nouns; sense targets use the indefinite citation form and good examples keep it
+# in head position so the word_prefix sense-target check holds.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Use тайна, never the loanword секрет; substitute съобщение (message) only when the source means a message."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    bg:
+      noun:
+        target: тайна
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-secret-created-good#c6051398
+        source: "Your secret has been created successfully."
+        target: "Вашата тайна е създадена успешно."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal possessive 'Вашата' plus passive/declarative voice for a status message; uses тайна (not секрет)."
+      - id: ex.bg-secret-informal-bad#bd906d47
+        source: "Your secret has been created successfully."
+        target: "Твоята тайна е създадена успешно."
+        verdict: bad
+        note: "Informal possessive 'Твоята' (informal 'your') — the forbidden informal register; formal would be 'Вашата'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect/view-a-secret contexts signal this sense. The guide's single most critical distinction."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    bg:
+      noun:
+        target: ключова фраза
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-passphrase-good#55aacc0b
+        source: "This message is encrypted with your passphrase."
+        target: "Това съобщение е криптирано с вашата ключова фраза."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Live-content phrasing; formal possessive 'вашата' and the term ключова фраза (not парола)."
+      - id: ex.bg-passphrase-bad#cc9cda26
+        source: "This message is encrypted with your passphrase."
+        target: "Това съобщение е криптирано с твоята парола."
+        verdict: bad
+        note: "Uses 'парола' (account password) where 'ключова фраза' is meant — violates rule.bg-passphrase-password; also informal 'твоята'."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's passphrase). Sign-in, account, and registration contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    bg:
+      noun:
+        target: парола
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-password-good#8b52a40e
+        source: "Enter your password to sign in."
+        target: "Въведете вашата парола, за да влезете."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2nd-plural imperative 'Въведете' plus formal possessive 'вашата'."
+      - id: ex.bg-password-bad#cdaff119
+        source: "Enter your password to sign in."
+        target: "Въведи твоята парола, за да влезеш."
+        verdict: bad
+        note: "Informal 2nd-singular imperative 'Въведи' plus informal possessive 'твоята' — the forbidden informal register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of destroying a secret before it is viewed. Verb/button form изтрий; state изтрит-а-о; add перманентно for irreversibility. The guide notes 'burned' may be изгорен but UI text clarifies permanent deletion."
+      key_patterns: ["*burn*", "*.destroy*", "*.delete*"]
+    bg:
+      verb:
+        target: изтрий
+        rule_ref: rule.terminology-consistency
+      state:
+        target: изтрита
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-burn-good#ea986f21
+        source: "Burn this secret before it is read."
+        target: "Изтрийте тази тайна, преди да бъде прочетена."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2nd-plural imperative 'Изтрийте' (head form изтрий); names its object (тази тайна) per rule.destructive-action-object."
+      - id: ex.bg-burn-bad#9c05c3f5
+        source: "Burn this secret before it is read."
+        target: "Можеш да изтриеш твоята тайна, преди да бъде прочетена."
+        verdict: bad
+        note: "Informal 2nd-singular 'Можеш ... изтриеш' plus informal possessive 'твоята' — the forbidden informal register."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. връзка is the standard Bulgarian term across the app."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    bg:
+      noun:
+        target: връзка
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-link-good#1ef8fbbd
+        source: "Copy the secret link to share it."
+        target: "Копирайте тайната връзка, за да я споделите."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2nd-plural imperatives 'Копирайте'/'споделите'; uses връзка."
+      - id: ex.bg-link-bad#2757d4ea
+        source: "Copy the secret link to share it."
+        target: "Копирай твоята тайна връзка, за да я споделиш."
+        verdict: bad
+        note: "Informal 2nd-singular 'споделиш' plus informal possessive 'твоята' — the forbidden informal register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; live content uses the криптиран family — криптиране (verb/noun), криптиран-о-а (encrypted state)."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    bg:
+      verb:
+        target: криптиране
+        rule_ref: rule.terminology-consistency
+      state:
+        target: криптирано
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-encrypt-good#d508bd58
+        source: "This message is encrypted with your passphrase."
+        target: "Това съобщение е криптирано с вашата ключова фраза."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Live-content phrasing; encrypted state криптирано plus formal possessive 'вашата' and the term ключова фраза."
+      - id: ex.bg-encrypt-bad#57e988e1
+        source: "Your secret is encrypted with your passphrase."
+        target: "Твоята тайна е криптирана с твоята парола."
+        verdict: bad
+        note: "Informal possessive 'Твоята'/'твоята' plus 'парола' where ключова фраза is meant — forbidden informal register and term confusion."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. имейл is the standard live form."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    bg:
+      noun:
+        target: имейл
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-email-good#e42808a9
+        source: "Enter your email address."
+        target: "Въведете вашия имейл адрес."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2nd-plural imperative 'Въведете' plus formal possessive 'вашия'."
+      - id: ex.bg-email-bad#6b702dc7
+        source: "Enter your email address."
+        target: "Въведи твоя имейл адрес."
+        verdict: bad
+        note: "Informal 2nd-singular imperative 'Въведи' plus informal possessive 'твоя' — the forbidden informal register."
+  - id: term.view#7ef567df
+    key: view
+    en: view
+    disambiguation:
+      heuristic: "The action of accessing/revealing a secret (view/reveal). преглед (noun) / прегледам (verb) is the standard live form."
+      key_patterns: ["*view*", "*.reveal*", "*.show*"]
+    bg:
+      noun:
+        target: преглед
+        rule_ref: rule.terminology-consistency
+      verb:
+        target: прегледайте
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.bg-view-good#3c1c5e01
+        source: "View this secret now."
+        target: "Прегледайте тази тайна сега."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2nd-plural imperative 'Прегледайте' (head form преглед-)."
+      - id: ex.bg-view-bad#ec589de3
+        source: "View this secret now."
+        target: "Прегледай твоята тайна сега."
+        verdict: bad
+        note: "Informal 2nd-singular imperative 'Прегледай' plus informal possessive 'твоята' — the forbidden informal register."

--- a/locales/bg/register.yaml
+++ b/locales/bg/register.yaml
@@ -65,7 +65,4 @@ forbidden_tokens:
   - { token: искаш,  context: standalone_word, severity: error, note: "informal 2nd-singular verb 'you want' — formal is искате" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# `baselines.bg` entry exists yet, this backfill must not edit baselines.yaml,
-# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
-# central baselines.bg pin at commit time, after which this file can carry it.
+baseline_ref: baselines.bg

--- a/locales/bg/register.yaml
+++ b/locales/bg/register.yaml
@@ -1,0 +1,71 @@
+id: register.bg
+source: onetimesecret/locales/guides/for-translators/bg.md
+# Bulgarian is locked to the FORMAL "Вие" register (2nd-person plural polite
+# address). Grounded in the live app content
+# (onetimesecret/locales/content/bg/*.json), direct address is formal throughout:
+#   - formal possessive "ваш" family — вашия (30), вашата (22), вашият (14),
+#     вашето (7), вашите (7), ваши (2) ≈ 82 occurrences (e.g. "за вашия акаунт",
+#     "Вашето защитено съобщение е доставено.", "перфектния план за вашата
+#     организация");
+#   - formal address pronoun — ви (95), вие (5), вас (6) ≈ 106 occurrences;
+#   - formal 2nd-PLURAL verb forms — можете (24), имате (17), изберете (16),
+#     въведете (27), натиснете (11), споделете (8), създайте (9).
+#   The informal "твой" possessive family appears ZERO times (твой/твоя/твое/
+#   твоят/твоята/твоето/твоите/твои all 0, standalone AND substring), the informal
+#   oblique pronoun теб/тебе is absent, and the informal 2nd-SINGULAR verb forms
+#   можеш/имаш/искаш are all 0. The prose guide concurs indirectly: §3 "Предпочитайте
+#   яснотата пред неформалния език" (prefer clarity over informal language) and §5
+#   sets a "professional, but direct" tone.
+#
+# Because the locked register is formal, the FORBIDDEN register is the informal
+# one: the informal-singular possessives (твой family) and the informal oblique
+# address pronoun (теб/тебе), plus the unambiguous informal 2nd-singular verb
+# auxiliaries (можеш/имаш/искаш). These are matched as standalone_word (NOT
+# word_prefix/substring): every token is a whole Cyrillic word with zero
+# substring collisions in the corpus (verified: substring count 0 for the твой
+# family and теб/тебе), so standalone_word is both safe and tight. Matching is
+# casefolded, so each lowercase token also catches its sentence-initial
+# capitalized form (Твоя, Твоята, …).
+#
+# Deliberately NOT forbidden (judgment calls for the native reviewer):
+#   - "ти" — the informal 2nd-sg subject pronoun and the name of the locked-OUT
+#     register, BUT it is also the high-frequency dative clitic "to you" and a
+#     common verb/adjective ending; it occurs 0× standalone yet 284× as a
+#     substring, so forbidding even standalone_word risks confusion. The твой
+#     possessives + теб/тебе are the unambiguous standalone markers that carry
+#     the lock.
+#   - "те" (3rd-pl pronoun "they/them" + definite-article suffix, 1114× as
+#     substring) and "си" (reflexive/dative clitic "oneself/one's own", 95×
+#     standalone) — both are legitimate, register-neutral forms, not informal
+#     direct address, so listing them would flag valid prose.
+#   - the singular imperatives Създай / Сподели / Изтрий / Копирай — these LOOK
+#     like the informal-singular imperative but are the STANDARD Bulgarian form
+#     for button/action labels even in a formal-Вие interface (live: web.COMMON.
+#     button_create_secret "Създай тайна връзка", web.LABELS.share "Сподели",
+#     web.COMMON.burn "Изтрий"). Forbidding them would break every button, so the
+#     lock targets possessives/pronouns/auxiliaries, not imperatives.
+#
+# AGENT-AUTHORED; requires native-speaker (BG) sign-off — see PR label.
+form: formal
+pronoun: Вие
+possessive: [ваш, ваша, ваше, ваши, вашия, вашият, вашата, вашето, вашите, вашему]
+forbidden_tokens:
+  - { token: твой,   context: standalone_word, severity: error, note: "informal possessive 'your' (masc. nom.) — the register bg does NOT use; formal is ваш/вашия" }
+  - { token: твоя,   context: standalone_word, severity: error, note: "informal possessive 'your' (fem. / masc. obl.) — formal is вашата/вашия" }
+  - { token: твое,   context: standalone_word, severity: error, note: "informal possessive 'your' (neut.) — formal is вашето" }
+  - { token: твоят,  context: standalone_word, severity: error, note: "informal possessive 'your' (masc. def.) — formal is вашият" }
+  - { token: твоята, context: standalone_word, severity: error, note: "informal possessive 'your' (fem. def.) — formal is вашата" }
+  - { token: твоето, context: standalone_word, severity: error, note: "informal possessive 'your' (neut. def.) — formal is вашето" }
+  - { token: твоите, context: standalone_word, severity: error, note: "informal possessive 'your' (plural def.) — formal is вашите" }
+  - { token: твои,   context: standalone_word, severity: error, note: "informal possessive 'your' (plural indef.) — formal is ваши" }
+  - { token: теб,    context: standalone_word, severity: error, note: "informal oblique address pronoun 'you' (acc./after prep.) — formal is вас/Вас" }
+  - { token: тебе,   context: standalone_word, severity: error, note: "informal oblique address pronoun 'you' (full form) — formal is вас/Вас" }
+  - { token: можеш,  context: standalone_word, severity: error, note: "informal 2nd-singular verb 'you can' — formal is можете" }
+  - { token: имаш,   context: standalone_word, severity: error, note: "informal 2nd-singular verb 'you have' — formal is имате" }
+  - { token: искаш,  context: standalone_word, severity: error, note: "informal 2nd-singular verb 'you want' — formal is искате" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# `baselines.bg` entry exists yet, this backfill must not edit baselines.yaml,
+# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
+# central baselines.bg pin at commit time, after which this file can carry it.

--- a/locales/bg/rules.yaml
+++ b/locales/bg/rules.yaml
@@ -58,7 +58,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.bg
 glossary_ref: glossary.bg
-# baseline_ref intentionally omitted: no baselines.bg entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it
-# is left out until a reviewer adds the central baselines.bg pin.
+baseline_ref: baselines.bg

--- a/locales/bg/rules.yaml
+++ b/locales/bg/rules.yaml
@@ -1,0 +1,64 @@
+id: rules.bg
+source: onetimesecret/locales/guides/for-translators/bg.md
+inherits: base
+merge_strategy: append
+# Bulgarian locale layer. bg is a standalone shipping language (no family
+# parent), so it inherits `base` directly — mirroring locales/pl/rules.yaml and
+# locales/cs/rules.yaml (the Slavic pilots) but with the OPPOSITE register
+# decision: Bulgarian is locked to the FORMAL "Вие" register. That choice is
+# grounded in the live app content (onetimesecret/locales/content/bg/*.json),
+# which uses formal 2nd-person-plural address throughout — the ваш possessive
+# family (~82 occurrences), the ви/вие/вас pronoun (~106), and 2nd-plural verb
+# forms (можете/имате/изберете/въведете) — and contains ZERO informal твой
+# possessives and zero informal 2nd-singular verbs (можеш/имаш). See
+# register.bg for the full token-by-token evidence. The prose guide concurs
+# indirectly (§3 "prefer clarity over informal language"; §5 professional tone).
+#
+# The "парола" (account password) vs "ключова фраза" (secret passphrase)
+# distinction is the single most critical terminology rule in the guide
+# (Bulgarian Translation Notes §1; Summary "Terminology Distinction"). The guide
+# also fixes "тайна" over the loanword "секрет" for the core secret concept
+# (Special Considerations: The Term "Secret"; live content uses секрет 0×).
+#
+# Each rule below carries a `rule_ref` to the universal base rule it specialises;
+# no new base ids are introduced.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (BG) sign-off before merge — see PR label.
+rules:
+  - id: rule.bg-register-formal
+    modality: MUST
+    statement: Bulgarian content uses the formal "Вие" register (Вие / Ви / Вас with the ваш / вашия / вашата possessive family) and 2nd-person-PLURAL verb forms (можете, имате, въведете, изберете) for direct address throughout product UI and email content; the informal "ти" register (твой possessives, теб/тебе, можеш/имаш) is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.bg-passphrase-password
+    modality: MUST
+    statement: Keep парола (account login credential — sign-in, registration, account password operations) distinct from ключова фраза (the passphrase protecting an individual secret — secret creation/viewing, protection mechanism); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.bg-secret-tayna-not-sekret
+    modality: MUST
+    statement: Translate the core "secret" concept as тайна consistently; do not use the loanword секрет, and do not substitute съобщение (message) unless the source specifically refers to a message.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.bg-burn-deletion-clarity
+    modality: MUST
+    statement: Render burn / burned with the изтрий (verb) / изтрит-а-о (state) deletion family used in the live UI, and add перманентно (permanently) where the source stresses irreversibility; do not vary terminology for the same destructive action across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.bg-pluralization
+    modality: MUST
+    statement: Express countable strings (минута/минути, ден/дни, тайна/тайни) with vue-i18n pipe syntax so both Bulgarian number forms are expressible; never collapse to a single form.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.bg-imperative-buttons
+    modality: SHOULD
+    statement: Use the short singular imperative for button and action labels (Създай, Сподели, Изтрий, Копирай) — the standard Bulgarian UI convention even under the formal register — and passive/declarative voice for status and system messages (Тайната е създадена успешно).
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.bg
+glossary_ref: glossary.bg
+# baseline_ref intentionally omitted: no baselines.bg entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it
+# is left out until a reviewer adds the central baselines.bg pin.

--- a/locales/ca_ES/glossary.yaml
+++ b/locales/ca_ES/glossary.yaml
@@ -1,0 +1,201 @@
+id: glossary.ca_ES
+source: onetimesecret/locales/guides/for-translators/ca_ES.md
+# Sense-split of the core domain terminology from the Catalan translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/ca_ES.md:
+# Terminologia bàsica, Termes relacionats amb el compte, Funcions de seguretat),
+# grounded against the live app content in onetimesecret/locales/content/ca_ES/.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (CA)
+# sign-off before merge — see PR label. Each `good` example uses the informal tu
+# register and contains the term's target; each `bad` example demonstrates a
+# forbidden form (the formal vostè register, or the wrong/forbidden term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as secret."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    ca_ES:
+      noun:
+        target: secret
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created."
+        target: "El teu secret s'ha creat."
+        verdict: good
+        note: "Informal possessive 'El teu' per the tu register; declarative voice for status; uses the noun 'secret'."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created."
+        target: "El secret de vostè s'ha creat."
+        verdict: bad
+        note: "Formal address 'de vostè' used for direct address — the forbidden formal vostè register."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense of secret/secure — protection. Render as segur (m.) / segura (f.); the guide also allows 'secret' as an adjective."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    ca_ES:
+      adjective:
+        target: segur
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adj-good#10b14bad
+        source: "Share secure links with anyone."
+        target: "Comparteix enllaços segurs amb qualsevol persona."
+        verdict: good
+        note: "Adjective sense 'segurs' (word_prefix of 'segur'); informal imperative 'Comparteix'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.secret-adj-bad#ccab3c56
+        source: "Share secure links with anyone."
+        target: "Comparteixi enllaços segurs amb qualsevol persona."
+        verdict: bad
+        note: "Formal imperative 'Comparteixi' (vostè register) instead of informal 'Comparteix' — the forbidden formal register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    ca_ES:
+      noun:
+        target: frase de contrasenya
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Introdueix la frase de contrasenya per veure aquest secret."
+        verdict: good
+        note: "Informal imperative 'Introdueix'; uses 'frase de contrasenya', not 'contrasenya'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Introdueix la contrasenya per veure aquest secret."
+        verdict: bad
+        note: "Uses 'contrasenya' (account credential) where 'frase de contrasenya' (secret protection) is meant — violates rule.ca_ES-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    ca_ES:
+      noun:
+        target: contrasenya
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Introdueix la teva contrasenya per iniciar sessió."
+        verdict: good
+        note: "Informal imperative 'Introdueix' plus informal possessive 'la teva'; 'iniciar sessió' per the UI glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Introdueixi la contrasenya de vostè per iniciar sessió."
+        verdict: bad
+        note: "Formal imperative 'Introdueixi' plus formal address 'de vostè' — the forbidden vostè register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb 'destruir' for the action label; past participle 'destruït' for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    ca_ES:
+      verb:
+        target: destruir
+        rule_ref: rule.terminology-consistency
+      state:
+        target: destruït
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Destruir aquest secret abans no es llegeixi."
+        verdict: good
+        note: "Infinitive 'Destruir' for the button label, per the guide's burn -> destruir choice; uses the noun 'secret'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Cremar aquest secret abans no es llegeixi."
+        verdict: bad
+        note: "Uses 'Cremar' instead of the glossary term 'destruir' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Render as enllaç (note geminated/accented forms enllaços)."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    ca_ES:
+      noun:
+        target: enllaç
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy your secret link to share it."
+        target: "Copia el teu enllaç per compartir-lo."
+        verdict: good
+        note: "Informal imperative 'Copia' plus informal possessive 'el teu'; uses 'enllaç' per the glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy your secret link to share it."
+        target: "Copiï l'enllaç de vostè per compartir-lo."
+        verdict: bad
+        note: "Formal imperative 'Copiï' plus formal address 'de vostè' (vostè register) instead of informal 'Copia' + 'el teu' — the forbidden formal register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'xifrar' (always with x, never 'cifrar'), past participle 'xifrat' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    ca_ES:
+      verb:
+        target: xifrar
+        rule_ref: rule.terminology-consistency
+      state:
+        target: xifrat
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Aquest missatge està xifrat amb la teva frase de contrasenya."
+        verdict: good
+        note: "Verbatim from live content; state 'xifrat' (with x), informal possessive 'la teva'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Aquest missatge està cifrat amb la frase de contrasenya de vostè."
+        verdict: bad
+        note: "Uses 'cifrat' (Spanish spelling) instead of the standard Catalan 'xifrat', plus formal address 'de vostè' (vostè register)."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Render as correu electrònic."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    ca_ES:
+      noun:
+        target: correu electrònic
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Introdueix la teva adreça de correu electrònic."
+        verdict: good
+        note: "Grounded in live content; informal imperative 'Introdueix' plus informal possessive 'la teva'; uses 'correu electrònic'."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Introdueixi l'adreça de correu electrònic de vostè."
+        verdict: bad
+        note: "Formal imperative 'Introdueixi' plus formal address 'de vostè' — the forbidden vostè register."

--- a/locales/ca_ES/register.yaml
+++ b/locales/ca_ES/register.yaml
@@ -1,0 +1,38 @@
+id: register.ca_ES
+source: onetimesecret/locales/guides/for-translators/ca_ES.md
+# Catalan is locked to the INFORMAL tu register. Grounded in the live app content
+# (onetimesecret/locales/content/ca_ES/*.json): direct address consistently uses
+# the informal tu forms — informal possessives el teu / la teva / els teus /
+# les teves (e.g. "Introdueix la teva contrasenya per confirmar", "El teu missatge
+# s'autodestruirà després de ser visualitzat", "Comprova el teu correu electrònic")
+# and informal imperatives / clitics (Introdueix, Comprova, Assegura't, torna-ho,
+# destrueix-los, t'enviarem, Pots, Estàs). Zero standalone vostè / vostès / vós
+# (the formal address pronouns) appear anywhere in the live content. The prose
+# guide agrees: "Informal second person (tu) for friendly tone" (Voice and Tone /
+# Key Points). So the FORBIDDEN register is the formal vostè register; the
+# forbidden tokens are the formal address pronouns vostè / vostès (and vós).
+#
+# Deliberately NOT forbidden: the possessive seu / seva / seus / seves. In Catalan
+# these are also the ordinary 3rd-person possessives and appear legitimately in the
+# live content referring to third parties, not as a formal direct address — e.g.
+# "El remitent rebrà una notificació que el seu secret s'ha visualitzat", "la seva
+# pròpia infraestructura", "els membres de l'organització i els seus rols".
+# Forbidding seu/seva would flag valid 3rd-person prose, so they are left out (cf.
+# the prompt's warning, and the es agent leaving su/sus free). vostè/vostès/vós
+# have no such ambiguity as standalone words.
+#
+# AGENT-AUTHORED; requires native-speaker (CA) sign-off — see PR label.
+form: informal
+pronoun: tu
+possessive: [teu, teva, teus, teves]
+forbidden_tokens:
+  - { token: vostè,   context: standalone_word, severity: error, note: "formal address pronoun (singular) — the register ca_ES does NOT use" }
+  - { token: vostès,  context: standalone_word, severity: error, note: "formal address pronoun (plural) — the register ca_ES does NOT use" }
+  - { token: vós,     context: standalone_word, severity: error, note: "archaic/formal address pronoun — the register ca_ES does NOT use" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.ca_ES is intentionally omitted — no `baselines.ca_ES`
+# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
+# The pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the `fr`/`de_AT` baselines entries), after which this and rules.yaml
+# can carry `baseline_ref: baselines.ca_ES`.

--- a/locales/ca_ES/register.yaml
+++ b/locales/ca_ES/register.yaml
@@ -31,8 +31,4 @@ forbidden_tokens:
   - { token: vós,     context: standalone_word, severity: error, note: "archaic/formal address pronoun — the register ca_ES does NOT use" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.ca_ES is intentionally omitted — no `baselines.ca_ES`
-# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
-# The pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the `fr`/`de_AT` baselines entries), after which this and rules.yaml
-# can carry `baseline_ref: baselines.ca_ES`.
+baseline_ref: baselines.ca_ES

--- a/locales/ca_ES/rules.yaml
+++ b/locales/ca_ES/rules.yaml
@@ -1,0 +1,39 @@
+id: rules.ca_ES
+source: onetimesecret/locales/guides/for-translators/ca_ES.md
+inherits: base
+merge_strategy: append
+# Catalan locale layer. ca_ES is a standalone shipping language, so it inherits
+# `base` directly (no family parent). Carries the Catalan conventions transcribed
+# from onetimesecret/locales/guides/for-translators/ca_ES.md: the informal tu
+# register lock, the contrasenya / frase de contrasenya distinction, the
+# burn -> destruir terminology choice, and the standard-Catalan encryption
+# spelling xifrar (with x, never cifrar).
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live ca_ES content;
+# requires native-speaker (CA) sign-off before merge — see PR label.
+rules:
+  - id: rule.ca_ES-register-informal
+    modality: MUST
+    statement: Catalan content uses the informal tu register (tu / el teu / la teva / els teus / les teves) throughout product UI and email content; the formal vostè register (vostè / vostès / vós) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ca_ES-passphrase-password
+    modality: MUST
+    statement: Keep contrasenya (account login / authentication credential) distinct from frase de contrasenya (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ca_ES-burn-destruir
+    modality: MUST
+    statement: Translate burn / burned consistently as destruir (verb) and destruït (state / past participle), per the agreed Catalan terminology; do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ca_ES-encrypt-xifrar
+    modality: MUST
+    statement: Translate encrypt / encrypted with the standard Catalan spelling xifrar (verb) and xifrat (state), always with x; never use the Spanish form cifrar / cifrado.
+    severity: error
+    rule_ref: rule.terminology-consistency
+register_ref: register.ca_ES
+glossary_ref: glossary.ca_ES
+# baseline_ref: baselines.ca_ES is intentionally omitted until a human reviewer
+# adds the `baselines.ca_ES` entry to baselines.yaml centrally — a dangling
+# reference fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/ca_ES/rules.yaml
+++ b/locales/ca_ES/rules.yaml
@@ -34,6 +34,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.ca_ES
 glossary_ref: glossary.ca_ES
-# baseline_ref: baselines.ca_ES is intentionally omitted until a human reviewer
-# adds the `baselines.ca_ES` entry to baselines.yaml centrally — a dangling
-# reference fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.ca_ES

--- a/locales/cs/glossary.yaml
+++ b/locales/cs/glossary.yaml
@@ -1,0 +1,174 @@
+id: glossary.cs
+source: onetimesecret/locales/guides/for-translators/cs.md
+# Sense-split of the core domain terminology from the Czech translator guide's
+# terminology tables (Základní terminologie, Special Considerations), grounded
+# against the live app content in onetimesecret/locales/content/cs/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (CS)
+# sign-off before merge — see PR label. Each `good` example uses the locked
+# informal "ty" register and contains its term's sense target; each `bad`
+# example demonstrates a forbidden form — the formal/plural register (váš / vám /
+# vás family). Czech nouns decline across 7 cases and verbs carry aspect, so
+# sense targets use a sensible citation form (nominative noun / a participle stem
+# for state senses) and good examples keep that form so the word_prefix
+# sense-target check holds.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application (neuter gender). Never substitute zpráva (message) for this sense."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    cs:
+      noun:
+        target: tajemství
+        rule_ref: rule.cs-secret-not-message
+    rule_refs: [rule.cs-register-informal, rule.cs-secret-not-message]
+    examples:
+      - id: ex.cs-secret-good#8934f759
+        source: "Your secret has been created successfully."
+        target: "Tvoje tajemství bylo úspěšně vytvořeno."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-secret-bad#b2dacf1e
+        source: "Your secret has been created successfully."
+        target: "Vaše tajemství bylo úspěšně vytvořeno."
+        verdict: bad
+        note: "Formal/plural possessive 'Vaše' (formal 'your') — the forbidden formal register; informal would be 'Tvoje'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (feminine: fráze), distinct from the account login heslo and from a WebAuthn passkey (přístupový klíč). Protect/compose-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    cs:
+      noun:
+        target: přístupová fráze
+        rule_ref: rule.cs-passphrase-password
+    rule_refs: [rule.cs-register-informal, rule.cs-passphrase-password]
+    examples:
+      - id: ex.cs-passphrase-good#b85c7e37
+        source: "A passphrase is required to view this secret."
+        target: "Přístupová fráze je vyžadována pro zobrazení tohoto tajemství."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-passphrase-bad#5a0d845f
+        source: "A passphrase is required to view this secret."
+        target: "Vaše heslo je vyžadováno pro zobrazení tohoto tajemství."
+        verdict: bad
+        note: "Uses 'heslo' (account password) where 'přístupová fráze' is meant — violates rule.cs-passphrase-password; also formal 'Vaše'."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (neuter: heslo), distinct from a secret's přístupová fráze. Sign-in, account, and reset-password contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    cs:
+      noun:
+        target: heslo
+        rule_ref: rule.cs-passphrase-password
+    rule_refs: [rule.cs-register-informal, rule.cs-passphrase-password]
+    examples:
+      - id: ex.cs-password-good#cf3d9571
+        source: "Enter your password to confirm."
+        target: "Pro potvrzení zadej své heslo."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-password-bad#22813f4b
+        source: "Enter your password to confirm."
+        target: "Pro potvrzení zadejte vaše heslo."
+        verdict: bad
+        note: "Formal plural imperative 'zadejte' plus formal possessive 'vaše' — the forbidden formal register; informal is the singular 'zadej ... své'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently destroying a secret. Verb form 'trvale smazat' (perfective) for the action; 'trvale smazáno/smazán' for the resulting state. Do not use a literal 'spálit'."
+      key_patterns: ["*burn*", "*.destroy*"]
+    cs:
+      verb:
+        target: trvale smazat
+        rule_ref: rule.cs-burn-trvale-smazat
+      state:
+        target: trvale smazáno
+        rule_ref: rule.cs-burn-trvale-smazat
+    rule_refs: [rule.cs-register-informal, rule.cs-burn-trvale-smazat]
+    examples:
+      - id: ex.cs-burn-good#f26982cb
+        source: "After it is viewed, this secret will be permanently burned."
+        target: "Toto tajemství bude po zobrazení trvale smazáno."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-burn-bad#2c40cacc
+        source: "Are you sure you want to burn this secret?"
+        target: "Jste si jisti, že chcete spálit toto tajemství?"
+        verdict: bad
+        note: "Formal 2nd-pl 'Jste/chcete' plus literal 'spálit' — violates the register lock and rule.cs-burn-trvale-smazat; informal is 'Jsi si jistý/á, že chceš trvale smazat ...'."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides one-time access to a secret (masculine: odkaz). Share/copy/reveal contexts signal this sense."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    cs:
+      noun:
+        target: odkaz
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.cs-register-informal, rule.terminology-consistency]
+    examples:
+      - id: ex.cs-link-good#05120873
+        source: "Copy the secret link and share it separately."
+        target: "Zkopíruj tajný odkaz a sdílej ho odděleně."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-link-bad#e5456c40
+        source: "Copy the secret link and share it separately."
+        target: "Zkopírujte váš tajný odkaz a sdílejte ho odděleně."
+        verdict: bad
+        note: "Formal plural imperatives 'Zkopírujte/sdílejte' plus formal possessive 'váš' — the forbidden formal register; informal is 'Zkopíruj ... sdílej'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. Verb 'šifrovat'; participle stem 'šifrován' for the encrypted state (šifrováno / šifrována / šifrované, with gender agreement)."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    cs:
+      verb:
+        target: šifrovat
+        rule_ref: rule.terminology-consistency
+      state:
+        target: šifrován
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.cs-register-informal, rule.terminology-consistency]
+    examples:
+      - id: ex.cs-encrypt-good#432c330c
+        source: "This message is encrypted with your passphrase."
+        target: "Tato zpráva je šifrována tvojí přístupovou frází."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-encrypt-bad#1cd2cd00
+        source: "This message is encrypted with your passphrase."
+        target: "Tato zpráva je šifrována vaší přístupovou frází."
+        verdict: bad
+        note: "Formal/plural possessive 'vaší' (formal 'your') — the forbidden formal register; informal would be 'tvojí'."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail (account identifier and notification contexts). Kept hyphenated as 'e-mail' in Czech, per the live content and guide."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    cs:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.cs-register-informal, rule.terminology-consistency]
+    examples:
+      - id: ex.cs-email-good#8107ddbe
+        source: "Enter your email and we'll send you a link."
+        target: "Zadej svůj e-mail, ať ti pošleme odkaz."
+        verdict: good
+        rule_refs: [rule.cs-register-informal]
+      - id: ex.cs-email-bad#b3bdd885
+        source: "Enter your email and we'll send you a link."
+        target: "Zadejte váš e-mail a my vám pošleme odkaz."
+        verdict: bad
+        note: "Formal plural imperative 'Zadejte' plus formal pronoun 'vám' and possessive 'váš' — the forbidden formal register; informal is 'Zadej svůj ... ti pošleme'."

--- a/locales/cs/register.yaml
+++ b/locales/cs/register.yaml
@@ -1,0 +1,66 @@
+id: register.cs
+source: onetimesecret/locales/guides/for-translators/cs.md
+# Czech is locked to the INFORMAL "ty" register (2nd-person singular). Grounded
+# in the live app content (onetimesecret/locales/content/cs/*.json), direct
+# address overwhelmingly uses the informal "ty" form:
+#   - informal possessives tvůj / tvoje / tvého / tvému / tvou / tvých (124
+#     occurrences) vs the formal váš family (~11) — e.g. "Tvůj tajný odkaz brzy
+#     vyprší", "Tvoje tajemství bylo zobrazeno", "tvojí přístupovou frází";
+#   - informal 2nd-sg "jsi" (41) vs formal 2nd-pl "jste" (1) — e.g.
+#     "Obdržel jsi tajnou zprávu", "Zapomněl jsi heslo?", "Byl jsi pozván";
+#   - informal singular imperatives throughout (Vytvoř, Zadej, Vyber, Ulož,
+#     Klikni, Přihlas, Sdílej, Použij, Zkus — 170+) vs the formal plural -te
+#     imperative, which is essentially absent. Even the email content (the most
+#     formal surface) is informal: "Požádal jsi o přihlašovací odkaz pro tvůj
+#     účet". The prose guide concurs: "Informal 'ty' for modern UX" /
+#     "Use informal 'ty' form for modern UX experience" (Czech Translation Notes,
+#     Voice and Tone).
+#
+# Because the locked register is informal, the FORBIDDEN register is the formal
+# one: the formal/plural-honorific possessive "váš" family and the formal
+# address pronoun forms vy / vám / vás / vámi. In Czech these are 2nd-person
+# formal/plural ONLY — the 3rd-person possessive is jeho/její/jejich, so unlike
+# Spanish su/sus there is no 3rd-person ambiguity to spare them. They DO appear
+# as residual register inconsistencies in the otherwise-informal live content
+# (e.g. "Tvoje data ... ve vámi zvoleném regionu", "s vašimi osobními údaji ...
+# tvojí země"), which is precisely the register-regression this lock catches.
+#
+# Tokens are matched as standalone_word (NOT word_prefix/substring) on purpose:
+# every formal marker here is a substring of valid Czech words present in the
+# content — "vy" begins the productive verbal prefix vy- (Vytvoř, vyprší, Vyber,
+# vyžaduje), "vám"/"vás" sit inside zprávám / dívám / nás, "váš"/"vaš" inside no
+# common word but kept tight for parity — so a looser context would
+# false-positive. As standalone words the formal forms have zero legitimate use
+# in this informal corpus. Matching is casefolded, so each lowercase token also
+# catches its sentence-initial capitalized form (Vám, Vaše, …).
+#
+# Deliberately NOT forbidden: the bare prefix "vy"/"Vy". Although standalone
+# "vy"/"Vy" is the formal subject pronoun, it never appears as a standalone word
+# in the live content, and listing it risks confusion with the ubiquitous vy-
+# verbal prefix; the formal possessives + oblique pronoun forms (vám/vás/vámi)
+# are the unambiguous standalone markers actually present, so they carry the lock.
+#
+# AGENT-AUTHORED; requires native-speaker (CS) sign-off — see PR label.
+form: informal
+pronoun: ty
+possessive: [tvůj, tvoje, tvá, tvé, tvého, tvému, tvém, tvým, tvou, tvých, tvými, svůj, své, svou]
+forbidden_tokens:
+  - { token: váš,     context: standalone_word, severity: error, note: "formal/plural possessive 'your' (nom. masc.) — the register cs does NOT use; informal is tvůj" }
+  - { token: vaše,    context: standalone_word, severity: error, note: "formal/plural possessive 'your' (nom. neut./fem.) — informal is tvoje/tvá" }
+  - { token: vaši,    context: standalone_word, severity: error, note: "formal/plural possessive 'your' (acc. fem. / nom. masc. pl.) — appears as a residual inconsistency in live content" }
+  - { token: vašeho,  context: standalone_word, severity: error, note: "formal/plural possessive 'your' (gen. masc./neut.) — informal is tvého" }
+  - { token: vašemu,  context: standalone_word, severity: error, note: "formal/plural possessive 'your' (dat. masc./neut.) — informal is tvému" }
+  - { token: vašem,   context: standalone_word, severity: error, note: "formal/plural possessive 'your' (loc. masc./neut.) — appears as a residual inconsistency in live content" }
+  - { token: vaším,   context: standalone_word, severity: error, note: "formal/plural possessive 'your' (instr. masc./neut.) — informal is tvým" }
+  - { token: vaší,    context: standalone_word, severity: error, note: "formal/plural possessive 'your' (gen./dat./loc./instr. fem.) — informal is tvé/tvou" }
+  - { token: vašich,  context: standalone_word, severity: error, note: "formal/plural possessive 'your' (gen./loc. pl.) — informal is tvých" }
+  - { token: vašimi,  context: standalone_word, severity: error, note: "formal/plural possessive 'your' (instr. pl.) — appears as a residual inconsistency in live content" }
+  - { token: vám,     context: standalone_word, severity: error, note: "formal/plural address pronoun 'you' (dat.) — substring of zprávám/dívám, so standalone_word only" }
+  - { token: vás,     context: standalone_word, severity: error, note: "formal/plural address pronoun 'you' (gen./acc.) — informal is tě/tebe" }
+  - { token: vámi,    context: standalone_word, severity: error, note: "formal/plural address pronoun 'you' (instr.) — appears as a residual inconsistency in live content; informal is tebou" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# `baselines.cs` entry exists yet, this backfill must not edit baselines.yaml,
+# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
+# central baselines.cs pin at commit time, after which this file can carry it.

--- a/locales/cs/register.yaml
+++ b/locales/cs/register.yaml
@@ -60,7 +60,4 @@ forbidden_tokens:
   - { token: vámi,    context: standalone_word, severity: error, note: "formal/plural address pronoun 'you' (instr.) — appears as a residual inconsistency in live content; informal is tebou" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# `baselines.cs` entry exists yet, this backfill must not edit baselines.yaml,
-# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
-# central baselines.cs pin at commit time, after which this file can carry it.
+baseline_ref: baselines.cs

--- a/locales/cs/rules.yaml
+++ b/locales/cs/rules.yaml
@@ -1,0 +1,66 @@
+id: rules.cs
+source: onetimesecret/locales/guides/for-translators/cs.md
+inherits: base
+merge_strategy: append
+# Czech locale layer. cs is a standalone shipping language (no family parent),
+# so it inherits `base` directly — mirroring locales/pl/rules.yaml (the closest
+# Slavic pilot) with the SAME register decision: Czech is locked to the INFORMAL
+# "ty" register. That choice is grounded in the live app content
+# (onetimesecret/locales/content/cs/*.json), which uses informal 2nd-person
+# singular throughout (tvůj/tvoje/tvého possessives, "jsi" 41x vs "jste" 1x, and
+# singular imperatives Vytvoř/Zadej/Vyber/Klikni), and contains no standalone
+# formal vy/vám/vás address. The prose guide agrees ("Informal 'ty' for modern
+# UX"; Czech Translation Notes, Voice and Tone).
+#
+# rule.cs-pluralization captures the complex Czech plural system (1 / 2-4 / 5+,
+# e.g. den / dny / dnů), which the guide flags as critical (Special
+# Considerations, Plural Forms); it specialises the base rule.pluralization-syntax.
+# The heslo / přístupová fráze distinction is the single most critical
+# terminology rule in the guide (Special Considerations: Password vs. Passphrase).
+# Czech declines nouns across 7 cases and requires diacritics that change meaning
+# (být vs byt), both captured below.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (CS) sign-off before merge — see PR label.
+rules:
+  - id: rule.cs-register-informal
+    modality: MUST
+    statement: Czech content uses the informal "ty" register (ty / tvůj / tvoje / tvé / tě / tebe) with 2nd-person singular verb forms and singular imperatives throughout product UI and email content; the formal/plural register (vy / váš / vaše / vám / vás) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.cs-pluralization
+    modality: MUST
+    statement: Express countable strings with the three Czech plural forms (1 / 2-4 / 5+, e.g. den / dny / dnů) via vue-i18n pipe syntax; choose the form by the count and never collapse to a single plural.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.cs-passphrase-password
+    modality: MUST
+    statement: Keep heslo (account login credential) distinct from přístupová fráze (the passphrase protecting an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.cs-secret-not-message
+    modality: MUST
+    statement: Translate the core "secret" concept as tajemství (neuter) consistently; do not substitute zpráva (message) unless the source specifically refers to a message.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.cs-burn-trvale-smazat
+    modality: MUST
+    statement: Translate burn / burned consistently as trvale smazat (verb) and trvale smazáno/smazán (state), per the agreed Czech terminology; do not vary across strings or use a literal "spálit".
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.cs-diacritics
+    modality: MUST
+    statement: Always use correct Czech diacritics (á č ď é ě í ň ó ř š ť ú ů ý ž); they are not optional and change meaning (být "to be" vs byt "apartment"). Never omit or substitute them.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.cs-imperative-buttons
+    modality: SHOULD
+    statement: Use the 2nd-person-singular imperative for button and action labels (Vytvoř, Zadej, Ulož, Sdílej); use passive voice or past participles with correct gender agreement for status and system messages.
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.cs
+glossary_ref: glossary.cs
+# baseline_ref intentionally omitted: no baselines.cs entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it
+# is left out until a reviewer adds the central baselines.cs pin.

--- a/locales/cs/rules.yaml
+++ b/locales/cs/rules.yaml
@@ -60,7 +60,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.cs
 glossary_ref: glossary.cs
-# baseline_ref intentionally omitted: no baselines.cs entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it
-# is left out until a reviewer adds the central baselines.cs pin.
+baseline_ref: baselines.cs

--- a/locales/da_DK/glossary.yaml
+++ b/locales/da_DK/glossary.yaml
@@ -1,0 +1,251 @@
+id: glossary.da_DK
+source: onetimesecret/locales/guides/for-translators/da.md
+# Sense-split of the core domain terminology from the Danish translator guide's
+# terminology tables and critical-rules section
+# (onetimesecret/locales/guides/for-translators/da.md), grounded against the live
+# app content in onetimesecret/locales/content/da_DK/*.json. Targets and worked
+# examples are AGENT-AUTHORED and require native-speaker (DA) sign-off before
+# merge — see PR label. Each `good` example uses the informal du register and
+# contains its term's sense target (word_prefix); each `bad` example demonstrates
+# a forbidden form (wrong term, e.g. hemmelighed, or the wrong sense).
+#
+# The defining Danish decision is "secret -> besked, NEVER hemmelighed": the live
+# content uses besked/beskeden/beskeder 140+ times, and the 3 stray "hemmelighed"
+# occurrences are exactly the terminology drift rule.da-secret-besked forbids.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the app. Danish standardises on 'besked' (message), NOT 'hemmelighed', whose childish/personal connotations undermine the security context. Common gender: en besked."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    da_DK:
+      noun:
+        target: besked
+        rule_ref: rule.da-secret-besked
+    rule_refs: [rule.register-lock, rule.da-secret-besked, rule.terminology-consistency]
+    examples:
+      - id: ex.da-secret-besked-good#c88621fd
+        source: "Your secret has been created."
+        target: "Din besked er blevet oprettet."
+        verdict: good
+        note: "Informal possessive 'Din' per the du register; passive/past-participle 'er blevet oprettet' for status. Uses the glossary noun 'besked', not 'hemmelighed'."
+        rule_refs: [rule.register-lock, rule.da-secret-besked]
+      - id: ex.da-secret-hemmelighed-bad#15bc854c
+        source: "Your secret has been created."
+        target: "Din hemmelighed er blevet oprettet."
+        verdict: bad
+        note: "Uses 'hemmelighed' (personal-secret/gossip connotation) where the product term 'besked' is required — violates rule.da-secret-besked. Mirrors the 3 stray 'hemmelighed' drifts in the live content."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secret
+    disambiguation:
+      heuristic: "The adjective sense ('secret'/'secure' qualifier on a link or content). Danish uses 'hemmelig' or, in marketing/security framing, 'sikker' (secure). Distinct from the product noun, which is always 'besked'."
+      key_patterns: ["*secret_link*", "*.secure*", "*hemmelig*"]
+    da_DK:
+      adjective:
+        target: hemmelig
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-secret-adj-good#adfffec4
+        source: "Copy your secret link."
+        target: "Kopier dit hemmelige link."
+        verdict: good
+        note: "Adjective 'hemmelige' qualifies 'link'; informal possessive 'dit'; imperative 'Kopier' for an action. The product noun stays 'besked' elsewhere — only the qualifier is 'hemmelig'."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-secret-adj-bad#5cd4b493
+        source: "Copy your secret link."
+        target: "Kopier din hemmelighed link."
+        verdict: bad
+        note: "Collapses the adjective into the noun 'hemmelighed' (the forbidden product-noun rendering) and breaks agreement — should be the adjective 'hemmelige' modifying 'link'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual besked (distinct from the account login password). Compose/protect-a-secret contexts signal this sense. Danish compound: adgangssætning."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    da_DK:
+      noun:
+        target: adgangssætning
+        rule_ref: rule.da-passphrase-password
+    rule_refs: [rule.register-lock, rule.da-passphrase-password]
+    examples:
+      - id: ex.da-passphrase-good#334a5d30
+        source: "Enter the passphrase to view this secret."
+        target: "Indtast adgangssætningen for at se denne besked."
+        verdict: good
+        note: "Imperative 'Indtast'; uses 'adgangssætning' (besked protection), not 'adgangskode'. Grounded in live phrasing ('Forkert adgangssætning', 'Dobbelttjek adgangssætningen')."
+        rule_refs: [rule.register-lock, rule.da-passphrase-password]
+      - id: ex.da-passphrase-bad#8fe56e31
+        source: "Enter the passphrase to view this secret."
+        target: "Indtast adgangskoden for at se denne besked."
+        verdict: bad
+        note: "Uses 'adgangskode' (account credential) where 'adgangssætning' (besked protection) is meant — violates rule.da-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a besked's passphrase). Sign-in, account, and reset contexts signal this sense. Danish compound: adgangskode."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    da_DK:
+      noun:
+        target: adgangskode
+        rule_ref: rule.da-passphrase-password
+    rule_refs: [rule.register-lock, rule.da-passphrase-password]
+    examples:
+      - id: ex.da-password-good#5e33fc2b
+        source: "Enter your password to sign in."
+        target: "Indtast din adgangskode for at logge ind."
+        verdict: good
+        note: "Informal possessive 'din' per the du register; 'logge ind' per the UI glossary; 'adgangskode' for the account credential. Grounded in live string 'Indtast din adgangskode'."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-password-bad#79fc26f9
+        source: "Enter your password to sign in."
+        target: "Indtast din adgangssætning for at logge ind."
+        verdict: bad
+        note: "Uses 'adgangssætning' (besked protection) for the account login — the exact confusion rule.da-passphrase-password forbids (the guide flags this same wrong pairing)."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a besked before it is viewed. Danish standardises on 'ødelæg' (verb, imperative) and 'ødelagt' (state, past participle), conveying permanent irreversible deletion."
+      key_patterns: ["*burn*", "*.destroy*"]
+    da_DK:
+      verb:
+        target: ødelæg
+        rule_ref: rule.da-burn-oedelaeg
+      state:
+        target: ødelagt
+        rule_ref: rule.da-burn-oedelaeg
+    rule_refs: [rule.register-lock, rule.da-burn-oedelaeg]
+    examples:
+      - id: ex.da-burn-good#c7a6deb6
+        source: "Burn this secret before it is read."
+        target: "Ødelæg denne besked før den bliver læst."
+        verdict: good
+        note: "Imperative 'Ødelæg' for the action label per the guide's burn -> 'ødelæg' choice; product noun 'besked'. Grounded in live string 'Ødelæg denne besked'."
+        rule_refs: [rule.register-lock, rule.da-burn-oedelaeg]
+      - id: ex.da-burn-bad#58783aa9
+        source: "Burn this secret before it is read."
+        target: "Brænd denne hemmelighed før den bliver læst."
+        verdict: bad
+        note: "Uses literal 'Brænd' instead of the glossary verb 'ødelæg', AND 'hemmelighed' instead of 'besked' — double terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a besked. Danish keeps the loanword 'link' (en link / et link; plural links)."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    da_DK:
+      noun:
+        target: link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-link-good#8b060627
+        source: "Copy the secret link to share it."
+        target: "Kopier dit hemmelige link for at dele det."
+        verdict: good
+        note: "Imperative 'Kopier' plus informal possessive 'dit'; uses the loanword 'link' per the glossary. Grounded in live phrasing ('Opret et beskedlink')."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-link-bad#2406b826
+        source: "Copy the secret link to share it."
+        target: "Kopier hemmelighed link for at dele det."
+        verdict: bad
+        note: "Drops the informal possessive and uses 'hemmelighed' (forbidden product noun) as the qualifier; should keep informal 'dit' and the adjective 'hemmelige'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'krypter', past participle 'krypteret' for the encrypted state. A technical security term — prioritise accuracy."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    da_DK:
+      verb:
+        target: krypter
+        rule_ref: rule.terminology-consistency
+      state:
+        target: krypteret
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-encrypt-good#c301792d
+        source: "This message is encrypted with your passphrase."
+        target: "Denne besked er krypteret med din adgangssætning."
+        verdict: good
+        note: "Informal possessive 'din'; past participle 'krypteret' for the encrypted state; 'adgangssætning' for besked protection; product noun 'besked'. Grounded in live 'krypteret'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.da-encrypt-bad#13a754db
+        source: "This message is encrypted with your passphrase."
+        target: "Denne hemmelighed er krypteret med din adgangskode."
+        verdict: bad
+        note: "Uses 'hemmelighed' (forbidden product noun) and 'adgangskode' (account credential) where 'besked' and 'adgangssætning' are required."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Danish hyphenated loanword: e-mail."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    da_DK:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-email-good#0172a3eb
+        source: "Enter your email address."
+        target: "Indtast din e-mailadresse."
+        verdict: good
+        note: "Informal possessive 'din' per the du register; hyphenated loanword 'e-mail' per the glossary. Grounded in live phrasing ('Tjek din e-mail')."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-email-bad#77a68ca7
+        source: "Enter your email address."
+        target: "Indtast Deres e-mailadresse."
+        verdict: bad
+        note: "Formal possessive 'Deres' (the archaic De-register V-form) instead of informal 'din' — the forbidden formal register (rule.da-register-informal)."
+  - id: term.secure#952acf0e
+    key: secure
+    en: secure
+    disambiguation:
+      heuristic: "The protection-state adjective ('secure'/'safe'). Danish: sikker / sikre. A marketing and security-framing qualifier on links, content and connections."
+      key_patterns: ["*secure*", "*.safe*", "*.protected*"]
+    da_DK:
+      adjective:
+        target: sikker
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-secure-good#aae1ab1e
+        source: "Your message is secure."
+        target: "Din besked er sikker."
+        verdict: good
+        note: "Informal possessive 'Din'; predicative adjective 'sikker' (the base form, the glossary sense target); product noun 'besked'. The inflected attributive form appears in live phrasing ('Din sikre besked')."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-secure-bad#e89c8df6
+        source: "Your message is secure."
+        target: "Deres hemmelighed er sikker."
+        verdict: bad
+        note: "Formal possessive 'Deres' (archaic V-form) and 'hemmelighed' (forbidden product noun) instead of informal 'Din' + 'besked'."
+  - id: term.account#3a541ed7
+    key: account
+    en: account
+    disambiguation:
+      heuristic: "The user's profile / account. Danish: konto (en konto). Sign-up, login and settings contexts."
+      key_patterns: ["*account*", "*.signup*", "*.profile*"]
+    da_DK:
+      noun:
+        target: konto
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.da-account-good#62139390
+        source: "Sign in to your account."
+        target: "Log ind på din konto."
+        verdict: good
+        note: "Imperative 'Log ind' per the UI glossary; informal possessive 'din'; 'konto'. Grounded in live string 'Log ind på din konto'."
+        rule_refs: [rule.register-lock]
+      - id: ex.da-account-bad#ce635187
+        source: "Sign in to your account."
+        target: "Log ind på Deres konto."
+        verdict: bad
+        note: "Formal possessive 'Deres' (the archaic De-register V-form) instead of informal 'din' — the forbidden formal register (rule.da-register-informal)."

--- a/locales/da_DK/register.yaml
+++ b/locales/da_DK/register.yaml
@@ -37,7 +37,4 @@ possessive: [din, dit, dine]
 forbidden_tokens: []
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.da_DK is intentionally omitted — baselines.yaml has no
-# da_DK entry yet and is off-limits to this change. A dangling baseline_ref would
-# fail the resolver; a human reviewer pins the baseline centrally (mirroring the
-# fr/de_AT baselines entries), after which this and rules.yaml can carry it.
+baseline_ref: baselines.da_DK

--- a/locales/da_DK/register.yaml
+++ b/locales/da_DK/register.yaml
@@ -1,0 +1,43 @@
+id: register.da_DK
+source: onetimesecret/locales/guides/for-translators/da.md
+# Danish is locked to the INFORMAL `du` register. This is grounded in the live
+# app content (onetimesecret/locales/content/da_DK/*.json): direct address is
+# overwhelmingly informal — the subject pronoun `du` appears as a standalone word
+# 127 times plus sentence-initial `Du` 44 times (e.g. "Har du allerede en
+# konto?", "Er du sikker?", "Når du sender feedback..."), and the informal
+# possessives din/dit/dine appear 294 times (e.g. "Indtast din adgangskode",
+# "Tjek din e-mail", "Log ind på din konto"). The translator guide agrees
+# explicitly: §6 "Direkte tiltale" — "Brug uformel tiltale konsekvent når du
+# henvender dig til brugere" with examples "Indtast din adgangskode" / "Din
+# sikre besked", and "Dansk flyder naturligt med direkte tiltale" (da.md). Like
+# Scandinavian neighbours (cf. the sv_SE du-reform pilot), modern Danish has no
+# enforced T/V split: the formal De/Dem/Deres is archaic and reads as stilted.
+#
+# forbidden_tokens is DELIBERATELY EMPTY. The formal Danish address forms are
+# De (subject), Dem (object) and Deres (possessive) — capitalised. The register
+# is enforced here by `form: informal` + `pronoun: du` + rule.da-register-informal,
+# NOT by a forbidden-token list, for two independent reasons:
+#   1. CASEFOLD AMBIGUITY. Lint matches casefolded (resolver/matching.py
+#      `_casefold` = NFC + .casefold()), so the capital-only distinction that
+#      separates the formal pronoun from an ordinary word is ERASED. Forbidding
+#      `De` would also match the everyday word `de` (= "they"/"the"), which
+#      occurs 29+ times in valid content, and `Deres` would match `deres`
+#      (= "their"), 6+ valid uses. The single capitalised `De` in the live
+#      content — "De vises her, når du har delt dem." — is in fact sentence-
+#      initial `de` (= "they") AND uses informal `du` in the same string, the
+#      exact false positive a forbidden token would produce.
+#   2. ABSENT FROM CONTENT. The genuine formal forms Dem and Deres appear ZERO
+#      times; there is no V-register to police. Per the es.md / sv_SE precedent
+#      (never forbid a token that collides with valid content), the safest list
+#      is empty. The informal lock is expressed structurally + via the rule.
+# AGENT-AUTHORED; requires native-speaker (DA) sign-off — see PR label.
+form: informal
+pronoun: du
+possessive: [din, dit, dine]
+forbidden_tokens: []
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.da_DK is intentionally omitted — baselines.yaml has no
+# da_DK entry yet and is off-limits to this change. A dangling baseline_ref would
+# fail the resolver; a human reviewer pins the baseline centrally (mirroring the
+# fr/de_AT baselines entries), after which this and rules.yaml can carry it.

--- a/locales/da_DK/rules.yaml
+++ b/locales/da_DK/rules.yaml
@@ -48,6 +48,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.da_DK
 glossary_ref: glossary.da_DK
-# baseline_ref: baselines.da_DK is intentionally omitted until a human reviewer
-# adds the baselines.da_DK entry to baselines.yaml centrally — a dangling
-# reference fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.da_DK

--- a/locales/da_DK/rules.yaml
+++ b/locales/da_DK/rules.yaml
@@ -1,0 +1,53 @@
+id: rules.da_DK
+source: onetimesecret/locales/guides/for-translators/da.md
+inherits: base
+merge_strategy: append
+# Danish locale layer. da_DK is the only Danish variant in the repo, so it
+# inherits `base` directly (no family `da` parent), mirroring how
+# locales/sv_SE/rules.yaml and locales/es/rules.yaml inherit base. Carries the
+# Danish conventions transcribed from
+# onetimesecret/locales/guides/for-translators/da.md and grounded in the live
+# app content under onetimesecret/locales/content/da_DK/: the informal `du`
+# register lock, the defining "secret -> besked (NOT hemmelighed)" terminology
+# rule, the adgangskode / adgangssætning distinction, the burn -> "ødelæg"
+# choice, the imperative-vs-status voice split, and the loanword-compound hyphen
+# orthography rule. Every rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live da_DK
+# content; requires native-speaker (DA) sign-off before merge — see PR label.
+rules:
+  - id: rule.da-register-informal
+    modality: MUST
+    statement: Danish content uses the informal du register (du / din / dit / dine) throughout product UI and email content; the formal De / Dem / Deres address form is archaic and is not used.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.da-secret-besked
+    modality: MUST
+    statement: Translate the product noun "secret" as "besked" (message), never "hemmelighed"; in Danish "hemmelighed" carries childish/personal-gossip connotations that undermine the professional security context. Use besked / beskeden / beskeder consistently.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.da-passphrase-password
+    modality: MUST
+    statement: Keep adgangskode (account login / authentication credential) distinct from adgangssætning (protection of an individual besked); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.da-burn-oedelaeg
+    modality: MUST
+    statement: Translate burn / burned consistently as "ødelæg" (action, imperative) and "ødelagt" (state, past participle), conveying the permanent irreversible deletion; do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.da-compound-hyphen
+    modality: MUST
+    statement: When forming compounds with English loanwords, join them with a hyphen (besked-apps, API-nøgle), never as separate words (NOT "besked apps", "API nøgle"); the split form is a Danish orthography error.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.da-voice-imperative-status
+    modality: SHOULD
+    statement: Use the imperative for buttons, links and user actions (Opret, Del, Gem, Kopier) and passive/past-participle forms for status messages and information (Oprettet, Gemt, Ødelagt, "Besked oprettet").
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.da_DK
+glossary_ref: glossary.da_DK
+# baseline_ref: baselines.da_DK is intentionally omitted until a human reviewer
+# adds the baselines.da_DK entry to baselines.yaml centrally — a dangling
+# reference fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/de/glossary.yaml
+++ b/locales/de/glossary.yaml
@@ -1,0 +1,210 @@
+id: glossary.de
+source: onetimesecret/locales/guides/for-translators/de.md
+# Germany-German BASELINE glossary: the core domain terminology from the German
+# translator guide's "German (DE)" columns
+# (onetimesecret/locales/guides/for-translators/de.md), grounded against the live
+# app content (onetimesecret/locales/content/de/*.json). de is the family parent;
+# per ADR-001 de_AT's resolved glossary = merge(glossary.de, glossary.de_AT) with
+# de_AT overriding by term `key`. Keys here are deliberately kept consistent with
+# locales/de_AT/glossary.yaml so its overrides land cleanly:
+#   - secret_object  -> de: Geheimnis  (de_AT overrides, also Geheimnis)
+#   - secret_payload -> de: Nachricht  (de_AT overrides, also Nachricht)
+# The remaining terms (passphrase, password, burn, link, encrypt, email) are NOT
+# in de_AT's glossary, so de_AT INHERITS them from here unchanged.
+#
+# All `good` examples use the formal Sie register (Sie / Ihr / Ihre) so the merged
+# de_AT glossary also lints clean under the de_AT Sie-lock; `bad` examples show a
+# forbidden form (informal du register) or the wrong term.
+#
+# AGENT-AUTHORED; requires native-speaker (DE) sign-off — see PR label.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, or expired. Lifecycle verbs signal the object sense. Guide: Geheimnis in technical/security contexts."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.expire*"]
+    de:
+      noun:
+        target: Geheimnis
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created."
+        target: "Ihr Geheimnis wurde erstellt."
+        verdict: good
+        note: "Formal possessive 'Ihr' per the Sie register; declarative voice for status."
+        rule_refs: [rule.de-sie]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created."
+        target: "Dein Geheimnis wurde erstellt."
+        verdict: bad
+        note: "Informal possessive 'Dein' — the forbidden du register. (This is the live-content form the Sie-lock closes.)"
+  - id: term.secret_payload#1687a617
+    key: secret_payload
+    en: secret message
+    disambiguation:
+      heuristic: "The user-entered message content being protected, distinct from the secret object. Per the DE guide, 'Nachricht' is the neutral UI term for the generated secret content; input/compose/display contexts signal the payload sense."
+      key_patterns: ["*.message*", "*.content*", "*.body*"]
+    de:
+      noun:
+        target: Nachricht
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.payload-good#b71c6282
+        source: "Enter your secret message"
+        target: "Geben Sie Ihre Nachricht ein"
+        verdict: good
+        note: "Formal imperative 'Geben Sie' plus possessive 'Ihre'; 'Nachricht' per the DE UI term."
+        rule_refs: [rule.de-sie]
+      - id: ex.payload-bad#cb733e1d
+        source: "Enter your secret message"
+        target: "Gib deine Nachricht ein"
+        verdict: bad
+        note: "Informal imperative 'Gib' plus 'deine' — the forbidden du register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret, distinct from the account login Passwort. Compose/protect-a-secret and view-this-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    de:
+      noun:
+        target: Passphrase
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Geben Sie die Passphrase ein, um dieses Geheimnis anzusehen."
+        verdict: good
+        note: "Formal imperative 'Geben Sie'; uses 'Passphrase' (DE term), not 'Passwort'."
+        rule_refs: [rule.de-sie, rule.terminology-consistency]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Geben Sie das Passwort ein, um dieses Geheimnis anzusehen."
+        verdict: bad
+        note: "Uses 'Passwort' (account credential) where 'Passphrase' (secret protection) is meant — violates rule.de-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential, distinct from a secret's Passphrase. Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    de:
+      noun:
+        target: Passwort
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Geben Sie Ihr Passwort ein, um sich anzumelden."
+        verdict: good
+        note: "Formal imperative 'Geben Sie' plus possessive 'Ihr'; 'Passwort' for the account credential, 'anmelden' per the DE UI glossary."
+        rule_refs: [rule.de-sie]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Gib dein Passwort ein, um dich anzumelden."
+        verdict: bad
+        note: "Informal imperative 'Gib' plus 'dein'/'dich' — the forbidden du register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed; verb form for the action label, past participle for the resulting state. Per the German guide's DE column: löschen / gelöscht."
+      key_patterns: ["*burn*", "*.destroy*"]
+    de:
+      verb:
+        target: löschen
+        rule_ref: rule.terminology-consistency
+      state:
+        target: gelöscht
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Löschen Sie dieses Geheimnis, bevor es gelesen wird."
+        verdict: good
+        note: "Formal imperative 'Löschen Sie' per the DE burn -> löschen choice."
+        rule_refs: [rule.de-sie, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "The secret was burned."
+        target: "Das Geheimnis wurde verbrannt."
+        verdict: bad
+        note: "Uses 'verbrannt' (literal burn) instead of the DE glossary state 'gelöscht' — terminology drift (verbrennen is the de_AT term, not DE)."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Per the DE column: Link (anglicism, established)."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    de:
+      noun:
+        target: Link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Kopieren Sie den geheimen Link, um ihn zu teilen."
+        verdict: good
+        note: "Formal imperative 'Kopieren Sie'; uses 'Link' per the glossary."
+        rule_refs: [rule.de-sie]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Kopiere deinen geheimen Link, um ihn zu teilen."
+        verdict: bad
+        note: "Informal imperative 'Kopiere' plus possessive 'deinen' — the forbidden du register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'verschlüsseln', past participle 'verschlüsselt' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    de:
+      verb:
+        target: verschlüsseln
+        rule_ref: rule.terminology-consistency
+      state:
+        target: verschlüsselt
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Ihre Nachricht wird mit Ihrer Passphrase verschlüsselt."
+        verdict: good
+        note: "Grounded in live content ('verschlüsselt'); formal possessive 'Ihre' for the encrypted state."
+        rule_refs: [rule.de-sie, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Deine Nachricht wird mit deiner Passphrase verschlüsselt."
+        verdict: bad
+        note: "Informal possessives 'Deine'/'deiner' — the forbidden du register."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account-identifier and notification contexts. Per the DE column: E-Mail (hyphenated, capitalised)."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    de:
+      noun:
+        target: E-Mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Geben Sie Ihre E-Mail-Adresse ein."
+        verdict: good
+        note: "Grounded in live content; formal imperative 'Geben Sie' plus possessive 'Ihre'; 'E-Mail' per the DE term."
+        rule_refs: [rule.de-sie]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Gib deine E-Mail-Adresse ein."
+        verdict: bad
+        note: "Informal imperative 'Gib' plus possessive 'deine' — the forbidden du register."

--- a/locales/de/glossary.yaml
+++ b/locales/de/glossary.yaml
@@ -12,9 +12,21 @@ source: onetimesecret/locales/guides/for-translators/de.md
 # The remaining terms (passphrase, password, burn, link, encrypt, email) are NOT
 # in de_AT's glossary, so de_AT INHERITS them from here unchanged.
 #
-# All `good` examples use the formal Sie register (Sie / Ihr / Ihre) so the merged
-# de_AT glossary also lints clean under the de_AT Sie-lock; `bad` examples show a
-# forbidden form (informal du register) or the wrong term.
+# All `good` examples use the INFORMAL du register — the Germany-German shipping
+# register (see register.de / rule.de-du); `bad` examples show the forbidden
+# FORMAL Sie register (Sie / Ihr / Ihre) or the wrong term.
+#
+# de_AT COUPLING (important): de_AT pins its own FORMAL Sie register but INHERITS
+# every term it does not override. de_AT overrides only secret_object and
+# secret_payload (glossary.de_AT) — so for THOSE two terms the good examples
+# below carry full du possessives (Dein/deine) freely, since de_AT never sees
+# them. The other six terms (passphrase, password, burn, link, encrypt, email)
+# are inherited by de_AT and ARE linted under its Sie register, which forbids the
+# du pronouns (du/dein/deine/…/dich/dir). Their good examples therefore express
+# du via the unambiguous du IMPERATIVE verb form (Gib / Kopiere — not "Geben
+# Sie" / "Kopieren Sie") and avoid the forbidden du pronouns, so they read as du
+# for de yet stay token-clean under the de_AT Sie-lock. This is the same
+# inherit-safe discipline used for rules.de.
 #
 # AGENT-AUTHORED; requires native-speaker (DE) sign-off — see PR label.
 terms:
@@ -28,19 +40,19 @@ terms:
       noun:
         target: Geheimnis
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.secret-good#d81de1d4
         source: "Your secret has been created."
-        target: "Ihr Geheimnis wurde erstellt."
+        target: "Dein Geheimnis wurde erstellt."
         verdict: good
-        note: "Formal possessive 'Ihr' per the Sie register; declarative voice for status."
-        rule_refs: [rule.de-sie]
+        note: "Informal possessive 'Dein' per the du register; declarative voice for status."
+        rule_refs: [rule.register-lock]
       - id: ex.secret-bad#36c87b0a
         source: "Your secret has been created."
-        target: "Dein Geheimnis wurde erstellt."
+        target: "Ihr Geheimnis wurde erstellt."
         verdict: bad
-        note: "Informal possessive 'Dein' — the forbidden du register. (This is the live-content form the Sie-lock closes.)"
+        note: "Formal possessive 'Ihr' — the forbidden Sie register (used only by de_AT, not de)."
   - id: term.secret_payload#1687a617
     key: secret_payload
     en: secret message
@@ -51,19 +63,19 @@ terms:
       noun:
         target: Nachricht
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.payload-good#b71c6282
         source: "Enter your secret message"
-        target: "Geben Sie Ihre Nachricht ein"
+        target: "Gib deine Nachricht ein"
         verdict: good
-        note: "Formal imperative 'Geben Sie' plus possessive 'Ihre'; 'Nachricht' per the DE UI term."
-        rule_refs: [rule.de-sie]
+        note: "Informal imperative 'Gib' plus possessive 'deine'; 'Nachricht' per the DE UI term."
+        rule_refs: [rule.register-lock]
       - id: ex.payload-bad#cb733e1d
         source: "Enter your secret message"
-        target: "Gib deine Nachricht ein"
+        target: "Geben Sie Ihre Nachricht ein"
         verdict: bad
-        note: "Informal imperative 'Gib' plus 'deine' — the forbidden du register."
+        note: "Formal imperative 'Geben Sie' plus 'Ihre' — the forbidden Sie register (de_AT only)."
   - id: term.passphrase#44591635
     key: passphrase
     en: passphrase
@@ -74,17 +86,17 @@ terms:
       noun:
         target: Passphrase
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.passphrase-good#c9b8d63f
         source: "Enter the passphrase to view this secret."
-        target: "Geben Sie die Passphrase ein, um dieses Geheimnis anzusehen."
+        target: "Gib die Passphrase ein, um dieses Geheimnis anzusehen."
         verdict: good
-        note: "Formal imperative 'Geben Sie'; uses 'Passphrase' (DE term), not 'Passwort'."
-        rule_refs: [rule.de-sie, rule.terminology-consistency]
+        note: "Informal du imperative 'Gib' (vs. formal 'Geben Sie'); uses 'Passphrase' (DE term), not 'Passwort'. Inherited by de_AT, so it carries no forbidden du pronoun — the verb form alone marks du."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
       - id: ex.passphrase-bad#b2e929e0
         source: "Enter the passphrase to view this secret."
-        target: "Geben Sie das Passwort ein, um dieses Geheimnis anzusehen."
+        target: "Gib das Passwort ein, um dieses Geheimnis anzusehen."
         verdict: bad
         note: "Uses 'Passwort' (account credential) where 'Passphrase' (secret protection) is meant — violates rule.de-passphrase-password."
   - id: term.password#3e4e76cc
@@ -97,19 +109,19 @@ terms:
       noun:
         target: Passwort
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.password-good#ed4d76e5
         source: "Enter your password to sign in."
-        target: "Geben Sie Ihr Passwort ein, um sich anzumelden."
+        target: "Gib das Passwort zum Anmelden ein."
         verdict: good
-        note: "Formal imperative 'Geben Sie' plus possessive 'Ihr'; 'Passwort' for the account credential, 'anmelden' per the DE UI glossary."
-        rule_refs: [rule.de-sie]
+        note: "Informal du imperative 'Gib' (vs. formal 'Geben Sie'); 'Passwort' for the account credential, 'Anmelden' per the DE UI glossary. Inherited by de_AT, so it avoids the forbidden du pronouns 'dein'/'dich' — the du verb form marks the register."
+        rule_refs: [rule.register-lock]
       - id: ex.password-bad#83a8f72f
         source: "Enter your password to sign in."
-        target: "Gib dein Passwort ein, um dich anzumelden."
+        target: "Geben Sie Ihr Passwort ein, um sich anzumelden."
         verdict: bad
-        note: "Informal imperative 'Gib' plus 'dein'/'dich' — the forbidden du register."
+        note: "Formal imperative 'Geben Sie' plus 'Ihr'/'sich' — the forbidden Sie register (de_AT only)."
   - id: term.burn#8a886c8d
     key: burn
     en: burn
@@ -123,14 +135,14 @@ terms:
       state:
         target: gelöscht
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.burn-good#4bf35a91
-        source: "Burn this secret before it is read."
-        target: "Löschen Sie dieses Geheimnis, bevor es gelesen wird."
+        source: "The secret was deleted before it was read."
+        target: "Das Geheimnis wurde gelöscht, bevor es gelesen wurde."
         verdict: good
-        note: "Formal imperative 'Löschen Sie' per the DE burn -> löschen choice."
-        rule_refs: [rule.de-sie, rule.terminology-consistency]
+        note: "Declarative status using the DE burn-state 'gelöscht' (vs. de_AT 'verbrannt'). Register-neutral on pronouns (no Sie/du form), so it reads clean for de's du and for de_AT's Sie alike; the 'word_prefix' sense check needs the lemma 'gelöscht' present, which the du imperative 'Lösche' would not contain."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
       - id: ex.burn-bad#4228df6b
         source: "The secret was burned."
         target: "Das Geheimnis wurde verbrannt."
@@ -146,19 +158,19 @@ terms:
       noun:
         target: Link
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.link-good#77be696f
         source: "Copy the secret link to share it."
-        target: "Kopieren Sie den geheimen Link, um ihn zu teilen."
+        target: "Kopiere den geheimen Link, um ihn zu teilen."
         verdict: good
-        note: "Formal imperative 'Kopieren Sie'; uses 'Link' per the glossary."
-        rule_refs: [rule.de-sie]
+        note: "Informal du imperative 'Kopiere' (vs. formal 'Kopieren Sie'); uses 'Link' per the glossary. Inherited by de_AT, so it avoids the forbidden du pronoun 'deinen' — the du verb form marks the register."
+        rule_refs: [rule.register-lock]
       - id: ex.link-bad#748809c5
         source: "Copy the secret link to share it."
-        target: "Kopiere deinen geheimen Link, um ihn zu teilen."
+        target: "Kopieren Sie Ihren geheimen Link, um ihn zu teilen."
         verdict: bad
-        note: "Informal imperative 'Kopiere' plus possessive 'deinen' — the forbidden du register."
+        note: "Formal imperative 'Kopieren Sie' plus possessive 'Ihren' — the forbidden Sie register (de_AT only)."
   - id: term.encrypt#a4d3564b
     key: encrypt
     en: encrypt
@@ -172,19 +184,19 @@ terms:
       state:
         target: verschlüsselt
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.encrypt-good#791f7805
-        source: "This message is encrypted with your passphrase."
-        target: "Ihre Nachricht wird mit Ihrer Passphrase verschlüsselt."
+        source: "The message is encrypted with the passphrase."
+        target: "Die Nachricht wird mit der Passphrase verschlüsselt."
         verdict: good
-        note: "Grounded in live content ('verschlüsselt'); formal possessive 'Ihre' for the encrypted state."
-        rule_refs: [rule.de-sie, rule.terminology-consistency]
+        note: "Grounded in live content ('verschlüsselt'). Declarative status, register-neutral on pronouns (no possessive), so it reads clean for de's du and for the de_AT Sie-lock that inherits this term; a du possessive ('deiner') would be forbidden under de_AT."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
       - id: ex.encrypt-bad#450020c5
         source: "This message is encrypted with your passphrase."
-        target: "Deine Nachricht wird mit deiner Passphrase verschlüsselt."
+        target: "Ihre Nachricht wird mit Ihrer Passphrase verschlüsselt."
         verdict: bad
-        note: "Informal possessives 'Deine'/'deiner' — the forbidden du register."
+        note: "Formal possessives 'Ihre'/'Ihrer' — the forbidden Sie register (de_AT only)."
   - id: term.email#8c4fb076
     key: email
     en: email
@@ -195,16 +207,16 @@ terms:
       noun:
         target: E-Mail
         rule_ref: rule.terminology-consistency
-    rule_refs: [rule.de-sie, rule.terminology-consistency]
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
     examples:
       - id: ex.email-good#9138348f
         source: "Enter your email address."
-        target: "Geben Sie Ihre E-Mail-Adresse ein."
+        target: "Gib die E-Mail-Adresse ein."
         verdict: good
-        note: "Grounded in live content; formal imperative 'Geben Sie' plus possessive 'Ihre'; 'E-Mail' per the DE term."
-        rule_refs: [rule.de-sie]
+        note: "Grounded in live content; informal du imperative 'Gib' (vs. formal 'Geben Sie'); 'E-Mail' per the DE term. Inherited by de_AT, so it avoids the forbidden du pronoun 'deine' — the du verb form marks the register."
+        rule_refs: [rule.register-lock]
       - id: ex.email-bad#5c29e476
         source: "Enter your email address."
-        target: "Gib deine E-Mail-Adresse ein."
+        target: "Geben Sie Ihre E-Mail-Adresse ein."
         verdict: bad
-        note: "Informal imperative 'Gib' plus possessive 'deine' — the forbidden du register."
+        note: "Formal imperative 'Geben Sie' plus possessive 'Ihre' — the forbidden Sie register (de_AT only)."

--- a/locales/de/register.yaml
+++ b/locales/de/register.yaml
@@ -1,40 +1,36 @@
 id: register.de
 source: onetimesecret/locales/guides/for-translators/de.md
-# Germany-German BASELINE register, locked to the FORMAL Sie form (Sie / Ihr /
-# Ihre / Ihren / Ihrem / Ihrer / Ihres), mirroring the established de_AT Sie-lock
-# (locales/de_AT/register.yaml). The existing rules.de carries rule.de-sie, and
-# de_AT inherits it; this register makes that lock binding for the de family
-# parent.
+# Germany-German shipping register, locked to the INFORMAL du form (du / dein /
+# deine / deinen / deinem / deiner / deines). This reflects a maintainer-approved
+# register decision: the *live* de content
+# (onetimesecret/locales/content/de/*.json) is written in informal du
+# (du/dein/deine appear ~270x; "Du hast deine eigene Nachricht angesehen."), and
+# the prose guide's "Direct Address (Du vs. Sie)" section calls DE informal-du.
+# So de ships du. The Austrian sibling de_AT remains FORMAL Sie
+# (locales/de_AT/register.yaml) — a normal Germany-informal / Austria-formal
+# regional split. de_AT inherits rules.de but pins its own register.de_AT, so
+# this flip does not affect de_AT.
 #
-# JUDGMENT CALL FOR THE NATIVE (DE) REVIEWER: the *live* de content
-# (onetimesecret/locales/content/de/*.json) is currently written in the INFORMAL
-# du register (du/dein/deine appear ~270x; "Du hast deine eigene Nachricht
-# angesehen.") and the prose guide's "Direct Address (Du vs. Sie)" section calls
-# DE informal-du. This register deliberately encodes the FORMAL Sie governance
-# decision instead (matching rule.de-sie + the de_AT family Sie-lock), i.e. it
-# treats the live du-content as the register-regression class the backfill exists
-# to close, not as the target. If the DE locale is meant to ship informal du, the
-# fix is a centrally-agreed register flip (form: informal, forbid the Sie tokens)
-# — NOT a quiet edit here. Forbidden tokens below are the informal du-paradigm,
-# mirroring de_AT.
+# forbidden_tokens is DELIBERATELY EMPTY (mirroring da_DK). The opposite-form
+# markers here are the German FORMAL pronouns Sie / Ihnen / Ihr / Ihre, and they
+# CANNOT be safely token-matched: lint matches casefolded (resolver/matching.py
+# `_casefold` = NFC + .casefold()), which erases the capital-only distinction
+# that separates the formal forms from ordinary words. Forbidding `Sie` would
+# also match `sie` (= she / they), `Ihnen` would match `ihnen` (= to them), and
+# `Ihr` / `Ihre` would match `ihr` / `ihre` (= her / you-plural / their) — all of
+# which occur in huge amounts of valid prose, producing massive false positives.
+# Per the da_DK / es.md / sv_SE precedent (never forbid a token that collides
+# with valid content), the safest list is empty. The du-lock is carried
+# structurally by `form: informal` + `pronoun: du` + rule.de-du (rules.de) /
+# rule.register-lock, plus native review and content normalization.
 #
 # AGENT-AUTHORED; requires native-speaker (DE) sign-off — see PR label.
-form: formal
-pronoun: Sie
-possessive: [Ihr, Ihre, Ihren, Ihrem, Ihrer, Ihres]
-forbidden_tokens:
-  - { token: du,     context: standalone_word, severity: error }
-  - { token: dein,   context: standalone_word, severity: error }
-  - { token: deine,  context: standalone_word, severity: error }
-  - { token: deinen, context: standalone_word, severity: error }
-  - { token: deinem, context: standalone_word, severity: error }
-  - { token: deiner, context: standalone_word, severity: error }
-  - { token: dich,   context: standalone_word, severity: error }
-  - { token: dir,    context: standalone_word, severity: error }
-  - { token: euch,   context: standalone_word, severity: error }
-  - { token: euer,   context: standalone_word, severity: error }
+form: informal
+pronoun: du
+possessive: [dein, deine, deinen, deinem, deiner, deines]
+forbidden_tokens: []
 exceptions: []
-rule_ref: rule.de-sie
+rule_ref: rule.register-lock
 # baseline_ref: baselines.de is intentionally omitted — no `baselines.de` entry
 # exists in baselines.yaml yet, and a dangling reference fails the resolver. The
 # pin is for a human reviewer to add to baselines.yaml centrally at commit time

--- a/locales/de/register.yaml
+++ b/locales/de/register.yaml
@@ -1,0 +1,42 @@
+id: register.de
+source: onetimesecret/locales/guides/for-translators/de.md
+# Germany-German BASELINE register, locked to the FORMAL Sie form (Sie / Ihr /
+# Ihre / Ihren / Ihrem / Ihrer / Ihres), mirroring the established de_AT Sie-lock
+# (locales/de_AT/register.yaml). The existing rules.de carries rule.de-sie, and
+# de_AT inherits it; this register makes that lock binding for the de family
+# parent.
+#
+# JUDGMENT CALL FOR THE NATIVE (DE) REVIEWER: the *live* de content
+# (onetimesecret/locales/content/de/*.json) is currently written in the INFORMAL
+# du register (du/dein/deine appear ~270x; "Du hast deine eigene Nachricht
+# angesehen.") and the prose guide's "Direct Address (Du vs. Sie)" section calls
+# DE informal-du. This register deliberately encodes the FORMAL Sie governance
+# decision instead (matching rule.de-sie + the de_AT family Sie-lock), i.e. it
+# treats the live du-content as the register-regression class the backfill exists
+# to close, not as the target. If the DE locale is meant to ship informal du, the
+# fix is a centrally-agreed register flip (form: informal, forbid the Sie tokens)
+# — NOT a quiet edit here. Forbidden tokens below are the informal du-paradigm,
+# mirroring de_AT.
+#
+# AGENT-AUTHORED; requires native-speaker (DE) sign-off — see PR label.
+form: formal
+pronoun: Sie
+possessive: [Ihr, Ihre, Ihren, Ihrem, Ihrer, Ihres]
+forbidden_tokens:
+  - { token: du,     context: standalone_word, severity: error }
+  - { token: dein,   context: standalone_word, severity: error }
+  - { token: deine,  context: standalone_word, severity: error }
+  - { token: deinen, context: standalone_word, severity: error }
+  - { token: deinem, context: standalone_word, severity: error }
+  - { token: deiner, context: standalone_word, severity: error }
+  - { token: dich,   context: standalone_word, severity: error }
+  - { token: dir,    context: standalone_word, severity: error }
+  - { token: euch,   context: standalone_word, severity: error }
+  - { token: euer,   context: standalone_word, severity: error }
+exceptions: []
+rule_ref: rule.de-sie
+# baseline_ref: baselines.de is intentionally omitted — no `baselines.de` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the `de_AT`/`fr` baselines entries), after which this and rules.yaml
+# can carry `baseline_ref: baselines.de`.

--- a/locales/de/register.yaml
+++ b/locales/de/register.yaml
@@ -31,8 +31,4 @@ possessive: [dein, deine, deinen, deinem, deiner, deines]
 forbidden_tokens: []
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.de is intentionally omitted — no `baselines.de` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the `de_AT`/`fr` baselines entries), after which this and rules.yaml
-# can carry `baseline_ref: baselines.de`.
+baseline_ref: baselines.de

--- a/locales/de/rules.yaml
+++ b/locales/de/rules.yaml
@@ -3,16 +3,20 @@ source: local-guides/UX-TRANSLATION-GUIDE.md
 inherits: base
 merge_strategy: append
 # Inheritance parent for the de family AND the Germany-German shipping locale.
-# Carries the German formal-register rule (rule.de-sie, inherited by de_AT and
-# future de_* locales) plus de's own register/glossary refs so de is
-# resolved-only-ready. Per ADR-001, de_AT's glossary now merges over glossary.de.
+# Germany-German (de) ships the INFORMAL du register (rule.de-du), grounded in the
+# live de content. The Austrian sibling de_AT pins its own FORMAL Sie register
+# (register.de_AT / register.de_AT.formality) and inherits these rules, so the du
+# choice here does not change de_AT — rule.de-du's statement explicitly carves out
+# de_AT=Sie so it reads correctly under inheritance. Plus de's own
+# register/glossary refs so de is resolved-only-ready. Per ADR-001, de_AT's
+# glossary now merges over glossary.de.
 #
 # AGENT-AUTHORED transcription of the DE translator guide, grounded in live de
 # content; requires native-speaker (DE) sign-off before merge — see PR label.
 rules:
-  - id: rule.de-sie
+  - id: rule.de-du
     modality: MUST
-    statement: German content uses the formal Sie form (Sie / Ihr / Ihre), not the informal du.
+    statement: Germany-German (de) content uses the informal du form (du/dein/deine); the formal Sie is used only by de_AT (Austrian).
     severity: error
     rule_ref: rule.register-lock
   - id: rule.de-passphrase-password

--- a/locales/de/rules.yaml
+++ b/locales/de/rules.yaml
@@ -26,6 +26,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.de
 glossary_ref: glossary.de
-# baseline_ref: baselines.de is intentionally omitted until a human reviewer adds
-# the `baselines.de` entry to baselines.yaml centrally — a dangling reference
-# fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.de

--- a/locales/de/rules.yaml
+++ b/locales/de/rules.yaml
@@ -2,11 +2,26 @@ id: rules.de
 source: local-guides/UX-TRANSLATION-GUIDE.md
 inherits: base
 merge_strategy: append
-# Minimal inheritance parent for the de family. Carries only what de_AT (and
-# future de_* locales) need to inherit: the German formal-register rule.
+# Inheritance parent for the de family AND the Germany-German shipping locale.
+# Carries the German formal-register rule (rule.de-sie, inherited by de_AT and
+# future de_* locales) plus de's own register/glossary refs so de is
+# resolved-only-ready. Per ADR-001, de_AT's glossary now merges over glossary.de.
+#
+# AGENT-AUTHORED transcription of the DE translator guide, grounded in live de
+# content; requires native-speaker (DE) sign-off before merge — see PR label.
 rules:
   - id: rule.de-sie
     modality: MUST
     statement: German content uses the formal Sie form (Sie / Ihr / Ihre), not the informal du.
     severity: error
     rule_ref: rule.register-lock
+  - id: rule.de-passphrase-password
+    modality: MUST
+    statement: Keep Passwort (account login / authentication credential) distinct from Passphrase (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+register_ref: register.de
+glossary_ref: glossary.de
+# baseline_ref: baselines.de is intentionally omitted until a human reviewer adds
+# the `baselines.de` entry to baselines.yaml centrally — a dangling reference
+# fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/de_AT/rules.yaml
+++ b/locales/de_AT/rules.yaml
@@ -10,7 +10,7 @@ rules:
     modality: MUST
     statement: de_AT uses the formal Sie-form throughout product UI and email content; informal du/dein forms are forbidden.
     severity: error
-    rule_ref: rule.de-sie
+    rule_ref: rule.register-lock
 register_ref: register.de_AT
 glossary_ref: glossary.de_AT
 baseline_ref: baselines.de_AT

--- a/locales/el_GR/glossary.yaml
+++ b/locales/el_GR/glossary.yaml
@@ -1,0 +1,181 @@
+id: glossary.el_GR
+source: onetimesecret/locales/guides/for-translators/el_GR.md
+# Sense-split of the core domain terminology from the Greek translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/el_GR.md),
+# grounded against the live app content in onetimesecret/locales/content/el_GR/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (EL)
+# sign-off before merge — see PR label. Each `good` example uses the formal εσείς
+# register (2pl verbs + σας); each `bad` example demonstrates a forbidden form
+# (the informal εσύ register, or the wrong term).
+#
+# Greek inflects across 4 cases and 3 genders, so the sense `target` is a sensible
+# citation form (usually nominative singular) that also appears verbatim as a
+# word in the chosen good example, satisfying the lint's word_prefix target check.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Neuter noun (το μυστικό)."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    el_GR:
+      noun:
+        target: μυστικό
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.el-secret-good#7e44f10e
+        source: "Your secret has been created."
+        target: "Το μυστικό σας δημιουργήθηκε."
+        verdict: good
+        note: "Formal possessive σας per the εσείς register; passive past for status. Grounded in live el_GR phrasing (cf. 'Όλα τα μυστικά σας')."
+        rule_refs: [rule.register-lock]
+      - id: ex.el-secret-bad#f9b09970
+        source: "Your secret has been created."
+        target: "Το μυστικό σου δημιουργήθηκε."
+        verdict: bad
+        note: "Informal 2sg possessive σου — the forbidden εσύ register; formal is σας."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense. Feminine (η φράση πρόσβασης)."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    el_GR:
+      noun:
+        target: φράση πρόσβασης
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.el-passphrase-password]
+    examples:
+      - id: ex.el-passphrase-good#85ccc80c
+        source: "Enter the passphrase to view this secret."
+        target: "Εισάγετε τη φράση πρόσβασης για να προβάλετε αυτό το μυστικό."
+        verdict: good
+        note: "Formal 2pl imperative Εισάγετε; uses φράση πρόσβασης (secret protection), not κωδικός πρόσβασης. Grounded in live 'Εισάγετε τη φράση πρόσβασης εδώ'."
+        rule_refs: [rule.register-lock, rule.el-passphrase-password]
+      - id: ex.el-passphrase-bad#41b2bf7d
+        source: "Enter the passphrase to view this secret."
+        target: "Εισάγετε τον κωδικό πρόσβασης για να προβάλετε αυτό το μυστικό."
+        verdict: bad
+        note: "Uses κωδικός πρόσβασης (account credential) where φράση πρόσβασης (secret protection) is meant — violates rule.el-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Masculine (ο κωδικός πρόσβασης)."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    el_GR:
+      noun:
+        target: κωδικός πρόσβασης
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.el-passphrase-password]
+    examples:
+      - id: ex.el-password-good#7767d48d
+        source: "The password you enter protects your account."
+        target: "Ο κωδικός πρόσβασης που εισάγετε προστατεύει τον λογαριασμό σας."
+        verdict: good
+        note: "Formal 2pl verb εισάγετε plus formal possessive σας; uses κωδικός πρόσβασης (account credential). Nominative citation form per the live UI 'Νέος κωδικός πρόσβασης'."
+        rule_refs: [rule.register-lock]
+      - id: ex.el-password-bad#af9d3f0e
+        source: "The password you enter protects your account."
+        target: "Ο κωδικός πρόσβασης που εισάγεις προστατεύει τον λογαριασμό σου."
+        verdict: bad
+        note: "Informal 2sg verb εισάγεις plus informal possessive σου — the forbidden εσύ register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "Permanent deletion of a secret before it is viewed. Action label uses the noun phrase οριστική διαγραφή; the resulting state uses διαγράφηκε/διαγράφεται οριστικά. The guide forbids a literal 'καίω' rendering."
+      key_patterns: ["*burn*", "*.destroy*"]
+    el_GR:
+      action:
+        target: οριστική διαγραφή
+        rule_ref: rule.el-burn-oristiki-diagrafi
+      state:
+        target: διαγράφηκε οριστικά
+        rule_ref: rule.el-burn-oristiki-diagrafi
+    rule_refs: [rule.register-lock, rule.el-burn-oristiki-diagrafi]
+    examples:
+      - id: ex.el-burn-good#d1ccd8e5
+        source: "This secret has been burned."
+        target: "Αυτό το μυστικό διαγράφηκε οριστικά."
+        verdict: good
+        note: "State sense: διαγράφηκε οριστικά, grounded in live 'το περιεχόμενο θα διαγραφεί οριστικά' / 'διαγράφηκε οριστικά'."
+        rule_refs: [rule.register-lock, rule.el-burn-oristiki-diagrafi]
+      - id: ex.el-burn-bad#8809bfb6
+        source: "This secret has been burned."
+        target: "Αυτό το μυστικό κάηκε."
+        verdict: bad
+        note: "Uses a literal 'κάηκε' (was burned/scorched) instead of the agreed οριστική διαγραφή / διαγράφηκε οριστικά terminology — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Masculine (ο σύνδεσμος); final sigma ς in the nominative."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    el_GR:
+      noun:
+        target: σύνδεσμος
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.el-link-good#7826a9ed
+        source: "A secure link will be sent to your email."
+        target: "Ένας ασφαλής σύνδεσμος θα σταλεί στο email σας."
+        verdict: good
+        note: "Nominative σύνδεσμος; formal possessive σας. Grounded in live 'Θα σταλεί ασφαλής σύνδεσμος στο email σας.'"
+        rule_refs: [rule.register-lock]
+      - id: ex.el-link-bad#0c6efdb8
+        source: "A secure link will be sent to your email."
+        target: "Ένας ασφαλής σύνδεσμος θα σταλεί στο email σου."
+        verdict: bad
+        note: "Informal 2sg possessive σου — the forbidden εσύ register; formal is σας."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. Verb/noun κρυπτογράφηση (from Greek κρυπτός); past participle κρυπτογραφημένο for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    el_GR:
+      noun:
+        target: κρυπτογράφηση
+        rule_ref: rule.terminology-consistency
+      state:
+        target: κρυπτογραφημένο
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.el-encrypt-good#007c98bc
+        source: "This message is encrypted with your passphrase."
+        target: "Αυτό το μήνυμα είναι κρυπτογραφημένο με τη φράση πρόσβασής σας."
+        verdict: good
+        note: "State sense κρυπτογραφημένο; formal possessive σας. Grounded in live 'Αυτό το μήνυμα είναι κρυπτογραφημένο με τη φράση πρόσβασής σας.'"
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.el-encrypt-bad#8de90e86
+        source: "This message is encrypted with your passphrase."
+        target: "Αυτό το μήνυμα είναι κρυπτογραφημένο με τη φράση πρόσβασής σου."
+        verdict: bad
+        note: "Informal 2sg possessive σου — the forbidden εσύ register; formal is σας."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. The guide lists the formal term ηλεκτρονικό ταχυδρομείο, but the live UI uses the loanword 'email' throughout — follow live usage."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    el_GR:
+      noun:
+        target: email
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.el-email-good#140a569e
+        source: "Please check your email for a verification link."
+        target: "Παρακαλώ ελέγξτε το email σας για σύνδεσμο επαλήθευσης."
+        verdict: good
+        note: "Formal 2pl imperative ελέγξτε plus formal possessive σας. Verbatim live string from session-auth content."
+        rule_refs: [rule.register-lock]
+      - id: ex.el-email-bad#d9ad35fe
+        source: "Please check your email for a verification link."
+        target: "Παρακαλώ έλεγξε το email σου για σύνδεσμο επαλήθευσης."
+        verdict: bad
+        note: "Informal 2sg imperative έλεγξε plus informal possessive σου — the forbidden εσύ register."

--- a/locales/el_GR/register.yaml
+++ b/locales/el_GR/register.yaml
@@ -38,7 +38,4 @@ forbidden_tokens:
   - { token: σου,   context: standalone_word, severity: error, note: "informal 2sg weak possessive/genitive clitic — formal is σας; 0 standalone hits in live content. Left as standalone_word so the preposition-free σ' contraction and word-internal sequences are not flagged." }
 exceptions: []
 rule_ref: register.el_GR.formality
-# baseline_ref: baselines.el_GR is intentionally omitted — no `baselines.el_GR`
-# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
-# The pin is for a human reviewer to add to baselines.yaml centrally at commit
-# time (mirroring the fr / de_AT baselines entries).
+baseline_ref: baselines.el_GR

--- a/locales/el_GR/register.yaml
+++ b/locales/el_GR/register.yaml
@@ -1,0 +1,44 @@
+id: register.el_GR
+source: onetimesecret/locales/guides/for-translators/el_GR.md
+# Greek is locked to the FORMAL εσείς (2nd-person plural) register. Grounded in
+# the live app content (onetimesecret/locales/content/el_GR/*.json): every
+# user-facing string addresses the reader with formal 2pl verb forms and the
+# formal possessive/genitive clitic σας — e.g. "Εισάγετε τα διαπιστευτήριά σας",
+# "Δημιουργήστε τον λογαριασμό σας", "Μπορείτε να συνδεθείτε τώρα.",
+# "Ξεχάσατε τον κωδικό σας;", "Όλα τα μυστικά σας θα διαγραφούν οριστικά."
+# The emphatic formal pronoun appears too ("Εάν δεν κάνατε εσείς αυτήν την
+# αλλαγή..."). A scan of all 19 files finds 300+ formal 2pl/σας hits and ZERO
+# standalone informal 2sg forms (εσύ / εσένα / σου — 0 occurrences each). The
+# prose guide agrees explicitly: el_GR.md "Voice and Tone" / "Common Translation
+# Patterns" record "Use polite εσείς forms for professional tone".
+#
+# So the FORBIDDEN register is the informal εσύ (2sg) register. The forbidden
+# tokens are the informal address pronouns that are unambiguous as standalone
+# words: εσύ (subject), εσένα (stressed object), and σου (weak possessive/genitive
+# clitic — its formal counterpart is σας; σου never appears standalone in the live
+# content). Informal 2sg verb imperatives/forms are NOT enumerated as tokens: they
+# are too many and the formal forms are used uniformly, so the pronoun set is the
+# reliable, unambiguous lock.
+#
+# Deliberately LEFT FREE (documented, not forbidden): σε and the elided σ'.
+# Although σε is also the informal 2sg weak object pronoun, it is overwhelmingly
+# the ordinary preposition "in/at/to" in the live content ("σε πολλές γλώσσες",
+# "προσβάσιμα σε όλους", "Η γλώσσα άλλαξε σε {0}"). Forbidding σε would flag
+# valid prepositional prose, so it is omitted per the rule against forbidding a
+# token that is ambiguous as a standalone word. εσύ / εσένα / σου have no such
+# collision.
+#
+# AGENT-AUTHORED; requires native-speaker (EL) sign-off — see PR label.
+form: formal
+pronoun: εσείς
+possessive: [σας]
+forbidden_tokens:
+  - { token: εσύ,   context: standalone_word, severity: error, note: "informal 2sg subject pronoun — the register el_GR does NOT use (formal is εσείς)" }
+  - { token: εσένα, context: standalone_word, severity: error, note: "informal 2sg stressed object pronoun — formal is εσάς" }
+  - { token: σου,   context: standalone_word, severity: error, note: "informal 2sg weak possessive/genitive clitic — formal is σας; 0 standalone hits in live content. Left as standalone_word so the preposition-free σ' contraction and word-internal sequences are not flagged." }
+exceptions: []
+rule_ref: register.el_GR.formality
+# baseline_ref: baselines.el_GR is intentionally omitted — no `baselines.el_GR`
+# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
+# The pin is for a human reviewer to add to baselines.yaml centrally at commit
+# time (mirroring the fr / de_AT baselines entries).

--- a/locales/el_GR/rules.yaml
+++ b/locales/el_GR/rules.yaml
@@ -34,6 +34,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.el_GR
 glossary_ref: glossary.el_GR
-# baseline_ref: baselines.el_GR is intentionally omitted until a human reviewer
-# adds the `baselines.el_GR` entry to baselines.yaml centrally — a dangling
-# reference fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.el_GR

--- a/locales/el_GR/rules.yaml
+++ b/locales/el_GR/rules.yaml
@@ -1,0 +1,39 @@
+id: rules.el_GR
+source: onetimesecret/locales/guides/for-translators/el_GR.md
+inherits: base
+merge_strategy: append
+# Greek locale layer. el_GR is a standalone shipping language, so it inherits
+# `base` directly (no family parent). Carries the Greek conventions transcribed
+# from onetimesecret/locales/guides/for-translators/el_GR.md and grounded in the
+# live el_GR content: the formal εσείς register lock, the
+# κωδικός πρόσβασης / φράση πρόσβασης distinction the guide calls critical, and
+# the burn -> οριστική διαγραφή terminology the guide standardised on.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live el_GR content;
+# requires native-speaker (EL) sign-off before merge — see PR label.
+rules:
+  - id: register.el_GR.formality
+    modality: MUST
+    statement: Greek content uses the formal εσείς register (2nd-person plural verb forms and the possessive/genitive clitic σας) throughout product UI and email content; the informal εσύ register (εσύ / εσένα / σου) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.el-passphrase-password
+    modality: MUST
+    statement: Keep κωδικός πρόσβασης (account login / authentication credential) distinct from φράση πρόσβασης (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.el-burn-oristiki-diagrafi
+    modality: MUST
+    statement: Translate burn / burned consistently as οριστική διαγραφή (the action, "permanent deletion") and διαγράφηκε οριστικά / διαγράφεται οριστικά (the resulting state), per the agreed Greek terminology; do not use a literal "καίω" rendering and do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.el-monotonic-accents
+    modality: MUST
+    statement: Use the monotonic system (single acute accent only, in force since 1982); never use polytonic marks (grave, circumflex, breathings). Use final sigma ς at word end and σ elsewhere.
+    severity: warning
+    rule_ref: rule.terminology-consistency
+register_ref: register.el_GR
+glossary_ref: glossary.el_GR
+# baseline_ref: baselines.el_GR is intentionally omitted until a human reviewer
+# adds the `baselines.el_GR` entry to baselines.yaml centrally — a dangling
+# reference fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/eo/glossary.yaml
+++ b/locales/eo/glossary.yaml
@@ -1,0 +1,188 @@
+id: glossary.eo
+source: onetimesecret/locales/guides/for-translators/eo.md
+# Sense-split of the core domain terminology from the Esperanto translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/eo.md),
+# grounded against the live app content in onetimesecret/locales/content/eo/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native/fluent-speaker
+# (EO) sign-off before merge — see PR label.
+#
+# Register note: Esperanto has no T/V split, so every `good` example simply uses
+# the universal `vi`/`via` address. `bad` examples demonstrate either a wrong term
+# (e.g. pasvorto where sekreta frazo is meant, the x-system surrogate, or a
+# non-glossary synonym) or the archaic intimate `ci`/`cia` that register.eo
+# forbids. Good targets are quoted from or modelled on live strings where one
+# exists; each contains its term's sense target as a substring for lint.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Noun 'sekreto'; adjective 'sekreta' (e.g. sekreta mesaĝo, sekreta ligilo)."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    eo:
+      noun:
+        target: sekreto
+        rule_ref: rule.terminology-consistency
+      adjective:
+        target: sekreta
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-eo-good#c24bc788
+        source: "Your secret has been created securely."
+        target: "Via sekreto estis sekure kreita."
+        verdict: good
+        note: "Quoted from live content (secret-manage.json); universal 'Via' address, accusative not needed in a copular clause."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.secret-eo-bad#eba80e66
+        source: "Your secret has been created securely."
+        target: "Cia sekreto estis sekure kreita."
+        verdict: bad
+        note: "Uses the archaic intimate possessive 'Cia' instead of universal 'Via' — register.eo forbids the obsolete ci/cia."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose / protect-a-secret contexts signal this sense. Always 'sekreta frazo', never the coinage 'pasfrazo'."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    eo:
+      noun:
+        target: sekreta frazo
+        rule_ref: rule.eo-passphrase-password
+    rule_refs: [rule.register-lock, rule.eo-passphrase-password]
+    examples:
+      - id: ex.passphrase-eo-good#5de3e893
+        source: "This message is encrypted with your passphrase."
+        target: "Ĉi tiu mesaĝo estas ĉifrita per via sekreta frazo."
+        verdict: good
+        note: "Quoted from live content (secret-manage.json); uses 'sekreta frazo', not 'pasvorto'."
+        rule_refs: [rule.register-lock, rule.eo-passphrase-password]
+      - id: ex.passphrase-eo-bad#77a18aea
+        source: "This message is encrypted with your passphrase."
+        target: "Ĉi tiu mesaĝo estas ĉifrita per via pasvorto."
+        verdict: bad
+        note: "Uses 'pasvorto' (account credential) where 'sekreta frazo' (secret protection) is meant — violates rule.eo-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    eo:
+      noun:
+        target: pasvorto
+        rule_ref: rule.eo-passphrase-password
+    rule_refs: [rule.register-lock, rule.eo-passphrase-password]
+    examples:
+      - id: ex.password-eo-good#251da90f
+        source: "We received a request to reset your password."
+        target: "Ni ricevis peton restarigi vian pasvorton."
+        verdict: good
+        note: "Quoted from live content (email.json); universal 'vian' plus accusative 'pasvorton' on the direct object."
+        rule_refs: [rule.register-lock, rule.eo-passphrase-password]
+      - id: ex.password-eo-bad#173fed0d
+        source: "We received a request to reset your password."
+        target: "Ni ricevis peton restarigi cian pasvorton."
+        verdict: bad
+        note: "Uses the archaic intimate possessive 'cian' instead of universal 'vian' — register.eo forbids ci/cia."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently deleting a secret before it is viewed. Verb 'forbruligi' for the action label, past participle 'forbruligita' for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    eo:
+      verb:
+        target: forbruligi
+        rule_ref: rule.eo-burn-forbruligi
+      state:
+        target: forbruligita
+        rule_ref: rule.eo-burn-forbruligi
+    rule_refs: [rule.register-lock, rule.eo-burn-forbruligi]
+    examples:
+      - id: ex.burn-eo-good#089f5752
+        source: "Yes, burn this secret"
+        target: "Jes, forbruligi ĉi tiun sekreton"
+        verdict: good
+        note: "Quoted from live content (00-common.json); infinitive 'forbruligi' for the action, accusative 'sekreton'."
+        rule_refs: [rule.register-lock, rule.eo-burn-forbruligi]
+      - id: ex.burn-eo-bad#15b49cf4
+        source: "Yes, burn this secret"
+        target: "Jes, detrui ĉi tiun sekreton"
+        verdict: bad
+        note: "Uses 'detrui' instead of the glossary term 'forbruligi' — terminology drift, violates rule.eo-burn-forbruligi."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    eo:
+      noun:
+        target: ligilo
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-eo-good#6d172607
+        source: "Your secret link will expire soon"
+        target: "Via sekreta ligilo baldaŭ eksvalidiĝos"
+        verdict: good
+        note: "Quoted from live content (email.json); 'ligilo' for the URL, universal 'Via'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.link-eo-bad#d7e18628
+        source: "Your secret link will expire soon"
+        target: "Cia sekreta ligilo baldaŭ eksvalidiĝos"
+        verdict: bad
+        note: "Uses the archaic intimate possessive 'Cia' instead of universal 'Via' — register.eo forbids ci/cia."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'ĉifri', past participle 'ĉifrita' for the encrypted state. Use the essential circumflex, never the x-system 'cxifri'."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    eo:
+      verb:
+        target: ĉifri
+        rule_ref: rule.terminology-consistency
+      state:
+        target: ĉifrita
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency, rule.eo-diacritics]
+    examples:
+      - id: ex.encrypt-eo-good#3b2e4546
+        source: "This information will be encrypted and viewed only once"
+        target: "Ĉi tiu informo estos ĉifrita kaj rigardata nur unufoje"
+        verdict: good
+        note: "Quoted from live content (feature-incoming.json); 'ĉifrita' with the essential circumflex."
+        rule_refs: [rule.register-lock, rule.terminology-consistency, rule.eo-diacritics]
+      - id: ex.encrypt-eo-bad#4c030a54
+        source: "This information will be encrypted and viewed only once"
+        target: "Ĉi tiu informo estos cxifrita kaj rigardata nur unufoje"
+        verdict: bad
+        note: "Uses the x-system surrogate 'cxifrita' instead of 'ĉifrita' — violates rule.eo-diacritics."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email message or address. 'retpoŝto' for the message / mail; 'retpoŝtadreso' (or 'retpoŝta adreso') for the address as account identifier."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    eo:
+      message:
+        target: retpoŝto
+        rule_ref: rule.terminology-consistency
+      address:
+        target: retpoŝtadreso
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-eo-good#f833f9a1
+        source: "Welcome - Please confirm your email"
+        target: "Bonvenon - Bonvolu konfirmi vian retpoŝton"
+        verdict: good
+        note: "Quoted from live content (email.json); 'retpoŝton' (message sense) with accusative -n, universal 'vian'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.email-eo-bad#f14d7622
+        source: "Welcome - Please confirm your email"
+        target: "Bonvenon - Bonvolu konfirmi cian retpoŝton"
+        verdict: bad
+        note: "Uses the archaic intimate possessive 'cian' instead of universal 'vian' — register.eo forbids ci/cia."

--- a/locales/eo/register.yaml
+++ b/locales/eo/register.yaml
@@ -35,7 +35,4 @@ forbidden_tokens:
   - { token: cia, context: standalone_word, severity: warning, note: "archaic intimate possessive (companion to `ci`); use `via`." }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.eo is intentionally omitted — no `baselines.eo` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
-# human reviewer adds the pin to baselines.yaml centrally at commit time (as for
-# the es/nl pilots); after that this and rules.yaml can carry baseline_ref.
+baseline_ref: baselines.eo

--- a/locales/eo/register.yaml
+++ b/locales/eo/register.yaml
@@ -1,0 +1,41 @@
+id: register.eo
+source: onetimesecret/locales/guides/for-translators/eo.md
+# Esperanto has effectively NO T/V (formal/informal) split to enforce. The 2nd-
+# person pronoun `vi` is universal: it serves singular, plural, formal, and
+# informal address alike. The archaic intimate `ci`/`cia` exists historically but
+# is essentially unused in modern Esperanto and appears NOWHERE in the live app
+# content (onetimesecret/locales/content/eo/*.json — 0 occurrences), while `vi`/
+# `via`/`vian`/`vin` appear pervasively (e.g. "Enigu vian pasvorton", "Via
+# sekreto estis sekure kreita", "Via privateco estas protektata"). The guide's
+# "Voice and Tone" section confirms this: "Use the formal 'vi' ... Esperanto does
+# not have a separate formal/informal distinction."
+#
+# Modelling the absent split: rather than `form: other` + a `register_spec`
+# extension (which suits graded systems like ja keigo / ko politeness, not a flat
+# single-pronoun language), this register uses `form: informal` — `vi` reads as
+# the warm, inclusive default the guide calls for — with `pronoun: vi` and
+# `possessive: [via]`. There is no register lock to enforce between two competing
+# 2nd-person forms because there is only one.
+#
+# forbidden_tokens is therefore not a T/V guard. Its single entry forbids the
+# archaic intimate `ci` so that no one regresses the content by introducing it.
+# It is scoped `standalone_word` deliberately: `ci` occurs as a substring inside
+# many valid Esperanto words, and even the demonstrative particle `ĉi` (with the
+# essential circumflex, per the guide's diacritics rule) is a distinct token, so
+# only the bare standalone pronoun is flagged. `cia` (the possessive) is added for
+# the same reason. severity: warning, not error — this is drift-prevention, not a
+# register violation between live alternatives.
+#
+# AGENT-AUTHORED; requires native/fluent-speaker (EO) sign-off — see PR label.
+form: informal
+pronoun: vi
+possessive: [via]
+forbidden_tokens:
+  - { token: ci,  context: standalone_word, severity: warning, note: "archaic intimate 2nd-person pronoun; never used in modern Esperanto — `vi` is universal. Guards against regression, not a live T/V alternative." }
+  - { token: cia, context: standalone_word, severity: warning, note: "archaic intimate possessive (companion to `ci`); use `via`." }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.eo is intentionally omitted — no `baselines.eo` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
+# human reviewer adds the pin to baselines.yaml centrally at commit time (as for
+# the es/nl pilots); after that this and rules.yaml can carry baseline_ref.

--- a/locales/eo/rules.yaml
+++ b/locales/eo/rules.yaml
@@ -1,0 +1,53 @@
+id: rules.eo
+source: onetimesecret/locales/guides/for-translators/eo.md
+inherits: base
+merge_strategy: append
+# Esperanto locale layer. eo is a standalone shipping language, so it inherits
+# `base` directly (no family parent). Transcribed from
+# onetimesecret/locales/guides/for-translators/eo.md and grounded against the live
+# app content in onetimesecret/locales/content/eo/*.json. Carries the Esperanto
+# conventions the guide standardised on: the universal `vi` address (no T/V
+# split), the pasvorto / sekreta frazo distinction, the essential circumflex
+# diacritics (never the x-system), the accusative -n on direct objects, and the
+# imperative-for-buttons / infinitive-for-labels verb-form convention.
+#
+# Every rule's rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live eo content;
+# requires native/fluent-speaker (EO) sign-off before merge — see PR label.
+rules:
+  - id: rule.eo-address-vi
+    modality: MUST
+    statement: Esperanto uses the single universal 2nd-person pronoun vi (via / vian / vin) for all address — singular, plural, formal, and informal alike; the archaic intimate ci / cia must not be introduced. Esperanto has no formal/informal split to enforce.
+    severity: warning
+    rule_ref: rule.register-lock
+  - id: rule.eo-passphrase-password
+    modality: MUST
+    statement: Keep pasvorto (account login / authentication credential) distinct from sekreta frazo (protection of an individual secret); never use one where the other is meant, and never coin "pasfrazo".
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.eo-burn-forbruligi
+    modality: MUST
+    statement: Translate burn / burned consistently as forbruligi (verb) and forbruligita (state / past participle), per the agreed Esperanto terminology; do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.eo-diacritics
+    modality: MUST
+    statement: Use the essential Esperanto circumflex letters ĉ ĝ ĥ ĵ ŝ ŭ literally; never substitute the x-system surrogates cx gx hx jx sx ux in production content.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.eo-accusative
+    modality: SHOULD
+    statement: Apply the accusative ending -n to direct objects (e.g. "Krei sekreton", "Enigu vian pasvorton"), but not after prepositions (e.g. "Kopii al tondujo").
+    severity: warning
+    rule_ref: rule.message-voice
+  - id: rule.eo-verb-forms
+    modality: SHOULD
+    statement: Use the imperative -u for buttons and actions (Ensalutu, Konservu, Konfirmu) and the infinitive -i for labels and descriptions (Kopii al tondujo, Forbruligi ĉi tiun sekreton).
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.eo
+glossary_ref: glossary.eo
+# baseline_ref: baselines.eo is intentionally omitted until a human reviewer adds
+# the `baselines.eo` entry to baselines.yaml centrally — a dangling reference
+# fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/eo/rules.yaml
+++ b/locales/eo/rules.yaml
@@ -48,6 +48,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.eo
 glossary_ref: glossary.eo
-# baseline_ref: baselines.eo is intentionally omitted until a human reviewer adds
-# the `baselines.eo` entry to baselines.yaml centrally — a dangling reference
-# fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.eo

--- a/locales/es/glossary.yaml
+++ b/locales/es/glossary.yaml
@@ -1,0 +1,177 @@
+id: glossary.es
+source: onetimesecret/locales/guides/for-translators/es.md
+# Sense-split of the core domain terminology from the Spanish translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/es.md),
+# grounded against the live app content in onetimesecret/locales/content/es/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (ES)
+# sign-off before merge — see PR label. Each `good` example uses the informal tú
+# register; each `bad` example demonstrates a forbidden form (the formal usted
+# register, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    es:
+      noun:
+        target: secreto
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created."
+        target: "Tu secreto ha sido creado."
+        verdict: good
+        note: "Informal possessive 'Tu' per the tú register; declarative voice for status."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created."
+        target: "Su secreto ha sido creado."
+        verdict: bad
+        note: "Formal possessive 'Su' (usted register) used for direct address — the forbidden formal register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    es:
+      noun:
+        target: frase de contraseña
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Introduce la frase de contraseña para ver este secreto."
+        verdict: good
+        note: "Informal imperative 'Introduce'; uses 'frase de contraseña', not 'contraseña'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Introduce la contraseña para ver este secreto."
+        verdict: bad
+        note: "Uses 'contraseña' (account credential) where 'frase de contraseña' (secret protection) is meant — violates rule.es-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    es:
+      noun:
+        target: contraseña
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Introduce tu contraseña para iniciar sesión."
+        verdict: good
+        note: "Informal imperative 'Introduce' plus informal possessive 'tu'; 'iniciar sesión' per the UI glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Introduzca su contraseña para iniciar sesión."
+        verdict: bad
+        note: "Formal imperative 'Introduzca' plus formal possessive 'su' — the forbidden usted register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb form for the action label, past participle for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    es:
+      verb:
+        target: destruir
+        rule_ref: rule.terminology-consistency
+      state:
+        target: destruido
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Destruir este secreto antes de que sea leído."
+        verdict: good
+        note: "Infinitive 'Destruir' for the button label, per the guide's burn -> destruir choice."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Quemar este secreto antes de que sea leído."
+        verdict: bad
+        note: "Uses 'Quemar' instead of the glossary term 'destruir' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    es:
+      noun:
+        target: enlace
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Copia el enlace secreto para compartirlo."
+        verdict: good
+        note: "Informal imperative 'Copia'; uses 'enlace' per the glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Copie el enlace secreto para compartirlo."
+        verdict: bad
+        note: "Formal imperative 'Copie' (usted register) instead of informal 'Copia' — the forbidden formal register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'cifrar', past participle 'cifrado' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    es:
+      verb:
+        target: cifrar
+        rule_ref: rule.terminology-consistency
+      state:
+        target: cifrado
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Este mensaje está cifrado con tu frase de contraseña."
+        verdict: good
+        note: "Grounded in live content; informal possessive 'tu', 'cifrado' for the encrypted state."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Este mensaje está encriptado con su frase de contraseña."
+        verdict: bad
+        note: "Uses 'encriptado' instead of the established security term 'cifrado', plus formal possessive 'su' (usted register)."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    es:
+      noun:
+        target: correo electrónico
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Introduce tu dirección de correo electrónico."
+        verdict: good
+        note: "Grounded in live content; informal imperative 'Introduce' plus informal possessive 'tu'."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Introduzca su dirección de correo electrónico."
+        verdict: bad
+        note: "Formal imperative 'Introduzca' plus formal possessive 'su' — the forbidden usted register."

--- a/locales/es/register.yaml
+++ b/locales/es/register.yaml
@@ -28,8 +28,4 @@ forbidden_tokens:
   - { token: ustedes, context: standalone_word, severity: error, note: "formal subject/object pronoun (plural) — the register es does NOT use" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.es is intentionally omitted — no `baselines.es` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the `fr`/`de_AT` baselines entries), after which this and rules.yaml
-# can carry `baseline_ref: baselines.es`.
+baseline_ref: baselines.es

--- a/locales/es/register.yaml
+++ b/locales/es/register.yaml
@@ -1,0 +1,35 @@
+id: register.es
+source: onetimesecret/locales/guides/for-translators/es.md
+# Spanish is locked to the INFORMAL tú register. Grounded in the live app content
+# (onetimesecret/locales/content/es/*.json): direct address consistently uses the
+# informal tú forms — informal possessives tu/tus (e.g. "Introduce tu contraseña",
+# "Tu mensaje seguro ha sido entregado.", "Todos tus secretos serán eliminados"),
+# informal object/prepositional pronouns te/ti/contigo, and informal imperatives
+# and clitics (Introduce, Asegúrate, inténtalo, ¿Olvidaste...?, Puedes, Estás).
+# Zero standalone usted/ustedes appear anywhere in the live content. The prose
+# guide agrees: §4 "Direct Address (Tú vs. Usted)" and Principle #4 both record
+# the informal tú form. So the FORBIDDEN register is the formal usted register;
+# the forbidden tokens are the formal address pronouns usted / ustedes.
+#
+# Deliberately NOT forbidden: the formal possessive su/sus. In Spanish su/sus is
+# also the ordinary 3rd-person possessive and appears legitimately in the live
+# content referring to third parties, not as a formal direct address — e.g.
+# "Se notificará al remitente que su secreto fue visto", "su propia
+# infraestructura", "en su lugar". Forbidding su/sus would flag valid 3rd-person
+# prose, so it is left out (cf. the prompt's warning not to forbid a token that
+# appears in valid words). usted/ustedes have no such ambiguity.
+#
+# AGENT-AUTHORED; requires native-speaker (ES) sign-off — see PR label.
+form: informal
+pronoun: tú
+possessive: [tu, tus]
+forbidden_tokens:
+  - { token: usted,   context: standalone_word, severity: error, note: "formal subject/object pronoun (singular) — the register es does NOT use" }
+  - { token: ustedes, context: standalone_word, severity: error, note: "formal subject/object pronoun (plural) — the register es does NOT use" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.es is intentionally omitted — no `baselines.es` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the `fr`/`de_AT` baselines entries), after which this and rules.yaml
+# can carry `baseline_ref: baselines.es`.

--- a/locales/es/rules.yaml
+++ b/locales/es/rules.yaml
@@ -28,6 +28,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.es
 glossary_ref: glossary.es
-# baseline_ref: baselines.es is intentionally omitted until a human reviewer adds
-# the `baselines.es` entry to baselines.yaml centrally — a dangling reference
-# fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.es

--- a/locales/es/rules.yaml
+++ b/locales/es/rules.yaml
@@ -1,0 +1,33 @@
+id: rules.es
+source: onetimesecret/locales/guides/for-translators/es.md
+inherits: base
+merge_strategy: append
+# Spanish locale layer. es is a standalone shipping language, so it inherits
+# `base` directly (no family parent). Carries the Spanish conventions transcribed
+# from onetimesecret/locales/guides/for-translators/es.md: the informal tú
+# register lock, the contraseña / frase de contraseña distinction, and the
+# burn -> destruir terminology choice the guide standardised on.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live es content;
+# requires native-speaker (ES) sign-off before merge — see PR label.
+rules:
+  - id: rule.es-register-informal
+    modality: MUST
+    statement: Spanish content uses the informal tú register (tú / tu / tus / te / ti) throughout product UI and email content; the formal usted register (usted / ustedes) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.es-passphrase-password
+    modality: MUST
+    statement: Keep contraseña (account login / authentication credential) distinct from frase de contraseña (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.es-burn-destruir
+    modality: MUST
+    statement: Translate burn / burned consistently as destruir (verb) and destruido (state / past participle), per the agreed Spanish terminology; do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+register_ref: register.es
+glossary_ref: glossary.es
+# baseline_ref: baselines.es is intentionally omitted until a human reviewer adds
+# the `baselines.es` entry to baselines.yaml centrally — a dangling reference
+# fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/fr/glossary.yaml
+++ b/locales/fr/glossary.yaml
@@ -1,0 +1,167 @@
+id: glossary.fr
+source: onetimesecret/locales/guides/for-translators/fr.md
+# Sense-split of the core domain terminology from the French translator guide's
+# terminology tables, grounded against the live app content in
+# onetimesecret/locales/content/fr_FR/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (FR) sign-off before merge — see PR
+# label. Each `good` example uses the formal vous register; each `bad` example
+# demonstrates a forbidden form (informal tutoiement, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    fr:
+      noun:
+        target: secret
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Votre secret a été créé."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.secret-informal-bad#250567fe
+        source: "Your secret has been created."
+        target: "Ton secret a été créé."
+        verdict: bad
+        note: "Informal possessive 'Ton' — the forbidden tutoiement register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects a secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    fr:
+      noun:
+        target: phrase secrète
+        rule_ref: rule.fr-passphrase-password
+    rule_refs: [register.fr.formality, rule.fr-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Saisissez la phrase secrète pour consulter ce secret."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Saisissez le mot de passe pour consulter ce secret."
+        verdict: bad
+        note: "Uses 'mot de passe' (login credential) where 'phrase secrète' (secret protection) is meant — violates rule.fr-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    fr:
+      noun:
+        target: mot de passe
+        rule_ref: rule.fr-passphrase-password
+    rule_refs: [register.fr.formality, rule.fr-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Saisissez votre mot de passe pour vous connecter."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Saisis ton mot de passe pour te connecter."
+        verdict: bad
+        note: "Informal imperative 'Saisis' plus 'ton' and 'te' — forbidden tutoiement register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb form for the action label, past participle for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    fr:
+      verb:
+        target: brûler
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Brûler ce secret avant qu'il ne soit lu."
+        verdict: good
+        note: "Infinitive 'Brûler' for the button label, per rule.fr-infinitive-buttons."
+        rule_refs: [register.fr.formality, rule.fr-infinitive-buttons]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Détruire ce secret avant qu'il ne soit lu."
+        verdict: bad
+        note: "Uses 'Détruire' instead of the glossary term 'brûler' — terminology drift."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    fr:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Saisissez votre adresse e-mail."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Saisis ton adresse e-mail."
+        verdict: bad
+        note: "Informal 'Saisis' plus 'ton' — forbidden tutoiement register."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    fr:
+      noun:
+        target: lien
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Copiez le lien secret pour le partager."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Copie ton lien secret pour le partager."
+        verdict: bad
+        note: "Informal imperative 'Copie' plus 'ton' — forbidden tutoiement register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'chiffrer', past participle 'chiffré' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    fr:
+      verb:
+        target: chiffrer
+        rule_ref: rule.terminology-consistency
+      state:
+        target: chiffré
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Ce message est chiffré avec votre phrase secrète."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Ce message est crypté avec ta phrase secrète."
+        verdict: bad
+        note: "Uses 'crypté' (deprecated/incorrect in security French) instead of 'chiffré', plus informal 'ta'."

--- a/locales/fr/register.yaml
+++ b/locales/fr/register.yaml
@@ -1,0 +1,22 @@
+id: register.fr
+source: onetimesecret/locales/guides/for-translators/fr.md
+# French is locked to the formal vous register. Grounded in the live app content
+# (onetimesecret/locales/content/fr_FR/*.json and fr_CA/*.json): every string uses
+# vous/votre/vos (e.g. "Inscrivez-vous", "votre compte", "vos identifiants") and
+# zero standalone informal tutoiement tokens appear. This mirrors de_AT's Sie-lock:
+# the informal tu/ton/ta/tes/toi/te forms become forbidden standalone-word tokens.
+# AGENT-AUTHORED; requires native-speaker (FR) sign-off — see PR label.
+form: formal
+pronoun: vous
+possessive: [votre, vos]
+forbidden_tokens:
+  - { token: tu,  context: standalone_word, severity: error, note: "informal subject pronoun" }
+  - { token: ton, context: standalone_word, severity: error, note: "informal possessive (masc.)" }
+  - { token: ta,  context: standalone_word, severity: error, note: "informal possessive (fem.)" }
+  - { token: tes, context: standalone_word, severity: error, note: "informal possessive (plural)" }
+  - { token: toi, context: standalone_word, severity: error, note: "informal stressed pronoun" }
+  - { token: te,  context: standalone_word, severity: error, note: "informal object pronoun (non-contracted)" }
+  - { token: toi-même, context: standalone_word, severity: error, note: "informal reflexive" }
+exceptions: []
+rule_ref: register.fr.formality
+baseline_ref: baselines.fr

--- a/locales/fr/register.yaml
+++ b/locales/fr/register.yaml
@@ -17,6 +17,8 @@ forbidden_tokens:
   - { token: toi, context: standalone_word, severity: error, note: "informal stressed pronoun" }
   - { token: te,  context: standalone_word, severity: error, note: "informal object pronoun (non-contracted)" }
   - { token: toi-même, context: standalone_word, severity: error, note: "informal reflexive" }
+  - { token: "t'", context: word_prefix, severity: error, note: "elided informal object/reflexive pronoun (t'envoie, t'inscrire)" }
+  - { token: "t’", context: word_prefix, severity: error, note: "elided informal pronoun, curly apostrophe (U+2019)" }
 exceptions: []
 rule_ref: register.fr.formality
 baseline_ref: baselines.fr

--- a/locales/fr/rules.yaml
+++ b/locales/fr/rules.yaml
@@ -1,0 +1,37 @@
+id: rules.fr
+source: onetimesecret/locales/guides/for-translators/fr.md
+inherits: base
+merge_strategy: append
+# French-wide layer (base-inheriting family parent), mirroring locales/de/rules.yaml
+# but populated because `fr` is itself a shipping locale, not just an inheritance
+# stub. Carries the French conventions shared by every fr_* variant: the formal
+# vous register, the French double-punctuation spacing rule, the infinitive-for-
+# buttons rule, and the mot de passe / phrase secrète distinction. Regional
+# variants (fr_CA) inherit this and add only their deltas.
+#
+# AGENT-AUTHORED transcription of onetimesecret/locales/guides/for-translators/fr.md;
+# requires native-speaker (FR) sign-off before merge — see PR label.
+rules:
+  - id: register.fr.formality
+    modality: MUST
+    statement: French content uses the formal vous register (vous / votre / vos) throughout product UI and email content; informal tutoiement (tu / ton / ta / tes) is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.fr-punctuation-nbsp
+    modality: MUST
+    statement: Place a non-breaking space before the double punctuation marks `:` `;` `!` `?`, per French typographic convention.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.fr-infinitive-buttons
+    modality: MUST
+    statement: Use the infinitive for button and link labels (Mettre à niveau), and the noun form for titles and headings (Mise à niveau).
+    severity: warning
+    rule_ref: rule.message-voice
+  - id: rule.fr-passphrase-password
+    modality: MUST
+    statement: Keep mot de passe (system authentication / login) distinct from phrase secrète (protection of a secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+register_ref: register.fr
+glossary_ref: glossary.fr
+baseline_ref: baselines.fr

--- a/locales/fr_CA/glossary.yaml
+++ b/locales/fr_CA/glossary.yaml
@@ -1,0 +1,57 @@
+id: glossary.fr_CA
+source: onetimesecret/locales/guides/for-translators/fr_CA.md
+# Canadian French glossary. The resolver loads glossary per-locale and does NOT
+# merge it across the rules inheritance chain, so this file carries the fr_CA
+# terms directly rather than relying on glossary.fr inheritance. The substantive
+# DELTA from fr is the email term: fr_CA locks "courriel" (grounded in the live
+# fr_CA app content, which uses "courriel" throughout — e.g. "Adresse courriel",
+# "votre boîte de courriel"), whereas fr uses the European "e-mail". The secret
+# anchor term is restated here to demonstrate the shared core under the fr_CA
+# register. Every other core term is unchanged from glossary.fr and is governed by
+# the inherited rules.fr / register.fr.formality.
+# AGENT-AUTHORED; requires native-speaker (CA) sign-off before merge — see PR label.
+terms:
+  - id: term.email_ca#287480a5
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. In Canadian French this is 'courriel', never the European 'e-mail'."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    fr_CA:
+      noun:
+        target: courriel
+        rule_ref: rule.fr_CA-courriel
+    rule_refs: [register.fr.formality, rule.fr_CA-courriel]
+    examples:
+      - id: ex.email-ca-good#75bba47a
+        source: "Enter your email address."
+        target: "Saisissez votre adresse courriel."
+        verdict: good
+        rule_refs: [register.fr.formality, rule.fr_CA-courriel]
+      - id: ex.email-ca-bad#b8f4c2e2
+        source: "Enter your email address."
+        target: "Saisissez votre adresse e-mail."
+        verdict: bad
+        note: "Uses the European 'e-mail' instead of the Canadian 'courriel' — violates rule.fr_CA-courriel."
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application; identical to fr."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    fr_CA:
+      noun:
+        target: secret
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.fr.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Votre secret a été créé."
+        verdict: good
+        rule_refs: [register.fr.formality]
+      - id: ex.secret-informal-bad#250567fe
+        source: "Your secret has been created."
+        target: "Ton secret a été créé."
+        verdict: bad
+        note: "Informal possessive 'Ton' — the forbidden tutoiement register (shared with fr)."

--- a/locales/fr_CA/glossary.yaml
+++ b/locales/fr_CA/glossary.yaml
@@ -1,14 +1,13 @@
 id: glossary.fr_CA
 source: onetimesecret/locales/guides/for-translators/fr_CA.md
-# Canadian French glossary. The resolver loads glossary per-locale and does NOT
-# merge it across the rules inheritance chain, so this file carries the fr_CA
-# terms directly rather than relying on glossary.fr inheritance. The substantive
-# DELTA from fr is the email term: fr_CA locks "courriel" (grounded in the live
-# fr_CA app content, which uses "courriel" throughout — e.g. "Adresse courriel",
-# "votre boîte de courriel"), whereas fr uses the European "e-mail". The secret
-# anchor term is restated here to demonstrate the shared core under the fr_CA
-# register. Every other core term is unchanged from glossary.fr and is governed by
-# the inherited rules.fr / register.fr.formality.
+# Canadian French glossary — delta-only. The resolver merges glossaries along
+# the rules inheritance chain (ADR-001), keying by term `key`, so this file
+# only needs to carry terms that differ from fr. Every inherited fr term
+# (secret_object, passphrase, password, burn, link, encrypt) flows through
+# unchanged; only `email` is overridden to "courriel" (grounded in the live
+# fr_CA app content — "Adresse courriel", "votre boîte de courriel" —
+# whereas fr uses the European "e-mail"). All inherited terms remain governed
+# by rules.fr / register.fr.formality.
 # AGENT-AUTHORED; requires native-speaker (CA) sign-off before merge — see PR label.
 terms:
   - id: term.email_ca#287480a5
@@ -33,25 +32,3 @@ terms:
         target: "Saisissez votre adresse e-mail."
         verdict: bad
         note: "Uses the European 'e-mail' instead of the Canadian 'courriel' — violates rule.fr_CA-courriel."
-  - id: term.secret_object#c0902808
-    key: secret_object
-    en: secret
-    disambiguation:
-      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application; identical to fr."
-      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
-    fr_CA:
-      noun:
-        target: secret
-        rule_ref: rule.terminology-consistency
-    rule_refs: [register.fr.formality, rule.terminology-consistency]
-    examples:
-      - id: ex.secret-created-good#0492a4bc
-        source: "Your secret has been created."
-        target: "Votre secret a été créé."
-        verdict: good
-        rule_refs: [register.fr.formality]
-      - id: ex.secret-informal-bad#250567fe
-        source: "Your secret has been created."
-        target: "Ton secret a été créé."
-        verdict: bad
-        note: "Informal possessive 'Ton' — the forbidden tutoiement register (shared with fr)."

--- a/locales/fr_CA/register.yaml
+++ b/locales/fr_CA/register.yaml
@@ -1,0 +1,24 @@
+id: register.fr_CA
+source: onetimesecret/locales/guides/for-translators/fr_CA.md
+# Canadian French register. fr_CA shares fr's formal vous lock — there is NO
+# formality delta between fr and fr_CA (the guides are identical on register, and
+# the live fr_CA app content uses vous/votre/vos with zero standalone tutoiement).
+# This file is self-contained because the resolver loads register per-locale and
+# does NOT merge it across the rules inheritance chain (only rules.yaml inherits);
+# so fr_CA must restate the lock to keep .resolved/fr_CA.json's register populated.
+# Mirrors locales/de_AT/register.yaml, which is likewise self-contained.
+# AGENT-AUTHORED; requires native-speaker (CA) sign-off before merge — see PR label.
+form: formal
+pronoun: vous
+possessive: [votre, vos]
+forbidden_tokens:
+  - { token: tu,  context: standalone_word, severity: error, note: "informal subject pronoun" }
+  - { token: ton, context: standalone_word, severity: error, note: "informal possessive (masc.)" }
+  - { token: ta,  context: standalone_word, severity: error, note: "informal possessive (fem.)" }
+  - { token: tes, context: standalone_word, severity: error, note: "informal possessive (plural)" }
+  - { token: toi, context: standalone_word, severity: error, note: "informal stressed pronoun" }
+  - { token: te,  context: standalone_word, severity: error, note: "informal object pronoun (non-contracted)" }
+  - { token: toi-même, context: standalone_word, severity: error, note: "informal reflexive" }
+exceptions: []
+rule_ref: register.fr.formality
+baseline_ref: baselines.fr_CA

--- a/locales/fr_CA/register.yaml
+++ b/locales/fr_CA/register.yaml
@@ -19,6 +19,8 @@ forbidden_tokens:
   - { token: toi, context: standalone_word, severity: error, note: "informal stressed pronoun" }
   - { token: te,  context: standalone_word, severity: error, note: "informal object pronoun (non-contracted)" }
   - { token: toi-même, context: standalone_word, severity: error, note: "informal reflexive" }
+  - { token: "t'", context: word_prefix, severity: error, note: "elided informal object/reflexive pronoun (t'envoie, t'inscrire)" }
+  - { token: "t’", context: word_prefix, severity: error, note: "elided informal pronoun, curly apostrophe (U+2019)" }
 exceptions: []
 rule_ref: register.fr.formality
 baseline_ref: baselines.fr_CA

--- a/locales/fr_CA/rules.yaml
+++ b/locales/fr_CA/rules.yaml
@@ -1,0 +1,20 @@
+id: rules.fr_CA
+source: onetimesecret/locales/guides/for-translators/fr_CA.md
+inherits: rules.fr
+merge_strategy: append
+# Canadian French layer. Inherits every French-wide rule from rules.fr (formal
+# vous register, non-breaking-space punctuation, infinitive buttons, mot de passe
+# vs phrase secrète) and adds ONLY the fr_CA delta: the email term is locked to
+# "courriel", not the European "e-mail". Grounded in the live app content
+# (onetimesecret/locales/content/fr_CA/*.json uses "courriel" throughout, vs
+# fr_FR/*.json which uses "e-mail"). AGENT-AUTHORED; requires native-speaker (CA)
+# sign-off before merge — see PR label.
+rules:
+  - id: rule.fr_CA-courriel
+    modality: MUST
+    statement: Canadian French uses "courriel" for email throughout UI and email content; the European "e-mail" form is not used in fr_CA.
+    severity: error
+    rule_ref: rule.terminology-consistency
+register_ref: register.fr_CA
+glossary_ref: glossary.fr_CA
+baseline_ref: baselines.fr_CA

--- a/locales/fr_FR/glossary.yaml
+++ b/locales/fr_FR/glossary.yaml
@@ -1,0 +1,15 @@
+id: glossary.fr_FR
+source: onetimesecret/locales/guides/for-translators/fr_FR.md
+# France French glossary — intentionally empty (no regional term delta). The
+# resolver merges glossaries along the rules inheritance chain (ADR-001), keying
+# by term `key`, so an empty child inherits the full fr terminology unchanged:
+# secret_object, passphrase (phrase secrète), password (mot de passe), burn
+# (brûler), email (e-mail), link (lien), encrypt (chiffrer/chiffré) — 7 terms.
+# fr_FR is metropolitan French and the fr parent's defaults ARE the fr_FR forms
+# (the fr.md/fr_FR.md guides are identical and glossary.fr was grounded against
+# the live fr_FR content). In particular email stays "e-mail": the live
+# onetimesecret/locales/content/fr_FR/*.json uses "e-mail" 131 times and
+# "courriel" 0 times — so unlike fr_CA there is NO email override here.
+# All inherited terms remain governed by rules.fr / register.fr.formality.
+# AGENT-AUTHORED; requires native-speaker (FR) sign-off before merge — see PR label.
+terms: []

--- a/locales/fr_FR/register.yaml
+++ b/locales/fr_FR/register.yaml
@@ -24,5 +24,4 @@ forbidden_tokens:
   - { token: "t’", context: word_prefix, severity: error, note: "elided informal pronoun, curly apostrophe (U+2019)" }
 exceptions: []
 rule_ref: register.fr.formality
-# baseline_ref deferred: baselines.fr_FR is pinned centrally by the reviewer
-# (mirrors locales/fr_CA/register.yaml's deferred-baseline handling).
+baseline_ref: baselines.fr_FR

--- a/locales/fr_FR/register.yaml
+++ b/locales/fr_FR/register.yaml
@@ -1,0 +1,28 @@
+id: register.fr_FR
+source: onetimesecret/locales/guides/for-translators/fr_FR.md
+# France French register. fr_FR shares fr's formal vous lock with NO formality
+# delta (the fr.md and fr_FR.md guides are identical on register, and the live
+# fr_FR app content uses vous/votre/vos — "Inscrivez-vous", "votre compte",
+# "vos identifiants" — with zero standalone tutoiement tokens). This file is
+# self-contained because the resolver loads register per-locale and does NOT
+# merge it across the rules inheritance chain (only rules.yaml inherits); so
+# fr_FR must restate the lock to keep .resolved/fr_FR.json's register populated.
+# Mirrors locales/fr_CA/register.yaml, which is likewise self-contained.
+# AGENT-AUTHORED; requires native-speaker (FR) sign-off before merge — see PR label.
+form: formal
+pronoun: vous
+possessive: [votre, vos]
+forbidden_tokens:
+  - { token: tu,  context: standalone_word, severity: error, note: "informal subject pronoun" }
+  - { token: ton, context: standalone_word, severity: error, note: "informal possessive (masc.)" }
+  - { token: ta,  context: standalone_word, severity: error, note: "informal possessive (fem.)" }
+  - { token: tes, context: standalone_word, severity: error, note: "informal possessive (plural)" }
+  - { token: toi, context: standalone_word, severity: error, note: "informal stressed pronoun" }
+  - { token: te,  context: standalone_word, severity: error, note: "informal object pronoun (non-contracted)" }
+  - { token: toi-même, context: standalone_word, severity: error, note: "informal reflexive" }
+  - { token: "t'", context: word_prefix, severity: error, note: "elided informal object/reflexive pronoun (t'envoie, t'inscrire)" }
+  - { token: "t’", context: word_prefix, severity: error, note: "elided informal pronoun, curly apostrophe (U+2019)" }
+exceptions: []
+rule_ref: register.fr.formality
+# baseline_ref deferred: baselines.fr_FR is pinned centrally by the reviewer
+# (mirrors locales/fr_CA/register.yaml's deferred-baseline handling).

--- a/locales/fr_FR/rules.yaml
+++ b/locales/fr_FR/rules.yaml
@@ -15,5 +15,4 @@ merge_strategy: append
 rules: []
 register_ref: register.fr_FR
 glossary_ref: glossary.fr_FR
-# baseline_ref deferred: baselines.fr_FR is pinned centrally by the reviewer
-# (mirrors locales/fr_CA/register.yaml's deferred-baseline handling).
+baseline_ref: baselines.fr_FR

--- a/locales/fr_FR/rules.yaml
+++ b/locales/fr_FR/rules.yaml
@@ -1,0 +1,19 @@
+id: rules.fr_FR
+source: onetimesecret/locales/guides/for-translators/fr_FR.md
+inherits: rules.fr
+merge_strategy: append
+# France French layer. fr_FR is "metropolitan/European French" — the fr family
+# parent was authored largely FROM fr_FR content (the fr.md and fr_FR.md guides
+# are byte-identical, and the live onetimesecret/locales/content/fr_FR/*.json is
+# what grounds glossary.fr / register.fr). It therefore carries NO genuine
+# regional delta: every French-wide rule from rules.fr applies unchanged
+# (formal vous register, non-breaking-space punctuation, infinitive buttons,
+# mot de passe vs phrase secrète, and email -> "e-mail"). Unlike fr_CA — whose
+# delta is email -> "courriel" — fr_FR adds no override rules; it is pure
+# inheritance. Mirrors locales/fr_CA/rules.yaml structurally, minus the delta.
+# AGENT-AUTHORED; requires native-speaker (FR) sign-off before merge — see PR label.
+rules: []
+register_ref: register.fr_FR
+glossary_ref: glossary.fr_FR
+# baseline_ref deferred: baselines.fr_FR is pinned centrally by the reviewer
+# (mirrors locales/fr_CA/register.yaml's deferred-baseline handling).

--- a/locales/he/glossary.yaml
+++ b/locales/he/glossary.yaml
@@ -1,0 +1,185 @@
+id: glossary.he
+source: onetimesecret/locales/guides/for-translators/he.md
+# Sense-split of the core domain terminology from the Hebrew translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/he.md), grounded
+# against the live app content in onetimesecret/locales/content/he/*.json. Targets and
+# worked examples are AGENT-AUTHORED and require native-speaker (HE) sign-off before
+# merge — see PR label. Each `good` example uses the masculine-default register
+# (masculine singular address); each `bad` example demonstrates either the forbidden
+# feminine singular register or the wrong term.
+#
+# RTL / prefix lint note: the resolver matches sense targets with word_prefix on alnum
+# word boundaries, and Hebrew letters ARE alnum. A target term carrying a proclitic
+# (ה/ו/ב/ל/מ/ש), e.g. הסוד / לקישור / בדוא״ל, does NOT begin at a word boundary, so it
+# would FAIL the "good example must contain a sense target" check. Every `good` example
+# below therefore places the term's sense target in a BARE citation form at a word
+# boundary (preceded by a space or string start); the plural suffix (סודות) is fine
+# because word_prefix allows any suffix.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Masculine gender (הסוד נוצר)."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    he:
+      noun:
+        target: סוד
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created. Create another secret."
+        target: "הסוד שלך נוצר. צור סוד נוסף."
+        verdict: good
+        note: "Masculine singular imperative 'צור'; declarative past 'נוצר' for status. Bare סוד present at a word boundary so the sense-target check passes."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created. Create another secret."
+        target: "הסוד שלך נוצר. צרי סוד נוסף."
+        verdict: bad
+        note: "Feminine singular imperative 'צרי' for direct address — the forbidden feminine register (masculine default is צור)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    he:
+      noun:
+        target: ביטוי סיסמה
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "הזן ביטוי סיסמה כדי לצפות בסוד זה."
+        verdict: good
+        note: "Masculine singular imperative 'הזן'; uses 'ביטוי סיסמה' (live form), not bare 'סיסמה'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "הזן סיסמה כדי לצפות בסוד זה."
+        verdict: bad
+        note: "Uses 'סיסמה' (account credential) where 'ביטוי סיסמה' (secret protection) is meant — violates rule.he-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase, feminine). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    he:
+      noun:
+        target: סיסמה
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in. Create a random password."
+        target: "הזן את הסיסמה שלך כדי להתחבר. צור סיסמה אקראית."
+        verdict: good
+        note: "Masculine singular imperatives 'הזן' / 'צור' / 'התחבר'; bare 'סיסמה' present at a word boundary. Grounded in live content ('או צור סיסמה אקראית')."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in. Create a random password."
+        target: "הזיני את הסיסמה שלך כדי להתחבר. צרי סיסמה אקראית."
+        verdict: bad
+        note: "Feminine singular imperatives 'הזיני' / 'צרי' for direct address — the forbidden feminine register (masculine default is הזן / צור)."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "Permanently deleting a secret before it is viewed. Noun phrase מחיקה סופית for the feature/action, past participle נמחק (סופית) for the resulting state. Not a literal 'fire/burn' rendering."
+      key_patterns: ["*burn*", "*.destroy*"]
+    he:
+      action:
+        target: מחיקה סופית
+        rule_ref: rule.terminology-consistency
+      state:
+        target: נמחק
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "מחיקה סופית של סוד זה לפני שייקרא."
+        verdict: good
+        note: "Uses the agreed 'מחיקה סופית' (permanent deletion); bare סוד at a word boundary. Grounded in live content ('מחיקה סופית')."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "שריפה של סוד זה לפני שייקרא."
+        verdict: bad
+        note: "Uses literal 'שריפה' (combustion/fire) instead of the glossary term 'מחיקה סופית' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Masculine gender (קישור)."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    he:
+      noun:
+        target: קישור
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "העתק את הקישור הסודי כדי לשתף קישור זה."
+        verdict: good
+        note: "Masculine singular imperative 'העתק'; bare קישור present at a word boundary. Grounded in live content ('העתק והדבק קישור זה')."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "העתיקי את הקישור הסודי כדי לשתף קישור זה."
+        verdict: bad
+        note: "Feminine singular imperative 'העתיקי' for direct address — the forbidden feminine register (masculine default is העתק)."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; noun/verbal-noun הצפנה for the act, past participle מוצפן for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    he:
+      action:
+        target: הצפנה
+        rule_ref: rule.terminology-consistency
+      state:
+        target: מוצפן
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "הודעה זו מוצפן בביטוי סיסמה שלך."
+        verdict: good
+        note: "Uses the encrypted-state term 'מוצפן' at a word boundary. Grounded in live content ('מוצפן בהעברה ובמנוחה'). (Native reviewer: confirm gender agreement מוצפנת for ההודעה.)"
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "הודעה זו אנקריפטד בביטוי סיסמה שלך."
+        verdict: bad
+        note: "Uses a transliterated 'אנקריפטד' instead of the established Hebrew security term 'מוצפן' — terminology drift."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Abbreviated דוא״ל (with gershayim) or full דואר אלקטרוני."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    he:
+      noun:
+        target: דוא״ל
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "If an account exists with this email, you will receive a verification message."
+        target: "אם קיים חשבון עם דוא״ל זה, תקבל הודעת אימות."
+        verdict: good
+        note: "Masculine future 'תקבל' (you will receive); bare 'דוא״ל' with gershayim ״ at a word boundary. Grounded in live content verbatim."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "If an account exists with this email, you will receive a verification message."
+        target: "אם קיים חשבון עם דוא״ל זה, תקבלי הודעת אימות."
+        verdict: bad
+        note: "Feminine future 'תקבלי' (you-fem will receive) for direct address — the forbidden feminine register (masculine default is תקבל)."

--- a/locales/he/register.yaml
+++ b/locales/he/register.yaml
@@ -1,0 +1,91 @@
+id: register.he
+source: onetimesecret/locales/guides/for-translators/he.md
+# Hebrew has essentially NO T/V formality split — it is informal/direct by default,
+# so form: other (not formal|informal|mixed in the T/V sense). The DEFINING register
+# dimension for Hebrew is the GRAMMATICAL GENDER of 2nd-person address: masculine
+# (אתה, verbs like הזן/לחץ/בחר, possessive -ך realised in masc agreement) vs feminine
+# (את, verbs like הזיני/לחצי/בחרי). The app must pick a policy; this is the core
+# deliverable. PILOT shape borrowed from locales/ja (form: other + register_spec).
+#
+# GENDER POLICY: masculine_default. Determined from the LIVE app content
+# (onetimesecret/locales/content/he/*.json), not invented:
+#   - 2nd-person SINGULAR IMPERATIVES are masculine across every common UI verb:
+#     הזן (enter) ×25, לחץ (click) ×10, בחר (choose) ×18, העתק (copy) ×12,
+#     שלח (send) ×57, צור (create) ×16 as a bare button label, התחבר (sign in) ×64,
+#     מחק (delete) ×33, שמור (save) ×12, אשר (confirm) ×18, נסה (try) ×25, ודא ×8.
+#   - The masculine 2nd-person pronoun אתה appears ×18 standalone (e.g. "האם אתה
+#     בטוח שברצונך למחוק סוד זה"); masc future תוכל appears for "you can".
+#   - There are ZERO genuine feminine 2nd-person SINGULAR forms in the live content.
+#     Apparent matches (צרי, נסי, שלחי, ערכי) are ALL false positives — substrings of
+#     unrelated words: צרי⊂צריך/צריכה (need), נסי⊂נכנסים (enter,pl)/נסיבות,
+#     שלחי⊂ונשלחים (are sent), ערכי⊂ערכים (values). Verified by inspecting the
+#     surrounding word for every hit.
+#   - The prose guide agrees explicitly: §"Voice and Tone" / §"Common Translation
+#     Patterns" record "Use masculine singular imperative for buttons (standard in
+#     Hebrew UI)" and gender-agreement examples keyed to masculine address.
+#   NOTE: the live content also uses some masculine-PLURAL / impersonal phrasing
+#   (e.g. אבטחו, צרו, שלחו, שלכם) in marketing/multi-recipient copy. That is a softer,
+#   gender-spanning style, not the feminine SINGULAR register — it is NOT forbidden;
+#   the lock is specifically: do not address a single user in the FEMININE singular.
+#
+# forbidden_tokens — the non-chosen gender (feminine 2nd-sg) forms, but ONLY the ones
+# that tokenize with ZERO false positives in the live content. Each token below was
+# verified to have zero occurrences anywhere in he/*.json (neither standalone nor as a
+# substring of any other word), so flagging them cannot misfire:
+#   הזיני / הקלידי / לחצי / בחרי / העתיקי / התחברי / הירשמי / תוכלי.
+# DELIBERATELY LEFT OUT (cannot be safely tokenized — would false-positive):
+#   - את  — feminine "you", but identical spelling to the ubiquitous direct-OBJECT
+#     marker את (×222, e.g. "למחוק את הסוד"); even standalone_word would flag every
+#     valid object marker. Locked via register_spec + rule.he-register-gender instead.
+#   - -ך (2nd-sg possessive suffix) and שלך ("your") are written IDENTICALLY for
+#     masculine and feminine in unvocalized Modern Hebrew, so they carry no gender
+#     signal and cannot be forbidden.
+# RTL / prefixed-particle note: Hebrew is RTL but the resolver matches in logical
+# (memory) order on alnum word boundaries; Hebrew letters ARE alnum, so prefixed
+# particles ה/ו/ב/ל/מ/ש attach to the following word and defeat word/standalone
+# boundaries. The feminine tokens above are full inflected imperatives that never
+# take those proclitics in this corpus, so standalone_word is safe for them.
+#
+# AGENT-AUTHORED; requires native-speaker (HE) sign-off — esp. the gender decision.
+form: other
+pronoun: "את/אתה (masculine default — single user addressed in masculine singular)"
+forbidden_tokens:
+  - { token: הזיני,   context: standalone_word, severity: error, note: "feminine sg imperative 'enter'; masculine default is הזן — zero live hits" }
+  - { token: הקלידי,  context: standalone_word, severity: error, note: "feminine sg imperative 'type'; masculine default is הקלד — zero live hits" }
+  - { token: לחצי,    context: standalone_word, severity: error, note: "feminine sg imperative 'click'; masculine default is לחץ — zero live hits" }
+  - { token: בחרי,    context: standalone_word, severity: error, note: "feminine sg imperative 'choose'; masculine default is בחר — zero live hits" }
+  - { token: העתיקי,  context: standalone_word, severity: error, note: "feminine sg imperative 'copy'; masculine default is העתק — zero live hits" }
+  - { token: התחברי,  context: standalone_word, severity: error, note: "feminine sg imperative 'sign in'; masculine default is התחבר — zero live hits" }
+  - { token: הירשמי,  context: standalone_word, severity: error, note: "feminine sg imperative 'register'; masculine default is הירשם — zero live hits" }
+  - { token: תוכלי,   context: standalone_word, severity: error, note: "feminine sg future 'you can'; masculine default is תוכל — zero live hits" }
+exceptions: []
+rule_ref: rule.he-register-gender
+# register_spec — FREE-FORM extension where the real gender policy lives (the part
+# that cannot be reduced to safe standalone tokens, e.g. the feminine pronoun את that
+# collides with the object marker). Pilot shape mirrors locales/ja register_spec.
+register_spec:
+  gender_policy: masculine_default
+  dimension: "grammatical gender of 2nd-person address (not T/V formality — Hebrew has no T/V split; it is informal/direct by default)"
+  notes: >-
+    Address a single user in the MASCULINE singular: pronoun אתה, masculine
+    singular imperatives for buttons/instructions (הזן, לחץ, בחר, שלח, צור, מחק,
+    שמור, אשר), masculine future תוכל for "you can". The feminine singular register
+    (pronoun את as 2nd person, feminine imperatives הזיני/לחצי/בחרי…, feminine
+    future תוכלי) is forbidden for direct address. Masculine-plural / impersonal
+    phrasing (אבטחו, צרו, שלכם) used in marketing/multi-recipient copy is an
+    accepted gender-spanning style, NOT a violation. Write Modern Hebrew without
+    niqqud; use gershayim ״ for acronyms (דוא״ל). RTL layout; numbers/Latin stay LTR.
+  target_forms:
+    pronoun: [אתה]
+    imperative_examples: [הזן, הקלד, לחץ, בחר, העתק, שלח, צור, מחק, שמור, אשר, נסה, ודא]
+    future_you_can: [תוכל]
+  forbidden:
+    feminine_pronoun: [את]          # 2nd-person feminine; NOT tokenized — collides with the object marker את. Locked here + by rule.he-register-gender.
+    feminine_imperative: [הזיני, הקלידי, לחצי, בחרי, העתיקי, התחברי, הירשמי]  # also in forbidden_tokens (zero false positives)
+    feminine_future: [תוכלי]        # also tokenized
+  allowed_non_violations:
+    masculine_plural_impersonal: [אבטחו, צרו, שלחו, שלכם, שלכן]   # gender-spanning marketing/multi-recipient style — not a singular-feminine violation
+# baseline_ref: baselines.he is intentionally omitted — no `baselines.he` entry exists
+# in baselines.yaml yet, and a dangling reference fails the resolver. A reviewer adds
+# the pin to baselines.yaml centrally at commit time (mirroring fr / de_AT), after
+# which this and rules.yaml can carry `baseline_ref: baselines.he`.

--- a/locales/he/register.yaml
+++ b/locales/he/register.yaml
@@ -85,7 +85,4 @@ register_spec:
     feminine_future: [תוכלי]        # also tokenized
   allowed_non_violations:
     masculine_plural_impersonal: [אבטחו, צרו, שלחו, שלכם, שלכן]   # gender-spanning marketing/multi-recipient style — not a singular-feminine violation
-# baseline_ref: baselines.he is intentionally omitted — no `baselines.he` entry exists
-# in baselines.yaml yet, and a dangling reference fails the resolver. A reviewer adds
-# the pin to baselines.yaml centrally at commit time (mirroring fr / de_AT), after
-# which this and rules.yaml can carry `baseline_ref: baselines.he`.
+baseline_ref: baselines.he

--- a/locales/he/rules.yaml
+++ b/locales/he/rules.yaml
@@ -1,0 +1,50 @@
+id: rules.he
+source: onetimesecret/locales/guides/for-translators/he.md
+inherits: base
+merge_strategy: append
+# Hebrew locale layer, inheriting base directly (standalone language, no regional
+# parent). Carries the Hebrew-wide conventions transcribed from the translator guide
+# (onetimesecret/locales/guides/for-translators/he.md), grounded against the live app
+# content (onetimesecret/locales/content/he/*.json): the masculine-default 2nd-person
+# GENDER register lock (Hebrew has no T/V split — gender is the register dimension),
+# the סיסמה (password) vs ביטוי סיסמה (passphrase) distinction, the burn -> מחיקה
+# סופית choice, secret -> סוד, the no-niqqud rule, and the masculine-singular
+# imperative-for-buttons UI voice.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (HE) sign-off — see PR label,
+# especially the gender decision.
+rules:
+  - id: rule.he-register-gender
+    modality: MUST
+    statement: "Hebrew has no T/V formality split (it is informal/direct by default); the register dimension is the grammatical GENDER of 2nd-person address. Address a single user in the MASCULINE singular throughout product UI and email content — pronoun אתה, masculine singular imperatives (הזן / לחץ / בחר / שלח / צור / מחק / שמור / אשר), masculine future תוכל. The feminine singular register (feminine pronoun את, feminine imperatives הזיני / לחצי / בחרי / העתיקי, feminine future תוכלי) is forbidden for direct address. Masculine-plural / impersonal phrasing (אבטחו / צרו / שלכם) used in marketing or multi-recipient copy is an accepted gender-spanning style, not a violation."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.he-passphrase-password
+    modality: MUST
+    statement: "Keep סיסמה (account login / authentication credential, feminine) distinct from ביטוי סיסמה (protection of an individual secret); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.he-burn-permanent-deletion
+    modality: MUST
+    statement: "Translate burn / burned consistently as מחיקה סופית (permanent deletion) and נמחק סופית (the burned state), per the agreed Hebrew terminology; do not use a literal 'fire/burn' translation."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.he-secret-sod
+    modality: MUST
+    statement: "Render the product concept 'secret' as סוד (masculine), used consistently across the application; use the adjective סודי / מאובטח only for the descriptive 'secret/secure' sense."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.he-no-niqqud
+    modality: MUST
+    statement: "Write Modern Hebrew without niqqud (vowel points); e.g. סוד not סוֹד. Use gershayim ״ for acronyms (דוא״ל) and geresh ׳ for single-letter abbreviations, never ASCII quotes."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.he-button-imperative
+    modality: SHOULD
+    statement: "Use the masculine singular imperative for button and action labels (שלח / צור / מחק / העתק / שמור), the standard Hebrew UI convention; use passive voice or gender-agreeing past participles for status messages (הסוד נוצר, הסוד נמחק)."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.he
+glossary_ref: glossary.he
+# baseline_ref: baselines.he intentionally omitted (no baselines.he entry yet); a
+# reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/he/rules.yaml
+++ b/locales/he/rules.yaml
@@ -46,5 +46,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.he
 glossary_ref: glossary.he
-# reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.he

--- a/locales/he/rules.yaml
+++ b/locales/he/rules.yaml
@@ -46,5 +46,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.he
 glossary_ref: glossary.he
-# baseline_ref: baselines.he intentionally omitted (no baselines.he entry yet); a
 # reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.he

--- a/locales/hu/glossary.yaml
+++ b/locales/hu/glossary.yaml
@@ -1,0 +1,210 @@
+id: glossary.hu
+source: onetimesecret/locales/guides/for-translators/hu.md
+# Sense-split of the core domain terminology from the Hungarian translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/hu.md
+# §Szójegyzék / §Hungarian Translation Notes), grounded against the live app
+# content in onetimesecret/locales/content/hu/. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (HU) sign-off before merge — see PR
+# label.
+#
+# Each `good` example uses the formal Ön register (3rd-person "magázó"
+# conjugation; no forbidden informal te-pronouns) and contains the term's sense
+# target as a word_prefix. Hungarian case-suffixes attach to noun stems, so
+# citation forms are chosen so the lint word_prefix check holds: nominative
+# `titok` (NOT `titka`/`titkot`, whose stem drops the o), `jelszó` (jelszót keeps
+# the prefix), `hivatkozás` (hivatkozást keeps it), `e-mail`, `titkosít` (prefix of
+# titkosítva/titkosított), and the noun phrase `hozzáférési mondat` /
+# `végleges törlés` (word_prefix matches even when the last word is suffixed).
+# Each `bad` example demonstrates a forbidden form (the informal te-register, or
+# the wrong/forbidden term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as titok."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    hu:
+      noun:
+        target: titok
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created. The link is ready to share."
+        target: "A titok létrejött. A hivatkozás megosztásra kész."
+        verdict: good
+        note: "Nominative 'titok' (stem-preserving, satisfies the word_prefix check); declarative status voice, no informal pronoun."
+        rule_refs: [rule.hu-register-formal]
+      - id: ex.secret-informal-bad#250567fe
+        source: "Your secret has been created."
+        target: "A te titkod létrejött."
+        verdict: bad
+        note: "Informal subject pronoun 'te' plus informal 2sg possessive suffix 'titkod' (-d) — the forbidden tegező register; should be the formal 'Az Ön titka'."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective / state sense of secret/secure — protection of information. Render as biztonságos (general) or titkos (confidential)."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    hu:
+      adjective:
+        target: biztonságos
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "Share secure links with anyone."
+        target: "Osszon meg biztonságos hivatkozásokat bárkivel."
+        verdict: good
+        note: "Adjective 'biztonságos' (word_prefix); formal 3rd-person imperative 'Osszon meg'."
+        rule_refs: [rule.hu-register-formal]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "Share secure links with anyone."
+        target: "Ossz meg biztonságos hivatkozásokat bárkivel."
+        verdict: bad
+        note: "Informal 2sg imperative 'Ossz meg' (tegező) instead of the formal 'Osszon meg' — the forbidden register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose / protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    hu:
+      noun:
+        target: hozzáférési mondat
+        rule_ref: rule.hu-passphrase-password
+    rule_refs: [rule.hu-register-formal, rule.hu-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Adja meg a hozzáférési mondatot a titok megtekintéséhez."
+        verdict: good
+        note: "Formal 3rd-person imperative 'Adja meg' (grounded: live content uses this verbatim); uses 'hozzáférési mondat', not 'jelszó'."
+        rule_refs: [rule.hu-register-formal, rule.hu-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Adja meg a jelszót a titok megtekintéséhez."
+        verdict: bad
+        note: "Uses 'jelszó' (account credential) where 'hozzáférési mondat' (secret protection) is meant — violates rule.hu-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    hu:
+      noun:
+        target: jelszó
+        rule_ref: rule.hu-passphrase-password
+    rule_refs: [rule.hu-register-formal, rule.hu-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Adja meg a jelszót a bejelentkezéshez."
+        verdict: good
+        note: "Formal 3rd-person imperative 'Adja meg'; 'jelszót' keeps the 'jelszó' word_prefix; 'bejelentkezés' per the UI glossary."
+        rule_refs: [rule.hu-register-formal, rule.hu-passphrase-password]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Add meg a jelszavadat a bejelentkezéshez."
+        verdict: bad
+        note: "Informal 2sg imperative 'Add meg' plus informal possessive 'jelszavadat' (-d) — the forbidden tegező register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently deleting a secret before it is viewed. Noun phrase 'végleges törlés' for the feature/label; 'véglegesen törölve' for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    hu:
+      noun:
+        target: végleges törlés
+        rule_ref: rule.hu-burn-permanent-deletion
+      state:
+        target: véglegesen törölve
+        rule_ref: rule.hu-burn-permanent-deletion
+    rule_refs: [rule.hu-register-formal, rule.hu-burn-permanent-deletion]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Végleges törlés: távolítsa el a titkot, mielőtt elolvasnák."
+        verdict: good
+        note: "Noun phrase 'Végleges törlés' (word_prefix) per the guide's burn -> végleges törlés choice; formal imperative 'távolítsa el'."
+        rule_refs: [rule.hu-register-formal, rule.hu-burn-permanent-deletion]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Égesse el a titkot, mielőtt elolvasnák."
+        verdict: bad
+        note: "Uses the literal 'Égesse el' (burn/incinerate) instead of the glossary term 'végleges törlés' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Render as hivatkozás (preferred) — the live content also uses 'link' loanword, but the guide standardises on hivatkozás."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    hu:
+      noun:
+        target: hivatkozás
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Másolja a hivatkozást a megosztáshoz."
+        verdict: good
+        note: "Formal 3rd-person imperative 'Másolja'; 'hivatkozást' keeps the 'hivatkozás' word_prefix."
+        rule_refs: [rule.hu-register-formal]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Másold a hivatkozást a megosztáshoz."
+        verdict: bad
+        note: "Informal 2sg imperative 'Másold' (-d) instead of the formal 'Másolja' — the forbidden tegező register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'titkosít', past participle 'titkosított' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    hu:
+      verb:
+        target: titkosít
+        rule_ref: rule.terminology-consistency
+      state:
+        target: titkosított
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Ez az üzenet az Ön hozzáférési mondatával van titkosítva."
+        verdict: good
+        note: "Grounded verbatim in live content (secret-manage.json); formal possessive 'az Ön'; 'titkosítva' keeps the 'titkosít' word_prefix; 'hozzáférési mondat', not 'jelszó'."
+        rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Ez az üzenet a te jelszavaddal van titkosítva."
+        verdict: bad
+        note: "Informal pronoun 'te' plus informal possessive 'jelszavaddal' (-d), AND 'jelszó' where 'hozzáférési mondat' is meant — register and terminology drift."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Written with a hyphen: e-mail."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    hu:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.hu-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Adja meg az e-mail címét."
+        verdict: good
+        note: "Formal 3rd-person imperative 'Adja meg' plus formal possessive 'címét'; 'e-mail' (word_prefix); hyphenated spelling per the guide."
+        rule_refs: [rule.hu-register-formal]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Add meg az e-mail címedet."
+        verdict: bad
+        note: "Informal 2sg imperative 'Add meg' plus informal possessive 'címedet' (-d) — the forbidden tegező register."

--- a/locales/hu/register.yaml
+++ b/locales/hu/register.yaml
@@ -53,8 +53,4 @@ forbidden_tokens:
   - { token: hozzád, context: standalone_word, severity: error, note: "informal 2sg allative pronoun (to/towards you); contrast formal Önhöz" }
 exceptions: []
 rule_ref: rule.hu-register-formal
-# baseline_ref: baselines.hu is intentionally omitted — no `baselines.hu` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the fr / de_AT baselines entries), after which this and rules.yaml
-# can carry `baseline_ref: baselines.hu`.
+baseline_ref: baselines.hu

--- a/locales/hu/register.yaml
+++ b/locales/hu/register.yaml
@@ -1,0 +1,60 @@
+id: register.hu
+source: onetimesecret/locales/guides/for-translators/hu.md
+# Hungarian is locked to the FORMAL "Ön" register. Grounded in the live app
+# content (onetimesecret/locales/content/hu/*.json): direct address consistently
+# uses the formal subject pronoun Ön and 3rd-person ("magázó") verb agreement —
+# e.g. "Az Ön fiókja", "Az Ön hozzáférési mondatával van titkosítva", "Ön hozta
+# létre ezt a titkot", and formal imperatives conjugated in the 3rd person
+# ("Adja meg a hozzáférési mondatot", "Adjon meg egy hozzáférési mondatot",
+# "Tesztelje az alkalmazást", "Biztosítsa ... fiókját", "lépjen kapcsolatba",
+# "hagyja figyelmen kívül", "Új titkot kell létrehoznia"). Zero informal 2nd-
+# person ("tegező") tokens (te / téged / neked / tiéd / veled) appear anywhere in
+# the live content. The prose guide agrees: "Voice and Tone" / "Help Text" both
+# say "Use formal address (maga/ön forms) for professional tone". So the FORBIDDEN
+# register is the INFORMAL te-register.
+#
+# HOW FORMALITY SURFACES — and why forbidden_tokens is short. In Hungarian, T/V
+# is carried MAINLY by verb conjugation (formal = 3rd-person agreement), not by a
+# standalone pronoun: the subject pronoun is usually dropped, so the contrast is
+# in the verb ending, not a word an agent can grep. There is no single informal
+# possessive word either (possession is a noun suffix: -d/-od/-ed = informal,
+# -e/-ja = neutral/formal, e.g. "titkod" vs "titka"); those live inside
+# agglutinated words and cannot be safely token-matched. The forbidden-token list
+# below therefore only captures the UNAMBIGUOUS, standalone informal address
+# pronouns; the conjugation/possessive-suffix dimension is captured as a rule
+# (rule.hu-register-formal in rules.yaml), not as a token. See per-token notes.
+#
+# Hungarian is agglutinative, so each forbidden token uses context:
+# standalone_word — `te` etc. appear as substrings inside many valid words
+# (tervezés, teszt, tehát, tartalmaz, neki, vele...). standalone_word matches only
+# when the token is bounded by non-word chars on both sides, so these flag the
+# informal pronoun without false-positiving on unrelated vocabulary.
+#
+# Deliberately NOT forbidden:
+#   - ön / önök / maga: these ARE the chosen formal register (Ön/Önök), or
+#     ambiguous — `maga` is also the ordinary reflexive ("Meggondolta magát?" =
+#     "Changed your mind?", which appears verbatim in workspace-billing.json), so
+#     forbidding it would flag valid 3rd-person reflexive prose.
+#   - possessive/verb suffixes (-d, -od, -ed, informal imperatives like "add
+#     meg"): agglutinated, not standalone — left to rule.hu-register-formal with a
+#     human-reviewable rationale rather than a brittle substring token.
+#
+# AGENT-AUTHORED; requires native-speaker (HU) sign-off — see PR label.
+form: formal
+pronoun: Ön
+possessive: [Ön, Önök]
+forbidden_tokens:
+  - { token: te,    context: standalone_word, severity: error, note: "informal 2sg subject pronoun (the tegező register hu does NOT use); substring of tervezés/teszt/tehát, so standalone_word only" }
+  - { token: téged, context: standalone_word, severity: error, note: "informal 2sg accusative pronoun" }
+  - { token: teged, context: standalone_word, severity: error, note: "informal 2sg accusative pronoun, diacritic-stripped spelling variant" }
+  - { token: neked, context: standalone_word, severity: error, note: "informal 2sg dative pronoun (to you); contrast formal Önnek" }
+  - { token: tiéd,  context: standalone_word, severity: error, note: "informal 2sg possessive pronoun (yours); contrast formal Öné" }
+  - { token: veled, context: standalone_word, severity: error, note: "informal 2sg comitative pronoun (with you); contrast formal Önnel" }
+  - { token: hozzád, context: standalone_word, severity: error, note: "informal 2sg allative pronoun (to/towards you); contrast formal Önhöz" }
+exceptions: []
+rule_ref: rule.hu-register-formal
+# baseline_ref: baselines.hu is intentionally omitted — no `baselines.hu` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the fr / de_AT baselines entries), after which this and rules.yaml
+# can carry `baseline_ref: baselines.hu`.

--- a/locales/hu/rules.yaml
+++ b/locales/hu/rules.yaml
@@ -1,0 +1,50 @@
+id: rules.hu
+source: onetimesecret/locales/guides/for-translators/hu.md
+inherits: base
+merge_strategy: append
+# Hungarian locale layer. hu is a standalone shipping language (no family parent),
+# so it inherits `base` directly — mirroring locales/fr/ and locales/nl/. Carries
+# the Hungarian conventions transcribed from
+# onetimesecret/locales/guides/for-translators/hu.md and grounded in the live app
+# content under onetimesecret/locales/content/hu/: the formal Ön-register lock, the
+# jelszó / hozzáférési mondat distinction, the burn -> végleges törlés terminology
+# choice, and the diacritics + vowel-harmony correctness rule the guide stresses.
+# Each rule_ref points at an existing base rule id.
+#
+# NOTE on rule.hu-register-formal: in Hungarian, formality is carried MAINLY by
+# verb conjugation (formal = 3rd-person "magázó" agreement) and possessive
+# suffixes, NOT by a standalone pronoun — the subject pronoun is usually dropped.
+# Those dimensions cannot be safely token-matched (they are agglutinated into
+# words), so the register.yaml forbidden_tokens list captures only the unambiguous
+# standalone informal pronouns (te / téged / neked / tiéd / veled / hozzád); the
+# conjugation + possessive-suffix dimension is captured HERE as a rule for the
+# human reviewer rather than as brittle substring tokens.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (HU) sign-off before merge
+# — see PR label.
+rules:
+  - id: rule.hu-register-formal
+    modality: MUST
+    statement: Hungarian content uses the formal Ön register throughout product UI and email content — formal address pronoun Ön/Önök and 3rd-person ("magázó") verb conjugation for instructions and imperatives (e.g. "Adja meg", "Tesztelje", "lépjen kapcsolatba"). The informal 2nd-person "tegező" register (te / téged / neked, informal imperatives like "add meg", and informal possessive suffixes -d/-od/-ed such as "titkod") is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.hu-passphrase-password
+    modality: MUST
+    statement: Keep jelszó (account login / authentication credential) distinct from hozzáférési mondat (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.hu-burn-permanent-deletion
+    modality: MUST
+    statement: Translate burn / burned consistently as végleges törlés (noun) / véglegesen törölve (state), per the agreed Hungarian terminology; do not vary across strings or use a literal "elégetés".
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.hu-diacritics-vowel-harmony
+    modality: MUST
+    statement: Diacritics are obligatory and meaning-bearing (á é í ó ö ő ú ü ű; e.g. kor vs kór) and case-suffixes must obey vowel harmony (házban, kertben — never "házben"); never strip diacritics or violate vowel harmony.
+    severity: warning
+    rule_ref: rule.terminology-consistency
+register_ref: register.hu
+glossary_ref: glossary.hu
+# baseline_ref: baselines.hu is intentionally omitted until a human reviewer adds
+# the `baselines.hu` entry to baselines.yaml centrally — a dangling reference
+# fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/hu/rules.yaml
+++ b/locales/hu/rules.yaml
@@ -45,6 +45,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.hu
 glossary_ref: glossary.hu
-# baseline_ref: baselines.hu is intentionally omitted until a human reviewer adds
-# the `baselines.hu` entry to baselines.yaml centrally — a dangling reference
-# fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.hu

--- a/locales/it_IT/glossary.yaml
+++ b/locales/it_IT/glossary.yaml
@@ -1,0 +1,201 @@
+id: glossary.it_IT
+source: onetimesecret/locales/guides/for-translators/it_IT.md
+# Sense-split of the core domain terminology from the Italian translator guide's
+# terminology tables (it_IT.md §Core Terminology Standards, §Standardized
+# Terminology), grounded against the live app content in
+# onetimesecret/locales/content/it_IT/. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (IT) sign-off before merge — see PR
+# label. Each `good` example uses the informal tu register AND contains the term's
+# target (lint checks both); each `bad` example demonstrates a forbidden form (the
+# formal Lei register, or the wrong/forbidden term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as segreto, never the generic Messaggio / Monouso / Temporaneo."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    it_IT:
+      noun:
+        target: segreto
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created."
+        target: "Il tuo segreto è stato creato."
+        verdict: good
+        note: "Informal possessive 'tuo' per the tu register; the noun term 'segreto'; declarative voice for status."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created."
+        target: "Il segreto è stato creato. Lei riceverà una notifica."
+        verdict: bad
+        note: "Formal address pronoun 'Lei' — the forbidden formal register; should use the informal tu form."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense — protected/secure content. Render as sicuro (secure) or segreto (confidential, e.g. 'link segreti'); agrees in gender/number with its noun."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    it_IT:
+      adjective:
+        target: sicuro
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "Share a secure link with anyone."
+        target: "Condividi un link sicuro con chiunque."
+        verdict: good
+        note: "Informal imperative 'Condividi'; adjective 'sicuro' agrees with the masc. sing. 'link'."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "Share a secure link with anyone."
+        target: "Condivida un link sicuro con chiunque."
+        verdict: bad
+        note: "Formal imperative 'Condivida' (Lei register) instead of informal 'Condividi' — the forbidden formal register."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    it_IT:
+      noun:
+        target: frase di sicurezza
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Inserisci la frase di sicurezza per visualizzare questo segreto."
+        verdict: good
+        note: "Informal imperative 'Inserisci'; uses 'frase di sicurezza', not 'password'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Inserisci la password per visualizzare questo segreto."
+        verdict: bad
+        note: "Uses 'password' (account credential) where 'frase di sicurezza' (secret protection) is meant — violates rule.it-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Kept in English: 'password'."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    it_IT:
+      noun:
+        target: password
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Inserisci la tua password per accedere."
+        verdict: good
+        note: "Informal imperative 'Inserisci' plus informal possessive 'tua'; 'accedere' for sign in. Matches the guide's worked Example 2."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Inserisca la Sua password per accedere."
+        verdict: bad
+        note: "Formal imperative 'Inserisca' plus formal possessive 'Sua' — the forbidden Lei register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb 'distruggere' (or 'bruciare') for the action label; past participle 'distrutto' for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    it_IT:
+      verb:
+        target: distruggere
+        rule_ref: rule.terminology-consistency
+      state:
+        target: distrutto
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Distruggere questo segreto prima che venga letto."
+        verdict: good
+        note: "Infinitive 'Distruggere' for the button label, per the guide's burn -> distruggere choice."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Cancellare questo segreto prima che venga letto."
+        verdict: bad
+        note: "Uses generic 'Cancellare' instead of the glossary verb 'distruggere' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. 'link' (borrowed, preferred in UI) or 'collegamento' (native, for longer prose); pick one and stay consistent."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    it_IT:
+      noun:
+        target: link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy your secret link to share it."
+        target: "Copia il tuo link segreto per condividerlo."
+        verdict: good
+        note: "Informal imperative 'Copia' plus informal possessive 'tuo'; uses 'link' per the glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy your secret link to share it."
+        target: "Copi il Suo link segreto per condividerlo."
+        verdict: bad
+        note: "Formal imperative 'Copi' plus formal possessive 'Suo' — the forbidden Lei register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'crittografare', past participle 'crittografato' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    it_IT:
+      verb:
+        target: crittografare
+        rule_ref: rule.terminology-consistency
+      state:
+        target: crittografato
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Questo messaggio è crittografato con la tua frase di sicurezza."
+        verdict: good
+        note: "State 'crittografato'; informal possessive 'tua'; uses 'frase di sicurezza' for the secret's passphrase."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Questo messaggio è criptato con la Sua frase di sicurezza."
+        verdict: bad
+        note: "Uses 'criptato' instead of the established security term 'crittografato', plus formal possessive 'Sua' (Lei register)."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Kept in English: 'email'."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    it_IT:
+      noun:
+        target: email
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Inserisci il tuo indirizzo email."
+        verdict: good
+        note: "Informal imperative 'Inserisci' plus informal possessive 'tuo'; 'email' per the glossary. Grounded in live content ('Inserisci la tua email')."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Inserisca il Suo indirizzo email."
+        verdict: bad
+        note: "Formal imperative 'Inserisca' plus formal possessive 'Suo' — the forbidden Lei register."

--- a/locales/it_IT/register.yaml
+++ b/locales/it_IT/register.yaml
@@ -39,8 +39,4 @@ forbidden_tokens:
   - { token: Lei, context: standalone_word, severity: error, note: "formal singular address pronoun (the V-form this locale forbids); lowercase 'lei' (=she) and any 3rd-person 'she' reference are absent from the live content, so capitalised Lei is unambiguous here" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.it_IT is intentionally omitted — no `baselines.it_IT`
-# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
-# The pin is for a human reviewer to add to baselines.yaml centrally at commit
-# time (mirroring the `fr`/`de_AT` baselines entries), after which this and
-# rules.yaml can carry `baseline_ref: baselines.it_IT`.
+baseline_ref: baselines.it_IT

--- a/locales/it_IT/register.yaml
+++ b/locales/it_IT/register.yaml
@@ -1,0 +1,46 @@
+id: register.it_IT
+source: onetimesecret/locales/guides/for-translators/it_IT.md
+# Italian is locked to the INFORMAL tu register. Grounded in the live app content
+# (onetimesecret/locales/content/it_IT/*.json): direct address consistently uses
+# the informal tu forms — informal possessives tuo/tua/tuoi/tue (131/57/17/16
+# occurrences; e.g. "Inserisci la tua password", "Il tuo segreto rimarrà
+# disponibile", "Inserisci il tuo feedback"), informal 2sg imperatives ending in
+# -i / -a-reflexive (Inserisci, Accedi, Crea, Conferma, Verifica, Assicurati),
+# the informal object pronoun ti ("ti invieremo un link"), and informal 2sg verbs
+# (Puoi 5x, Hai 47x, Sei 23x, Vuoi, Devi). ZERO formal-Lei markers appear anywhere
+# in the live content: no standalone "Lei"/"lei", no formal possessives
+# Suo/Sua/Suoi/Sue, no formal imperatives (Inserisca/Acceda/Può), and no formal
+# courtesy constructions (La preghiamo / Le invieremo). The prose guide agrees:
+# its worked Example 2 uses "Inserisci la tua password per accedere" and it warns
+# to "avoid overly formal language that creates distance". So the FORBIDDEN
+# register is the formal Lei register; the unambiguous forbidden token is the
+# formal address pronoun Lei.
+#
+# Deliberately NOT forbidden (ambiguity carve-outs, cf. the es agent leaving
+# su/sus unforbidden):
+#   * La / Le — in Italian these are the feminine definite articles ("la tua",
+#     "le tue") and unstressed object pronouns long before they are the formal
+#     courtesy object pronouns; they appear 33x / 17x as ordinary articles in the
+#     live content. Forbidding them as standalone words would flag valid prose.
+#   * Suo / Sua / Suoi / Sue — also the ordinary 3rd-person possessive ("his /
+#     her / its"); capitalised only as a formality convention. Forbidding them
+#     would flag legitimate 3rd-person references, so they are left out.
+#   * Può — formal 2sg "you can", but identical to the valid 3rd-person "he / she
+#     / it can"; ambiguous, so left out.
+# "Lei" has no such ambiguity in this product UI (lowercase "lei" = "she" never
+# appears, and the app never refers to a third-person "she"), so it is the one
+# forbidden standalone-word token.
+#
+# AGENT-AUTHORED; requires native-speaker (IT) sign-off — see PR label.
+form: informal
+pronoun: tu
+possessive: [tuo, tua, tuoi, tue]
+forbidden_tokens:
+  - { token: Lei, context: standalone_word, severity: error, note: "formal singular address pronoun (the V-form this locale forbids); lowercase 'lei' (=she) and any 3rd-person 'she' reference are absent from the live content, so capitalised Lei is unambiguous here" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.it_IT is intentionally omitted — no `baselines.it_IT`
+# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
+# The pin is for a human reviewer to add to baselines.yaml centrally at commit
+# time (mirroring the `fr`/`de_AT` baselines entries), after which this and
+# rules.yaml can carry `baseline_ref: baselines.it_IT`.

--- a/locales/it_IT/rules.yaml
+++ b/locales/it_IT/rules.yaml
@@ -37,6 +37,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.it_IT
 glossary_ref: glossary.it_IT
-# baseline_ref: baselines.it_IT is intentionally omitted until a human reviewer
-# adds the `baselines.it_IT` entry to baselines.yaml centrally — a dangling
-# reference fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.it_IT

--- a/locales/it_IT/rules.yaml
+++ b/locales/it_IT/rules.yaml
@@ -1,0 +1,42 @@
+id: rules.it_IT
+source: onetimesecret/locales/guides/for-translators/it_IT.md
+inherits: base
+merge_strategy: append
+# Italian locale layer. it_IT is the only Italian variant the app ships, so it
+# inherits `base` directly (no `it` family parent) — mirroring how
+# locales/es/rules.yaml and locales/nl/rules.yaml inherit base directly. Carries
+# the Italian conventions transcribed from
+# onetimesecret/locales/guides/for-translators/it_IT.md and grounded in the live
+# app content under onetimesecret/locales/content/it_IT/: the informal tu register
+# lock, the password / frase di sicurezza distinction, the secret -> segreto noun
+# choice the guide standardised on, and the active-imperative / passive-status
+# voice split. Every rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live it_IT content;
+# requires native-speaker (IT) sign-off before merge — see PR label.
+rules:
+  - id: rule.it-register-informal
+    modality: MUST
+    statement: Italian content uses the informal tu register (tu / tuo / tua / tuoi / tue / ti) throughout product UI and email content; the formal Lei register (the Lei address pronoun and the formal imperatives/possessives that go with it) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.it-passphrase-password
+    modality: MUST
+    statement: Keep password (account login / authentication credential) distinct from frase di sicurezza (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.it-secret-noun
+    modality: MUST
+    statement: Translate the noun "secret" consistently as segreto (never the generic Messaggio / Monouso / Temporaneo); Italian segreto correctly conveys confidential information and preserves the brand's security context.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.it-active-passive-voice
+    modality: SHOULD
+    statement: Use the active imperative for buttons and user actions (Crea, Copia, Elimina, Invia) and the passive/declarative voice for status and informational messages (Creato, Copiato, Eliminato, "Il segreto è stato visualizzato").
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.it_IT
+glossary_ref: glossary.it_IT
+# baseline_ref: baselines.it_IT is intentionally omitted until a human reviewer
+# adds the `baselines.it_IT` entry to baselines.yaml centrally — a dangling
+# reference fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/ja/glossary.yaml
+++ b/locales/ja/glossary.yaml
@@ -1,0 +1,209 @@
+id: glossary.ja
+source: onetimesecret/locales/guides/for-translators/ja.md
+# Sense-split of the core domain terminology from the Japanese translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/ja.md §Core
+# Terminology, §Account-Related Terms), grounded against the live app content in
+# onetimesecret/locales/content/ja/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (JA) sign-off before merge — see PR
+# label.
+#
+# CJK TOKENIZATION NOTE (pilot lesson): SPEC §2.3 lint check 2 requires every
+# `good` example's target to contain a sense target in `word_prefix` mode. With
+# no spaces in Japanese, "word boundary" = start-of-string or a non-word char
+# (Japanese punctuation 。、「」 or ASCII space) — a kana/kanji left-neighbour is
+# a word char and blocks the match. So each `good` example below places its sense
+# target in HEAD position (or after punctuation), e.g. 削除されたシークレットは…
+# rather than …シークレットを削除…. Each `good` example uses the polite teineigo
+# register and is verified clean against register.ja forbidden_tokens; each `bad`
+# example demonstrates a forbidden form (casual 常体 register, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as シークレット (katakana), never 秘密."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    ja:
+      noun:
+        target: シークレット
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "シークレットが作成されました。"
+        verdict: good
+        note: "Polite passive/declarative 作成されました for a status message; katakana シークレット in head position."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-casual-bad#297307d4
+        source: "Your secret has been created."
+        target: "秘密ができたぜ。"
+        verdict: bad
+        note: "Casual emphatic ぜ (forbidden register) AND 秘密 instead of シークレット — violates both rule.ja-register-teineigo and rule.ja-secret-katakana."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense of secret/secure — protection of information. Render as 機密 (機密情報) or 安全な / セキュアな; reserve シークレット for the product-noun sense."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    ja:
+      adjective:
+        target: 機密
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "Share confidential information securely."
+        target: "機密情報を安全に共有できます。"
+        verdict: good
+        note: "Adjective/general sense 機密 in head position; polite ます ending."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "Share confidential information securely."
+        target: "シークレット情報を安全に共有できます。"
+        verdict: bad
+        note: "Uses the product-noun シークレット for the general adjective sense where 機密 is meant — terminology drift (rule.ja-secret-katakana)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    ja:
+      noun:
+        target: パスフレーズ
+        rule_ref: rule.ja-passphrase-password
+    rule_refs: [rule.register-lock, rule.ja-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "パスフレーズを入力してください。"
+        verdict: good
+        note: "Verbatim from live content; polite request してください; パスフレーズ (secret protection), not パスワード, in head position."
+        rule_refs: [rule.register-lock, rule.ja-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "パスワードを入力しろ。"
+        verdict: bad
+        note: "Casual imperative しろ (forbidden register) AND パスワード (account credential) where パスフレーズ (secret protection) is meant — violates both the register lock and rule.ja-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    ja:
+      noun:
+        target: パスワード
+        rule_ref: rule.ja-passphrase-password
+    rule_refs: [rule.register-lock, rule.ja-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "パスワードを入力してログインしてください。"
+        verdict: good
+        note: "Grounded in live content (パスワードでログインしてください); polite してください; account term パスワード in head position."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "パスワード入れろよ。"
+        verdict: bad
+        note: "Casual imperative 入れろ plus casual particle よ — the forbidden casual 常体 register; should be polite パスワードを入力してください。"
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Rendered as 削除 (delete/remove), not the literal 燃やす. 削除 as the action label/verb, 削除済み for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    ja:
+      action:
+        target: 削除
+        rule_ref: rule.terminology-consistency
+      state:
+        target: 削除済み
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "A burned secret cannot be recovered."
+        target: "削除されたシークレットは復元できません。"
+        verdict: good
+        note: "Action term 削除 in head position; polite negative できません. Grounded in live 削除されました / 完全に削除されます."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "A burned secret cannot be recovered."
+        target: "燃やしたシークレットは戻せないぞ。"
+        verdict: bad
+        note: "Uses literal 燃やす instead of the glossary term 削除 (terminology drift) AND casual emphatic ぞ (forbidden register)."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Rendered as the katakana リンク."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    ja:
+      noun:
+        target: リンク
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the link to share it."
+        target: "リンクをコピーして共有してください。"
+        verdict: good
+        note: "Grounded in live このリンクをコピー…; term リンク in head position; polite してください."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy the link to share it."
+        target: "リンクをコピーして共有しろ。"
+        verdict: bad
+        note: "Casual imperative しろ — the forbidden casual register; should be polite してください."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; 暗号化 for the verbal-noun/action (暗号化する), 暗号化された / 暗号化済み for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    ja:
+      action:
+        target: 暗号化
+        rule_ref: rule.terminology-consistency
+      state:
+        target: 暗号化された
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "The encrypted message is protected with your passphrase."
+        target: "暗号化されたメッセージはパスフレーズで保護されています。"
+        verdict: good
+        note: "State 暗号化された in head position; polite passive 保護されています. Grounded in live このメッセージはパスフレーズで暗号化されています。"
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "The encrypted message is protected with your passphrase."
+        target: "暗号化されたメッセージはパスワードで守るぜ。"
+        verdict: bad
+        note: "Casual emphatic ぜ (forbidden register) AND パスワード (account credential) where パスフレーズ is meant — violates the register lock and rule.ja-passphrase-password."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Rendered as メール (or Eメール); メールアドレス for the address."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    ja:
+      noun:
+        target: メール
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "メールアドレスを入力してください。"
+        verdict: good
+        note: "Grounded in live メールアドレス…入力してください; term メール in head position (word_prefix of メールアドレス); polite してください."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "メールアドレス書けよ。"
+        verdict: bad
+        note: "Casual imperative 書け plus casual particle よ — the forbidden casual 常体 register; should be polite 入力してください."

--- a/locales/ja/register.yaml
+++ b/locales/ja/register.yaml
@@ -79,8 +79,4 @@ register_spec:
     である必要があります). It is enforced via rule.ja-register-teineigo and this
     spec rather than forbidden_tokens. Imperative noun-forms on buttons (保存,
     削除) are the prescribed UI voice, NOT a register violation.
-# baseline_ref: baselines.ja is intentionally omitted — no `baselines.ja` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
-# carry `baseline_ref: baselines.ja`.
+baseline_ref: baselines.ja

--- a/locales/ja/register.yaml
+++ b/locales/ja/register.yaml
@@ -1,0 +1,86 @@
+id: register.ja
+source: onetimesecret/locales/guides/for-translators/ja.md
+# PILOT for the non-T/V "register_spec" shape (CJK/keigo). Japanese has no binary
+# T/V split: register is keigo (politeness level), not a pronoun choice. The app
+# is locked to 丁寧語 / teineigo — the polite です/ます form. Grounded in the live
+# app content (onetimesecret/locales/content/ja/*.json): polite sentence endings
+# are pervasive (~185 ます, ~68 です, ~107 ません) while casual/plain enders are
+# absent (zero だ。 sentence-final copula, zero しろ / するな / だろ / かい). The
+# prose guide agrees: §"Voice and Tone" records 基本方針: です/ます調を使用
+# (base policy: use the です/ます form), imperative (命令形) for buttons, and
+# passive/declarative for status. So the FORBIDDEN register is the casual/plain
+# (常体) form; the lock is documented below and in `register_spec`.
+#
+# form: other  — keigo is not formal|informal|mixed in the T/V sense.
+# pronoun:      — Japanese normally omits 2nd-person pronouns; the register is
+#                 carried by sentence-ending verb/copula morphology, not a
+#                 pronoun. The required field records that, plus the marker.
+#
+# forbidden_tokens — TOKENIZATION NOTE (the pilot's hard lesson for CJK agents):
+# Japanese has no spaces, so `standalone_word`/`word_prefix` word boundaries
+# (which key off alphanumeric chars) do NOT segment Japanese — every kana/kanji
+# is a "word char", so a casual marker mid-sentence has no left boundary. We
+# therefore use `substring` for the casual markers, but ONLY for ones that do
+# NOT collide with polite text. Each token below was verified against the full
+# live ja content to have ZERO occurrences (no false positives):
+#   しろ / するな (casual imperative & prohibition), だろう / だろ (casual
+#   conjecture), かい (casual question particle), ぞ / ぜ (casual emphatics),
+#   じゃない (casual negation), してくれ (casual request).
+# DELIBERATELY LEFT OUT (cannot be safely tokenized — would false-positive on
+# polite text): the plain copula だ — it is a substring of the very common polite
+# request form ください (100+ hits) plus いただく / 一度だけ / まだ; and である —
+# it appears mid-sentence in the polite construction である必要があります. Those
+# two plain forms are locked via `register_spec.forbidden_forms` + the rule
+# rule.ja-register-teineigo instead. SPEC §2.3 lint only scans `good` examples,
+# and all `good` examples here are verified clean against this token list.
+#
+# AGENT-AUTHORED; requires native-speaker (JA) sign-off — see PR label.
+form: other
+pronoun: "(omitted; keigo politeness carried by sentence endings — teineigo です/ます)"
+forbidden_tokens:
+  - { token: しろ,     context: substring, severity: error, note: "casual imperative (する command form); polite UI uses 命令形 noun 削除/保存 or してください — zero live hits" }
+  - { token: するな,   context: substring, severity: error, note: "casual prohibition (do not ~); polite form is しないでください — zero live hits" }
+  - { token: だろう,   context: substring, severity: error, note: "casual conjecture (probably); polite form is でしょう — zero live hits" }
+  - { token: だろ,     context: substring, severity: error, note: "casual conjecture/tag, shortened; — zero live hits" }
+  - { token: かい,     context: substring, severity: error, note: "casual yes/no question particle; polite form is ですか — zero live hits" }
+  - { token: じゃない, context: substring, severity: error, note: "casual negation; polite form is ではありません / ではない(です) — zero live hits" }
+  - { token: してくれ, context: substring, severity: error, note: "casual request (do ~ for me); polite form is してください — zero live hits" }
+  - { token: ぞ,       context: substring, severity: error, note: "casual masculine emphatic sentence-final particle — zero live hits" }
+  - { token: ぜ,       context: substring, severity: error, note: "casual masculine emphatic sentence-final particle — zero live hits" }
+exceptions: []
+rule_ref: rule.ja-register-teineigo
+# register_spec — the FREE-FORM extension where the real keigo policy lives (the
+# part that cannot be reduced to safe substring tokens). This is the pilot shape
+# later CJK/keigo (ko) agents should follow: a `system` + `level`, the affirmed
+# `target_forms`, the `forbidden_forms` (including the plain copula that is not
+# safely tokenizable), and a `voice_by_context` map mirroring the guide.
+register_spec:
+  system: keigo
+  level: teineigo
+  description: "Polite form (丁寧語): です/ます sentence endings throughout product UI and email content. Not a pronoun T/V split."
+  target_forms:
+    copula: [です, でした, でしょう]
+    verb_endings: [ます, ません, ました, ましょう]
+    negative_polite: [ません, ありません, ではありません]
+  forbidden_forms:
+    plain_copula: [だ, である]            # plain/常体 copula — see note: NOT in forbidden_tokens (false-positives on ください/必要); locked here + by rule.
+    casual_imperative: [しろ, するな]      # also tokenized (zero false positives)
+    casual_conjecture: [だろう, だろ]      # also tokenized
+    casual_question: [かい]               # also tokenized
+    casual_negation: [じゃない]            # also tokenized
+    casual_emphatic: [ぞ, ぜ]             # also tokenized
+  voice_by_context:
+    buttons_and_actions: "命令形 / imperative noun-form (例: 保存, 削除, 送信) — concise label form, not casual speech."
+    status_and_notifications: "受動態/完了形 — passive/declarative polite (例: 保存されました, 削除済み)."
+    explanatory_text: "丁寧語 です/ます — polite, professional yet approachable."
+  notes: >-
+    The plain copula だ / である is the primary casual marker but is unsafe to
+    substring-match against polite Japanese (だ is inside ください, である inside
+    である必要があります). It is enforced via rule.ja-register-teineigo and this
+    spec rather than forbidden_tokens. Imperative noun-forms on buttons (保存,
+    削除) are the prescribed UI voice, NOT a register violation.
+# baseline_ref: baselines.ja is intentionally omitted — no `baselines.ja` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
+# carry `baseline_ref: baselines.ja`.

--- a/locales/ja/rules.yaml
+++ b/locales/ja/rules.yaml
@@ -1,0 +1,39 @@
+id: rules.ja
+source: onetimesecret/locales/guides/for-translators/ja.md
+inherits: base
+merge_strategy: append
+# Japanese locale layer, inheriting base directly (standalone language, no
+# regional parent). PILOT for the keigo / non-T/V register shape. Carries the
+# Japanese-wide conventions transcribed from the translator guide
+# (onetimesecret/locales/guides/for-translators/ja.md): the teineigo (です/ます)
+# register lock, the passphrase (パスフレーズ) vs password (パスワード)
+# distinction, the シークレット (not 秘密) terminology choice, and the
+# imperative-noun-form-for-buttons UI voice.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (JA) sign-off — see PR
+# label.
+rules:
+  - id: rule.ja-register-teineigo
+    modality: MUST
+    statement: "Japanese content uses the polite teineigo register (です/ます form) throughout product UI and email content. The plain/casual 常体 forms — plain copula だ / である, casual imperatives しろ / するな, casual conjecture だろう, casual question かい, casual negation じゃない — are forbidden. Exception: action buttons use the concise imperative noun-form (保存, 削除, 送信), and status messages use polite passive/declarative (保存されました, 削除済み); neither is a register violation."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ja-passphrase-password
+    modality: MUST
+    statement: "Keep パスワード (account login / authentication credential) distinct from パスフレーズ (protection of an individual secret); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ja-secret-katakana
+    modality: MUST
+    statement: "Render the product concept 'secret' as the katakana シークレット, not 秘密 (himitsu, which connotes a personal/general secret). Use 機密 / 秘密 only for the general adjective sense (機密情報)."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.ja-button-imperative
+    modality: SHOULD
+    statement: "Use the concise imperative noun-form for button and action labels (保存 / 削除 / 送信 / コピー); use polite passive/declarative for status messages (保存されました / 削除済み)."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.ja
+glossary_ref: glossary.ja
+# baseline_ref: baselines.ja intentionally omitted (no baselines.ja entry yet);
+# a reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/ja/rules.yaml
+++ b/locales/ja/rules.yaml
@@ -35,5 +35,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ja
 glossary_ref: glossary.ja
-# baseline_ref: baselines.ja intentionally omitted (no baselines.ja entry yet);
 # a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.ja

--- a/locales/ja/rules.yaml
+++ b/locales/ja/rules.yaml
@@ -35,5 +35,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ja
 glossary_ref: glossary.ja
-# a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.ja

--- a/locales/ko/glossary.yaml
+++ b/locales/ko/glossary.yaml
@@ -1,0 +1,212 @@
+id: glossary.ko
+source: onetimesecret/locales/guides/for-translators/ko.md
+# Sense-split of the core domain terminology from the Korean translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/ko.md
+# §Core Terminology, §Account-Related Terms, §Security Features), grounded
+# against the live app content in onetimesecret/locales/content/ko/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (KO)
+# sign-off before merge — see PR label.
+#
+# CJK TOKENIZATION NOTE (ja-pilot lesson, applies to Korean too): SPEC §2.3 lint
+# check 2 requires every `good` example's target to contain a sense target in
+# `word_prefix` mode. Korean uses spaces, but Hangul syllables are alphanumeric,
+# so a Hangul char immediately to the LEFT of the sense target blocks the
+# word_prefix match (left boundary must be start-of-string, a space, or
+# punctuation). Multi-eojeol sense targets (비밀 메시지, 접근 문구) must therefore
+# appear with that exact spacing AND in HEAD position (or right after a space /
+# punctuation). So each `good` example below leads with its sense target, e.g.
+# "비밀 메시지가 생성되었습니다." rather than "당신의 비밀 메시지가…". Each `good`
+# example uses the polite 합쇼체/해요체 register and is verified clean against
+# register.ko forbidden_tokens; each `bad` example demonstrates a forbidden form
+# (casual 반말 register, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The application's central concept. Render as 비밀 메시지 (secret message), never bare 비밀 or 보안 메시지."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    ko:
+      noun:
+        target: 비밀 메시지
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Your secret has been created."
+        target: "비밀 메시지가 생성되었습니다."
+        verdict: good
+        note: "Sense target 비밀 메시지 in head position; polite passive/declarative 합쇼체 생성되었습니다 for a status message. Grounded in live 생성되었습니다 status form."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-bad#36c87b0a
+        source: "Your secret has been created."
+        target: "비밀 다 만들었어."
+        verdict: bad
+        note: "Bare 비밀 (not 비밀 메시지 — terminology drift) AND casual 반말 past 만들었어 (forbidden register); should be 비밀 메시지가 생성되었습니다."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense — secret/secure/protected. Render as 비밀의 (descriptive) or 안전한 (secure/protected state); reserve 비밀 메시지 for the product-noun sense."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    ko:
+      adjective:
+        target: 안전한
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "Share confidential information securely."
+        target: "안전한 링크로 기밀 정보를 공유할 수 있습니다."
+        verdict: good
+        note: "Adjective sense 안전한 in head position; polite 합쇼체 -습니다. Grounded in guide 안전한 링크 (secure links)."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "Share confidential information securely."
+        target: "비밀 메시지 링크로 기밀 정보를 공유해."
+        verdict: bad
+        note: "Uses product-noun 비밀 메시지 for the general adjective sense where 안전한 is meant (terminology drift) AND casual 반말 imperative 공유해 (forbidden register)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense. Render as 접근 문구, never 비밀번호 or 암호."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    ko:
+      noun:
+        target: 접근 문구
+        rule_ref: rule.ko-passphrase-password
+    rule_refs: [rule.register-lock, rule.ko-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "접근 문구를 입력하세요."
+        verdict: good
+        note: "Verbatim from the guide; sense target 접근 문구 in head position; polite 해요체 imperative 입력하세요; 접근 문구 (secret protection), not 비밀번호."
+        rule_refs: [rule.register-lock, rule.ko-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "비밀번호 입력해."
+        verdict: bad
+        note: "Uses 비밀번호 (account credential) where 접근 문구 (secret protection) is meant AND casual 반말 imperative 입력해 — violates rule.ko-passphrase-password and the register lock."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Render as 비밀번호, never 암호 or 접근 문구."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    ko:
+      noun:
+        target: 비밀번호
+        rule_ref: rule.ko-passphrase-password
+    rule_refs: [rule.register-lock, rule.ko-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "비밀번호를 입력하여 로그인하세요."
+        verdict: good
+        note: "Sense target 비밀번호 in head position; polite 해요체 imperative 로그인하세요. Grounded in live 비밀번호로 로그인 / 비밀번호를 입력하세요."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "비밀번호 입력하고 로그인할게."
+        verdict: bad
+        note: "Casual 반말 promise/intention 할게 (forbidden register) plus dropped politeness; should be polite 비밀번호를 입력하여 로그인하세요."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed; emphasises permanent deletion. Render as 소각 (action label/verbal-noun), 소각됨 / 소각되었습니다 for the resulting state. Not the literal 태우다."
+      key_patterns: ["*burn*", "*.destroy*"]
+    ko:
+      action:
+        target: 소각
+        rule_ref: rule.terminology-consistency
+      state:
+        target: 소각됨
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "A burned secret cannot be recovered."
+        target: "소각된 비밀 메시지는 복구할 수 없습니다."
+        verdict: good
+        note: "Action term 소각 in head position (소각된); polite negative 합쇼체 없습니다. Grounded in guide 소각 / 소각되었습니다."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "A burned secret cannot be recovered."
+        target: "태운 비밀 메시지는 복구 못 해."
+        verdict: bad
+        note: "Uses literal 태우다 instead of the glossary term 소각 (terminology drift) AND casual 반말 imperative/declarative 해 (forbidden register)."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Render as the loanword 링크."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    ko:
+      noun:
+        target: 링크
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the link to share it."
+        target: "링크를 복사하여 공유하세요."
+        verdict: good
+        note: "Sense target 링크 in head position; polite 해요체 imperative 공유하세요. Grounded in guide 비밀 링크 / 안전한 링크."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy the link to share it."
+        target: "링크 복사해서 공유해줘."
+        verdict: bad
+        note: "Casual 반말 request 해줘 (forbidden register); should be the polite 링크를 복사하여 공유하세요."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; 암호화 for the verbal-noun/action (암호화하다), 암호화됨 / 암호화된 for the encrypted state. Distinct from 암호 (avoid — ambiguous)."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    ko:
+      action:
+        target: 암호화
+        rule_ref: rule.terminology-consistency
+      state:
+        target: 암호화됨
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "The encrypted message is protected with your passphrase."
+        target: "암호화된 메시지는 접근 문구로 보호됩니다."
+        verdict: good
+        note: "State sense 암호화 in head position (암호화된); polite passive 합쇼체 보호됩니다; 접근 문구 (not 비밀번호). Grounded in guide 암호화/암호화됨."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "The encrypted message is protected with your passphrase."
+        target: "암호화된 메시지는 비밀번호로 지킬 거야."
+        verdict: bad
+        note: "Casual 반말 assertion 거야 (forbidden register) AND 비밀번호 (account credential) where 접근 문구 is meant — violates the register lock and rule.ko-passphrase-password."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Render as 이메일 (이메일 주소 for the address)."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    ko:
+      noun:
+        target: 이메일
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "이메일 주소를 입력하세요."
+        verdict: good
+        note: "Sense target 이메일 in head position (word_prefix of 이메일 주소); polite 해요체 imperative 입력하세요. Grounded in guide §Account-Related Terms 이메일."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "이메일 주소 입력해줘."
+        verdict: bad
+        note: "Casual 반말 request 해줘 (forbidden register); should be the polite 이메일 주소를 입력하세요."

--- a/locales/ko/register.yaml
+++ b/locales/ko/register.yaml
@@ -95,8 +95,4 @@ register_spec:
     rule.ko-register-politeness and this spec rather than forbidden_tokens.
     Concise verbal-noun labels on buttons (복사, 소각, 공유) are the prescribed UI
     voice, NOT a register violation.
-# baseline_ref: baselines.ko is intentionally omitted — no `baselines.ko` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
-# carry `baseline_ref: baselines.ko`.
+baseline_ref: baselines.ko

--- a/locales/ko/register.yaml
+++ b/locales/ko/register.yaml
@@ -1,0 +1,102 @@
+id: register.ko
+source: onetimesecret/locales/guides/for-translators/ko.md
+# Korean register is a POLITENESS LEVEL (높임법 / speech level), not a binary
+# T/V pronoun split — Korean drops the 2nd-person pronoun and carries deference
+# in the verb/sentence-ending morphology. This file follows the ja keigo PILOT
+# shape (register_spec extension; form: other). Grounded in the live app content
+# (onetimesecret/locales/content/ko/*.json): the formal-polite forms dominate —
+# the 합쇼체 (hapsyo-che) declarative ending -습니다/-ㅂ니다 is pervasive
+# (~347 hits, e.g. "계정이 성공적으로 인증되었습니다", "이 로그인 링크가
+# 만료되었습니다.") and 해요체 (haeyo-che) polite imperatives in -세요 / 해 주세요
+# are used for instructions/requests (~223 -세요, ~128 하세요, e.g.
+# "자격 증명을 입력하세요", "다시 시도해 주세요."). Casual/plain 반말 (해체:
+# -아/-어 casual, -다 plain declarative, 해라 commands) is ABSENT from live
+# content. The prose guide agrees: §"Voice and Tone" prescribes imperative voice
+# for buttons ("복사", "비밀 메시지 소각") and passive/declarative polite for
+# status ("생성되었습니다", "소각되었습니다"), and §"Translation Principles" #6
+# records "appropriate politeness levels for a business application". So the
+# FORBIDDEN register is 반말 / the plain-casual speech level.
+#
+# form: other  — Korean speech levels are not formal|informal|mixed in the T/V
+#                sense; the politeness is morphological, so we use `other` and
+#                the register_spec extension (mirroring register.ja).
+# pronoun:      — Korean normally omits the 2nd-person pronoun; deference is in
+#                verb endings, so the required `pronoun` field records that.
+#
+# forbidden_tokens — TOKENIZATION NOTE (the CJK lint lesson from the ja pilot):
+# Korean DOES use spaces between eojeol (words), but particles and endings attach
+# directly to the stem with no space, so a casual ending sits mid-eojeol with a
+# Hangul (= alphanumeric) char on its left — `standalone_word`/`word_prefix`
+# boundaries won't segment it. We therefore use `context: substring`, but ONLY
+# for unambiguous 반말 markers verified to have ZERO occurrences across the full
+# live ko content (no false positives, including against polite -습니다/-세요
+# text):
+#   해라 (casual command), 해줘 (casual request), 해봐 (casual "try"),
+#   하지마 (casual prohibition), 했어 (casual past), 이야 (casual copula),
+#   거야 (casual future/assertion), 할게 (casual promise), 할래 (casual volition),
+#   하자 (casual proposal), 잖아 (casual softener), 거든 (casual explanation).
+# DELIBERATELY LEFT OUT (cannot be safely substring-matched — would false-positive
+# on valid polite text): the bare plain-form declarative endings -ㄴ다/-는다/-다.
+# (한다/된다/있다) — 있다 appears mid-sentence in polite prose, and 하라/라고
+# occur inside polite indirect quotation (완료하라는, 오류라고 생각되시면); and
+# -지 마 — which is the polite prohibition 하지 마세요 (걱정하지 마세요). Those
+# plain forms are locked via register_spec.forbidden_endings + the rule
+# rule.ko-register-politeness instead (this is exactly what the ja pilot did with
+# the plain copula だ). SPEC §2.3 lint only scans `good` examples, and every
+# `good` example here is verified clean against this token list.
+#
+# AGENT-AUTHORED; requires native-speaker (KO) sign-off — see PR label.
+form: other
+pronoun: "(omitted; politeness carried by verb endings — 합쇼체 -습니다 / 해요체 -세요)"
+forbidden_tokens:
+  - { token: 해라,   context: substring, severity: error, note: "casual/plain imperative (해라체 command); polite UI uses -세요 / 해 주세요 or noun-form labels — zero live hits" }
+  - { token: 해줘,   context: substring, severity: error, note: "casual request (do ~ for me); polite form is 해 주세요 — zero live hits" }
+  - { token: 해봐,   context: substring, severity: error, note: "casual 'try ~' imperative; polite form is 해 보세요 — zero live hits" }
+  - { token: 하지마, context: substring, severity: error, note: "casual prohibition (don't ~); polite form is 하지 마세요 — zero live hits" }
+  - { token: 했어,   context: substring, severity: error, note: "casual past/declarative (해체); polite form is 했습니다 / 했어요 — zero live hits" }
+  - { token: 이야,   context: substring, severity: error, note: "casual copula (it is ~); polite form is 입니다 / 이에요 — zero live hits" }
+  - { token: 거야,   context: substring, severity: error, note: "casual future/assertion (~할 거야); polite form is ~할 것입니다 / ~거예요 — zero live hits" }
+  - { token: 할게,   context: substring, severity: error, note: "casual promise/intention (I'll ~); polite form is 하겠습니다 — zero live hits" }
+  - { token: 할래,   context: substring, severity: error, note: "casual volition/offer (want to ~?); polite form is 하시겠습니까 — zero live hits" }
+  - { token: 하자,   context: substring, severity: error, note: "casual proposal (let's ~); polite form is 합시다 / 하시죠 — zero live hits" }
+  - { token: 잖아,   context: substring, severity: error, note: "casual softener (~you know); not used in polite UI — zero live hits" }
+  - { token: 거든,   context: substring, severity: error, note: "casual explanatory ending (~because/you see); not used in polite UI — zero live hits" }
+exceptions: []
+rule_ref: rule.ko-register-politeness
+# register_spec — the FREE-FORM extension where the real politeness policy lives
+# (the part that cannot be reduced to safe substring tokens). Follows the ja
+# pilot shape: system + level, the affirmed target_endings, the forbidden_endings
+# (including the bare plain-form -다 declaratives that are not safely tokenizable),
+# and a voice_by_context map mirroring the guide.
+register_spec:
+  system: korean_speech_levels
+  level: 합쇼체 (hapsyo-che, formal-polite) with 해요체 (haeyo-che) for requests
+  description: "Korean honorific politeness (높임법): formal-polite 합쇼체 (-습니다/-ㅂ니다) for declaratives/status and 해요체 (-세요 / 해 주세요) for instructions/requests, throughout product UI and email. Not a pronoun T/V split — the 2nd-person pronoun is dropped and deference is morphological."
+  target_endings:
+    declarative_formal: [-습니다, -ㅂ니다, -습니까, -ㅂ니까]      # 합쇼체 statements/questions (인증되었습니다, 만료되었습니다)
+    polite_imperative: [-세요, -으세요, 해 주세요, -십시오]        # 해요체 / 합쇼체 requests (입력하세요, 다시 시도해 주세요)
+    polite_haeyo: [-요, -에요, -예요]                            # 해요체 polite (used for softer requests/questions)
+  forbidden_endings:
+    plain_declarative: [-ㄴ다, -는다, -다]      # 해체/plain 반말 declaratives (한다/된다/있다) — see note: NOT in forbidden_tokens (-다 false-positives mid-sentence); locked here + by rule.
+    casual_imperative: [해라, 해, 해줘, 해봐]    # 반말 commands/requests (해라/해줘/해봐 also tokenized; bare 해 unsafe to tokenize)
+    casual_prohibition: [하지마, -지 마]         # 반말 prohibition (하지마 tokenized; -지 마 unsafe — collides with polite 하지 마세요)
+    casual_copula_future: [이야, 거야]           # 반말 copula/assertion (also tokenized)
+    casual_past: [했어, -았어, -었어]            # 반말 past (했어 tokenized)
+    casual_endings: [할게, 할래, 하자, 잖아, 거든]  # 반말 promise/volition/proposal/softeners (also tokenized)
+  voice_by_context:
+    buttons_and_actions: "imperative noun-form / verbal-noun labels (예: 복사, 비밀 메시지 소각, 비밀 링크 생성, 제출하기) — concise label form, not casual 반말 speech."
+    status_and_notifications: "passive/declarative 합쇼체 (예: 생성되었습니다, 소각되었습니다, 복사됨) — polite, not casual."
+    explanatory_and_instructions: "합쇼체 -습니다 for statements and 해요체 -세요 / 해 주세요 for instructions — polite and professional yet approachable."
+  notes: >-
+    The bare plain-form declarative endings -ㄴ다/-는다/-다 are the primary 반말
+    markers but are unsafe to substring-match against polite Korean (있다 appears
+    mid-sentence; 하라/라고 occur inside polite indirect quotation 완료하라는 /
+    오류라고; -다 is also inside many polite words). They are enforced via
+    rule.ko-register-politeness and this spec rather than forbidden_tokens.
+    Concise verbal-noun labels on buttons (복사, 소각, 공유) are the prescribed UI
+    voice, NOT a register violation.
+# baseline_ref: baselines.ko is intentionally omitted — no `baselines.ko` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
+# carry `baseline_ref: baselines.ko`.

--- a/locales/ko/rules.yaml
+++ b/locales/ko/rules.yaml
@@ -36,5 +36,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ko
 glossary_ref: glossary.ko
-# baseline_ref: baselines.ko intentionally omitted (no baselines.ko entry yet);
 # a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.ko

--- a/locales/ko/rules.yaml
+++ b/locales/ko/rules.yaml
@@ -1,0 +1,40 @@
+id: rules.ko
+source: onetimesecret/locales/guides/for-translators/ko.md
+inherits: base
+merge_strategy: append
+# Korean locale layer, inheriting base directly (standalone language, no regional
+# parent). Follows the ja keigo PILOT for the non-T/V register shape. Carries the
+# Korean-wide conventions transcribed from the translator guide
+# (onetimesecret/locales/guides/for-translators/ko.md): the formal-polite
+# 합쇼체/해요체 register lock, the 접근 문구 (passphrase) vs 비밀번호 (password)
+# distinction, the 비밀 메시지 (not bare 비밀 / 보안 메시지) terminology choice,
+# the 소각 / 암호화 security terms, and the imperative-noun-form-for-buttons UI
+# voice. Politeness in Korean is a speech level (높임법), not a pronoun T/V split.
+#
+# AGENT-AUTHORED transcription, grounded in live ko content; requires
+# native-speaker (KO) sign-off — see PR label.
+rules:
+  - id: rule.ko-register-politeness
+    modality: MUST
+    statement: "Korean content uses the formal-polite speech levels throughout product UI and email content: 합쇼체 (-습니다/-ㅂ니다) for declaratives and status, and 해요체 (-세요 / 해 주세요) for instructions and requests. The casual/plain 반말 (해체) forms — bare plain-form declaratives -ㄴ다/-는다/-다 (한다/된다/있다), casual imperatives/requests 해라/해/해줘/해봐, casual prohibition 하지마, casual copula/assertion 이야/거야, casual past 했어, and casual endings 할게/할래/하자/잖아/거든 — are forbidden. Exception: action buttons use concise verbal-noun / imperative noun-form labels (복사, 소각, 공유, 제출하기), and status messages use polite passive/declarative 합쇼체 (생성되었습니다, 소각되었습니다, 복사됨); neither is a register violation."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ko-passphrase-password
+    modality: MUST
+    statement: "Keep 비밀번호 (account login / authentication credential) distinct from 접근 문구 (protection of an individual secret); never use one where the other is meant, and never use the ambiguous 암호 for either."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ko-secret-message
+    modality: MUST
+    statement: "Render the product concept 'secret' as 비밀 메시지 (secret message), not bare 비밀 (only acceptable in short UI where context is absolutely clear) and never 보안 메시지. Use 비밀의 / 안전한 for the general adjective/secure sense."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.ko-button-imperative
+    modality: SHOULD
+    statement: "Use concise verbal-noun / imperative noun-form labels for buttons and actions (복사 / 소각 / 비밀 메시지 공유 / 비밀 링크 생성 / 제출하기); use polite passive/declarative 합쇼체 for status messages (생성되었습니다 / 소각되었습니다 / 복사됨)."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.ko
+glossary_ref: glossary.ko
+# baseline_ref: baselines.ko intentionally omitted (no baselines.ko entry yet);
+# a reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/ko/rules.yaml
+++ b/locales/ko/rules.yaml
@@ -36,5 +36,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ko
 glossary_ref: glossary.ko
-# a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.ko

--- a/locales/mi_NZ/glossary.yaml
+++ b/locales/mi_NZ/glossary.yaml
@@ -1,0 +1,207 @@
+id: glossary.mi_NZ
+source: onetimesecret/locales/guides/for-translators/mi_NZ.md
+# Sense-split of the core domain terminology from the te reo Māori translator
+# guide's terminology tables (onetimesecret/locales/guides/for-translators/mi_NZ.md
+# §Core Terminology, §Account-Related Terms, §Security Features), grounded against
+# the live app content in onetimesecret/locales/content/mi_NZ/*.json. Targets and
+# worked examples are AGENT-AUTHORED and require native-speaker (te reo Māori)
+# sign-off before merge — see PR label. Macronned vowels (ā ē ī ō ū) are used per
+# correct te reo orthography.
+#
+# Māori is space-delimited, so SPEC §2.3 lint check 2 (every `good` example's
+# target must contain a sense target in word_prefix mode) works normally: each
+# sense target below sits at a word boundary (start-of-string or after a space).
+# Each `good` example uses the singular koe address and is clean of the register
+# forbidden token (the plural koutou); each `bad` example demonstrates the wrong
+# form (plural koutou address, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as 'karere huna' (hidden message), never 'mea huna'."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    mi_NZ:
+      noun:
+        target: karere huna
+        rule_ref: rule.mi_NZ-secret-karere-huna
+    rule_refs: [rule.register-lock, rule.mi_NZ-secret-karere-huna]
+    examples:
+      - id: ex.secret-good#d81de1d4
+        source: "Create a secret"
+        target: "Waihanga karere huna"
+        verdict: good
+        note: "Grounded in live 'Waihanga hononga huna' / 'Tohatoha karere huna'; imperative 'Waihanga' for the action label; 'karere huna' (not 'mea huna')."
+        rule_refs: [rule.register-lock, rule.mi_NZ-secret-karere-huna]
+      - id: ex.secret-bad#36c87b0a
+        source: "Create a secret"
+        target: "Waihanga mea huna mā koutou"
+        verdict: bad
+        note: "Uses 'mea huna' (secret thing) instead of the glossary term 'karere huna' AND addresses the single user with the plural 'koutou' — violates rule.mi_NZ-secret-karere-huna and the singular-address register."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense of secret/secure/private — protection of information. Render as 'haumaru' (secure), 'huna' (hidden), 'matatapu' / 'tūmataiti' (private); reserve 'karere huna' for the product-noun sense."
+      key_patterns: ["*secure*", "*secured*", "*.protect*", "*private*"]
+    mi_NZ:
+      adjective:
+        target: haumaru
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adj-good#10b14bad
+        source: "Secure links, available one time only."
+        target: "Hononga haumaru, kotahi noa te wā e wātea ai ki a koe."
+        verdict: good
+        note: "Grounded in live 'Ngā hononga haumaru kotahi noa te wā e mahi ai'; adjective 'haumaru' for the secure/state sense; singular 'koe'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.secret-adj-bad#ccab3c56
+        source: "Secure links, available one time only."
+        target: "Hononga karere huna, kotahi noa te wā e wātea ai ki a koutou."
+        verdict: bad
+        note: "Uses the product-noun 'karere huna' for the general adjective/secure sense where 'haumaru' is meant (terminology drift), AND addresses the single user with plural 'koutou'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense. Render as 'kupu karapa'."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    mi_NZ:
+      noun:
+        target: kupu karapa
+        rule_ref: rule.mi_NZ-passphrase-password
+    rule_refs: [rule.register-lock, rule.mi_NZ-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Set a passphrase to protect this secret."
+        target: "Kupu karapa hei tiaki i tēnei karere huna nāu."
+        verdict: good
+        note: "Grounded in live 'kupu karapa' usage; 'kupu karapa' (secret protection), not 'kupuhipa'; singular possessive 'nāu'."
+        rule_refs: [rule.register-lock, rule.mi_NZ-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Set a passphrase to protect this secret."
+        target: "Whakatū kupuhipa hei tiaki i tēnei karere huna."
+        verdict: bad
+        note: "Uses 'kupuhipa' (account credential) where 'kupu karapa' (secret protection) is meant — violates rule.mi_NZ-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Render as 'kupuhipa'."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    mi_NZ:
+      noun:
+        target: kupuhipa
+        rule_ref: rule.mi_NZ-passphrase-password
+    rule_refs: [rule.register-lock, rule.mi_NZ-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Whakauru tō kupuhipa kia takiuru ai koe."
+        verdict: good
+        note: "Verbatim-grounded in live 'Whakauru tō kupuhipa'; account term 'kupuhipa' with singular possessive 'tō' and singular 'koe'."
+        rule_refs: [rule.register-lock, rule.mi_NZ-passphrase-password]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Whakauru ā koutou kupu karapa kia takiuru ai koutou."
+        verdict: bad
+        note: "Uses 'kupu karapa' (secret protection) where 'kupuhipa' (account credential) is meant, AND the plural 'koutou' for the single user — violates rule.mi_NZ-passphrase-password and the singular-address register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently deleting a secret before it is viewed. 'whakawareware' as the action label/verb; 'kua whakawarekia' for the resulting burned state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    mi_NZ:
+      action:
+        target: whakawareware
+        rule_ref: rule.terminology-consistency
+      state:
+        target: whakawarekia
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Whakawareware i tēnei karere huna i mua i te pānuitanga."
+        verdict: good
+        note: "Verbatim-grounded in live 'Whakawareware i tēnei karere huna'; action term 'whakawareware' in head position."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Tahuna tēnei karere huna mā koutou i mua i te pānuitanga."
+        verdict: bad
+        note: "Uses the literal 'tahuna' (set fire to) instead of the glossary term 'whakawareware' (terminology drift), AND the plural 'koutou' for the single user."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Render as 'hononga'."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    mi_NZ:
+      noun:
+        target: hononga
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Hononga huna hei tohatoha mā koe — tāruatia ki te papatopenga."
+        verdict: good
+        note: "Grounded in live 'Tohatoha he hononga huna'; term 'hononga' in head position; singular 'koe'; imperative 'tāruatia'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Tārua i te hokonga huna kia tohatoha ai koutou."
+        verdict: bad
+        note: "Uses 'hokonga' (a transaction/purchase mishearing) instead of the glossary term 'hononga' (terminology drift), AND the plural 'koutou' for the single user."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. 'whakamuhumuhu' for the action/verb; 'muhumuhu' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    mi_NZ:
+      action:
+        target: whakamuhumuhu
+        rule_ref: rule.terminology-consistency
+      state:
+        target: muhumuhu
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This information is encrypted; it can be viewed only once."
+        target: "Whakamuhumuhu tēnei mōhiohio; kotahi noa te wā e taea ai te tiro e koe."
+        verdict: good
+        note: "Verbatim-grounded in live 'Ka whakamuhumuhu tēnei mōhiohio, kotahi noa te wā e taea ai te tiro'; action term 'whakamuhumuhu' in head position; singular 'koe'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This information is encrypted; it can be viewed only once."
+        target: "Kua kāpuitia tēnei mōhiohio mā koutou; kotahi noa te wā e taea ai te tiro."
+        verdict: bad
+        note: "Uses 'kāpuitia' (locked/closed) instead of the glossary term 'whakamuhumuhu' / 'muhumuhu' (terminology drift), AND the plural 'koutou' for the single user."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Render as 'īmēra' (with macrons)."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    mi_NZ:
+      noun:
+        target: īmēra
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Check your email."
+        target: "Tirohia tō īmēra."
+        verdict: good
+        note: "Verbatim from live content ('Tirohia tō īmēra'); term 'īmēra' (macronned) with singular possessive 'tō'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.email-bad#5c29e476
+        source: "Check your email."
+        target: "Tirohia ā koutou īmera."
+        verdict: bad
+        note: "Plural 'koutou' for the single user (should be singular 'tō') AND 'īmera' missing the macrons of correct 'īmēra' orthography."

--- a/locales/mi_NZ/register.yaml
+++ b/locales/mi_NZ/register.yaml
@@ -51,10 +51,6 @@ register_spec:
     UI address. There is NO informal/formal lock to enforce — Māori has no T/V
     split, so this register is descriptive of number agreement, not a politeness
     register like es or de.
-# baseline_ref: baselines.mi_NZ is intentionally omitted — no `baselines.mi_NZ`
-# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
-# The pin is for a human reviewer to add to baselines.yaml centrally at commit
-# time (mirroring the fr / de_AT baselines entries), after which this and
-# rules.yaml can carry `baseline_ref: baselines.mi_NZ`.
 #
 # AGENT-AUTHORED; requires native-speaker (te reo Māori) sign-off — see PR label.
+baseline_ref: baselines.mi_NZ

--- a/locales/mi_NZ/register.yaml
+++ b/locales/mi_NZ/register.yaml
@@ -1,0 +1,60 @@
+id: register.mi_NZ
+source: onetimesecret/locales/guides/for-translators/mi_NZ.md
+# Te reo Māori has NO T/V formality split — there is no informal/formal pair to
+# lock (unlike es tú/usted or de du/Sie). The 2nd-person pronoun distinguishes
+# NUMBER, not politeness: koe (singular), kōrua (dual, exactly two), koutou
+# (plural, three or more). Product UI addresses ONE user, so the correct address
+# is the singular koe. Grounded in the live app content
+# (onetimesecret/locales/content/mi_NZ/*.json): direct address is uniformly
+# singular — koe appears ~125 times, while the dual kōrua and plural koutou have
+# ZERO occurrences anywhere. Singular possessives tō / ō are used likewise
+# (e.g. "Whakauru tō kupuhipa", "ō īmēra"). The prose guide agrees: §"Voice and
+# Tone" records "Addresses users in second person ('koe')".
+#
+# form: other — number-based 2nd person is not formal|informal|mixed in the T/V
+#   sense; there is no register to forbid, only a NUMBER agreement to keep.
+# pronoun: koe — the singular UI address (descriptive; the required field records
+#   it). The real number system lives in register_spec below.
+#
+# forbidden_tokens — the register dimension here is "correct pronoun NUMBER +
+# consistent terminology", not a forbidden politeness form. The one token that is
+# unambiguously wrong for singular UI address is the PLURAL koutou (addressing the
+# single user as 3+ people). It is safely tokenizable: Māori is space-delimited,
+# so standalone_word boundaries segment it cleanly, and koutou has ZERO live hits
+# (no false positives). The dual kōrua is NOT forbidden as a token — it could in
+# principle appear in legitimate quoted/relational prose, and it likewise has zero
+# live hits, so flagging it would add risk without benefit; it is documented in
+# register_spec instead. There is no informal/formal form to forbid.
+form: other
+pronoun: koe
+possessive: [tō, ō, tāu, āu]
+forbidden_tokens:
+  - { token: koutou, context: standalone_word, severity: warning, note: "plural 2nd-person pronoun (3+ people); singular UI address must use koe — zero live hits, so flagging it catches accidental plural address without false positives" }
+exceptions: []
+rule_ref: rule.mi_NZ-register-number
+# register_spec — FREE-FORM extension capturing the number-based (non-T/V) system.
+# This is the shape a native te reo reviewer should check: the pronoun system is
+# NUMBER, the UI default is the singular koe, and there is explicitly no T/V
+# politeness lock to enforce.
+register_spec:
+  pronoun_system: number_based
+  description: "Te reo Māori distinguishes 2nd person by NUMBER, not by politeness. There is no T/V (informal/formal) split; the register dimension is correct pronoun number plus consistent terminology."
+  singular: koe
+  dual: kōrua
+  plural: koutou
+  ui_default: koe
+  possessive_singular: [tō, ō, tāu, āu]
+  notes: >-
+    Product UI addresses a single user, so the singular koe (and singular
+    possessives tō / ō / tāu / āu) is the default and correct address. The dual
+    kōrua (exactly two) and plural koutou (three or more) are wrong for singular
+    UI address. There is NO informal/formal lock to enforce — Māori has no T/V
+    split, so this register is descriptive of number agreement, not a politeness
+    register like es or de.
+# baseline_ref: baselines.mi_NZ is intentionally omitted — no `baselines.mi_NZ`
+# entry exists in baselines.yaml yet, and a dangling reference fails the resolver.
+# The pin is for a human reviewer to add to baselines.yaml centrally at commit
+# time (mirroring the fr / de_AT baselines entries), after which this and
+# rules.yaml can carry `baseline_ref: baselines.mi_NZ`.
+#
+# AGENT-AUTHORED; requires native-speaker (te reo Māori) sign-off — see PR label.

--- a/locales/mi_NZ/rules.yaml
+++ b/locales/mi_NZ/rules.yaml
@@ -38,5 +38,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.mi_NZ
 glossary_ref: glossary.mi_NZ
-# yet); a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.mi_NZ

--- a/locales/mi_NZ/rules.yaml
+++ b/locales/mi_NZ/rules.yaml
@@ -38,5 +38,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.mi_NZ
 glossary_ref: glossary.mi_NZ
-# baseline_ref: baselines.mi_NZ intentionally omitted (no baselines.mi_NZ entry
 # yet); a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.mi_NZ

--- a/locales/mi_NZ/rules.yaml
+++ b/locales/mi_NZ/rules.yaml
@@ -1,0 +1,42 @@
+id: rules.mi_NZ
+source: onetimesecret/locales/guides/for-translators/mi_NZ.md
+inherits: base
+merge_strategy: append
+# Te reo Māori (New Zealand) locale layer, inheriting base directly (standalone
+# language, no regional parent). Carries the Māori-wide conventions transcribed
+# from the translator guide (onetimesecret/locales/guides/for-translators/mi_NZ.md)
+# and grounded in the live app content (onetimesecret/locales/content/mi_NZ/*.json):
+#   - number-based 2nd-person address (singular koe for the single-user UI; there
+#     is NO T/V politeness split to lock);
+#   - the kupuhipa (account password) vs kupu karapa (secret passphrase)
+#     distinction;
+#   - the "secret" -> "karere huna" (hidden message) terminology choice;
+#   - imperative voice for buttons / passive-declarative for status messages.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live mi_NZ content;
+# requires native-speaker (te reo Māori) sign-off before merge — see PR label.
+rules:
+  - id: rule.mi_NZ-register-number
+    modality: MUST
+    statement: "Te reo Māori has no T/V (informal/formal) split; the 2nd-person pronoun marks NUMBER. Product UI addresses one user, so use the singular koe (and singular possessives tō / ō / tāu / āu) throughout. Do not address the single user with the dual kōrua (exactly two) or the plural koutou (three or more)."
+    severity: warning
+    rule_ref: rule.register-lock
+  - id: rule.mi_NZ-passphrase-password
+    modality: MUST
+    statement: "Keep kupuhipa (account login / authentication credential) distinct from kupu karapa (protection of an individual secret); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.mi_NZ-secret-karere-huna
+    modality: MUST
+    statement: "Render the product concept 'secret' (the noun) consistently as karere huna (hidden message), not mea huna (secret thing). Reserve the adjectives huna / matatapu / tūmataiti for the general secret/private sense."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.mi_NZ-voice-imperative-status
+    modality: SHOULD
+    statement: "Use active imperative voice for button and action labels (Waihanga, Tiaki, Tārua); use passive declarative voice for status messages (Kua hangaia, Kua tiakina, Kua tāruatia)."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.mi_NZ
+glossary_ref: glossary.mi_NZ
+# baseline_ref: baselines.mi_NZ intentionally omitted (no baselines.mi_NZ entry
+# yet); a reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/nl/glossary.yaml
+++ b/locales/nl/glossary.yaml
@@ -1,0 +1,201 @@
+id: glossary.nl
+source: onetimesecret/locales/guides/for-translators/nl.md
+# Sense-split of the core domain terminology from the Dutch translator guide's
+# terminology tables (nl.md §Woordenlijst, §Kernterminologie, §Kritische
+# vertaalregels), grounded against the live app content in
+# onetimesecret/locales/content/nl/. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (NL) sign-off before merge — see PR
+# label. Each `good` example uses the informal `je` register and contains the
+# term's target; each `bad` example demonstrates a forbidden form (the formal
+# u/uw register, or the wrong/forbidden term such as `geheim`).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as bericht / beveiligd bericht, never geheim."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    nl:
+      noun:
+        target: bericht
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Je bericht is aangemaakt."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Informal possessive 'Je' and the noun term 'bericht'."
+      - id: ex.secret-geheim-bad#250567fe
+        source: "Your secret has been created."
+        target: "Uw geheim is aangemaakt."
+        verdict: bad
+        note: "Formal possessive 'Uw' (forbidden register) AND 'geheim' instead of 'bericht' (criminal-underworld associations) — violates both register-lock and rule.nl-secret-noun."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense of secret/secure — protection of information. Render as beveiligd; avoid geheim and vertrouwelijk in general UI text."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    nl:
+      adjective:
+        target: beveiligd
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.secret-adjective-good#7c1d5a40
+        source: "Share secure links with anyone."
+        target: "Deel beveiligde links met iedereen."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Adjective sense 'beveiligde' (word_prefix of 'beveiligd')."
+      - id: ex.secret-adjective-bad#9e2f01b7
+        source: "Share secure links with anyone."
+        target: "Deel vertrouwelijke links met iedereen."
+        verdict: bad
+        note: "'vertrouwelijke' is reserved for formal legal contexts and sounds defensive in general UI — should be 'beveiligde'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    nl:
+      noun:
+        target: wachtwoordzin
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Voer de wachtwoordzin in om dit bericht te bekijken."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Uses 'wachtwoordzin' (secret protection), distinct from the account 'wachtwoord'."
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Voer het wachtwoord in om dit bericht te bekijken."
+        verdict: bad
+        note: "Uses 'wachtwoord' (login credential) where 'wachtwoordzin' (secret protection) is meant — violates rule.nl-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    nl:
+      noun:
+        target: wachtwoord
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Voer je wachtwoord in om in te loggen."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Informal possessive 'je' plus the account term 'wachtwoord'."
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Voer uw wachtwoord in om in te loggen."
+        verdict: bad
+        note: "Formal possessive 'uw' — the forbidden formal register; should be 'je'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb 'verbranden' for the action label; past participle 'verbrand' for the resulting status."
+      key_patterns: ["*burn*", "*.destroy*"]
+    nl:
+      verb:
+        target: verbranden
+        rule_ref: rule.terminology-consistency
+      state:
+        target: verbrand
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Verbrand dit bericht voordat het wordt gelezen."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Imperative 'Verbrand' for the action, plus the noun 'bericht'."
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Vernietig uw geheim voordat het wordt gelezen."
+        verdict: bad
+        note: "Formal 'uw' plus 'geheim' (forbidden noun) and 'Vernietig' instead of the glossary verb 'verbranden' — register and terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. 'link' (borrowed, preferred in UI) or 'koppeling' (native, for longer documentation); pick one and stay consistent."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    nl:
+      noun:
+        target: link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy your secret link to share it."
+        target: "Kopieer je link om die te delen."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Informal imperative 'Kopieer' plus 'je' and the term 'link'."
+      - id: ex.link-bad#748809c5
+        source: "Copy your secret link to share it."
+        target: "Kopieer uw link om die te delen."
+        verdict: bad
+        note: "Formal possessive 'uw' — the forbidden formal register; should be 'je'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'versleutelen', past participle 'versleuteld' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    nl:
+      verb:
+        target: versleutelen
+        rule_ref: rule.terminology-consistency
+      state:
+        target: versleuteld
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Dit bericht is versleuteld met je wachtwoordzin."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "State 'versleuteld' plus informal 'je' and 'wachtwoordzin'."
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Dit bericht is versleuteld met uw wachtwoord."
+        verdict: bad
+        note: "Formal possessive 'uw' (forbidden register) plus 'wachtwoord' (account credential) where 'wachtwoordzin' is meant."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Written with a hyphen: e-mail."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    nl:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.terminology-consistency, rule.register-lock]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Voer je e-mailadres in."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Informal possessive 'je' plus the term 'e-mail' (word_prefix of 'e-mailadres')."
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Voer uw e-mailadres in."
+        verdict: bad
+        note: "Formal possessive 'uw' — the forbidden formal register; should be 'je'."

--- a/locales/nl/register.yaml
+++ b/locales/nl/register.yaml
@@ -23,6 +23,4 @@ forbidden_tokens:
   - { token: uzelf, context: standalone_word, severity: error, note: "formal reflexive pronoun" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted: baselines.yaml has no `nl` entry yet and is
-# off-limits to this change. baseline_ref: baselines.nl would dangle and fail the
-# resolver; add it with the baselines.yaml `nl` block when that lands centrally.
+baseline_ref: baselines.nl

--- a/locales/nl/register.yaml
+++ b/locales/nl/register.yaml
@@ -1,0 +1,28 @@
+id: register.nl
+source: onetimesecret/locales/guides/for-translators/nl.md
+# Dutch is locked to the informal `je` register. Grounded in the live app content
+# (onetimesecret/locales/content/nl/*.json): the informal forms je / jij / jouw /
+# jezelf appear across all 19 content files and dominate every user-facing flow
+# (e.g. "Heb je een account nodig?", "Voer je wachtwoord in", "Maak je account
+# aan"). The formal forms u / uw appear in only ~8 files and a small minority of
+# strings, confined to legal/regulatory (feature-regions), generic error pages,
+# and enterprise/billing marketing copy — exactly the formal-B2B carve-out the
+# prose guide names. The guide is explicit: use "je" (informeel), not "u"
+# (formeel), for an accessible tone (nl.md §"Directe aanspraak (je vs. u)").
+# This is the inverse of the fr/de_AT formal locks: here the FORMAL register is
+# forbidden, so the formal pronoun/possessive/reflexive (u / uw / uwe / uzelf)
+# become forbidden standalone-word tokens.
+# AGENT-AUTHORED; requires native-speaker (NL) sign-off — see PR label.
+form: informal
+pronoun: je
+possessive: [je, jouw]
+forbidden_tokens:
+  - { token: u,     context: standalone_word, severity: error, note: "formal subject/object pronoun (the V-form this locale forbids); note 'u' is also the abbreviation for 'uur' — keep it out of good examples" }
+  - { token: uw,    context: standalone_word, severity: error, note: "formal possessive" }
+  - { token: uwe,   context: standalone_word, severity: error, note: "formal possessive, inflected/archaic form" }
+  - { token: uzelf, context: standalone_word, severity: error, note: "formal reflexive pronoun" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted: baselines.yaml has no `nl` entry yet and is
+# off-limits to this change. baseline_ref: baselines.nl would dangle and fail the
+# resolver; add it with the baselines.yaml `nl` block when that lands centrally.

--- a/locales/nl/rules.yaml
+++ b/locales/nl/rules.yaml
@@ -1,0 +1,42 @@
+id: rules.nl
+source: onetimesecret/locales/guides/for-translators/nl.md
+inherits: base
+merge_strategy: append
+# Dutch locale layer. nl is a standalone language (no family parent), so it
+# inherits `base` directly — mirroring how locales/fr/rules.yaml inherits base.
+# Carries the Dutch conventions transcribed from
+# onetimesecret/locales/guides/for-translators/nl.md and grounded in the live
+# app content under onetimesecret/locales/content/nl/: the informal `je`
+# register, the secret->bericht (NOT geheim) noun choice, the wachtwoord /
+# wachtwoordzin distinction, and the active-imperative / passive-status voice
+# split. Each rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (NL) sign-off before
+# merge — see PR label.
+rules:
+  - id: register.nl.formality
+    modality: MUST
+    statement: Dutch content uses the informal je register (je / jij / jouw) throughout product UI and email content; the formal u / uw forms are forbidden except in explicitly formal B2B/enterprise or legal contexts.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.nl-secret-noun
+    modality: MUST
+    statement: Translate the noun "secret" as bericht (or beveiligd bericht for emphasis), never geheim — geheim evokes criminal-underworld associations in Dutch and is unfit for a security product. Use beveiligd for the adjective sense.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.nl-passphrase-password
+    modality: MUST
+    statement: Keep wachtwoord (account authentication / login) distinct from wachtwoordzin (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.nl-active-passive-voice
+    modality: SHOULD
+    statement: Use the active imperative for buttons and user actions (Opslaan, Verwijderen, Aanmaken) and the passive/declarative voice for status and informational messages (Opgeslagen, Verwijderd, Link aangemaakt).
+    severity: warning
+    rule_ref: rule.message-voice
+# baseline_ref intentionally omitted: baselines.yaml has no `nl` entry yet and is
+# off-limits to this change (a human reviewer pins the baseline centrally). A
+# baseline_ref: baselines.nl here would be a dangling reference and fail the
+# resolver. Add it together with the baselines.yaml `nl` block when that lands.
+register_ref: register.nl
+glossary_ref: glossary.nl

--- a/locales/nl/rules.yaml
+++ b/locales/nl/rules.yaml
@@ -34,9 +34,6 @@ rules:
     statement: Use the active imperative for buttons and user actions (Opslaan, Verwijderen, Aanmaken) and the passive/declarative voice for status and informational messages (Opgeslagen, Verwijderd, Link aangemaakt).
     severity: warning
     rule_ref: rule.message-voice
-# baseline_ref intentionally omitted: baselines.yaml has no `nl` entry yet and is
-# off-limits to this change (a human reviewer pins the baseline centrally). A
-# baseline_ref: baselines.nl here would be a dangling reference and fail the
-# resolver. Add it together with the baselines.yaml `nl` block when that lands.
 register_ref: register.nl
 glossary_ref: glossary.nl
+baseline_ref: baselines.nl

--- a/locales/pl/glossary.yaml
+++ b/locales/pl/glossary.yaml
@@ -1,0 +1,173 @@
+id: glossary.pl
+source: onetimesecret/locales/guides/for-translators/pl.md
+# Sense-split of the core domain terminology from the Polish translator guide's
+# terminology tables (§ Core Terminology, § Special Considerations), grounded
+# against the live app content in onetimesecret/locales/content/pl/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (PL)
+# sign-off before merge — see PR label. Each `good` example uses the locked
+# informal "ty" register and contains its term's sense target; each `bad`
+# example demonstrates a forbidden form — the formal Pan/Pani honorific address.
+# Polish nouns/verbs inflect heavily; sense targets use a sensible citation form
+# (nominative noun / infinitive verb) and good examples keep that form so the
+# word_prefix sense-target check holds.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Never substitute wiadomość (message) for this sense."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    pl:
+      noun:
+        target: sekret
+        rule_ref: rule.pl-secret-not-message
+    rule_refs: [register.pl.informality, rule.pl-secret-not-message]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Twój sekret został utworzony."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.secret-formal-bad#c6306bcd
+        source: "Your secret has been created."
+        target: "Pani sekret został utworzony."
+        verdict: bad
+        note: "Formal possessive 'Pani' (formal 'your') — the forbidden formal register; informal would be 'Twój'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    pl:
+      noun:
+        target: fraza dostępowa
+        rule_ref: rule.pl-passphrase-password
+    rule_refs: [register.pl.informality, rule.pl-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Your passphrase is required to view this secret."
+        target: "Twoja fraza dostępowa jest wymagana, aby wyświetlić ten sekret."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Your passphrase is required to view this secret."
+        target: "Hasło Pani jest wymagane, aby wyświetlić ten sekret."
+        verdict: bad
+        note: "Uses 'Hasło' (account password) where 'fraza dostępowa' is meant — violates rule.pl-passphrase-password; also formal 'Pani'."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset-password contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    pl:
+      noun:
+        target: hasło
+        rule_ref: rule.pl-passphrase-password
+    rule_refs: [register.pl.informality, rule.pl-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Wprowadź swoje hasło, aby się zalogować."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Proszę wprowadzić hasło Pana, aby się zalogować."
+        verdict: bad
+        note: "Formal honorific 'Pana' plus the deferential 'Proszę wprowadzić' construction — the forbidden formal register; informal is the imperative 'Wprowadź ... swoje'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of destroying a secret before it is viewed. Verb form (zniszczyć) for the action label; spalić is an accepted synonym, zniszczony the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    pl:
+      verb:
+        target: zniszczyć
+        rule_ref: rule.terminology-consistency
+      state:
+        target: zniszczony
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pl.informality, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Are you sure you want to burn this secret?"
+        target: "Czy na pewno chcesz zniszczyć ten sekret?"
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.burn-bad#4228df6b
+        source: "Are you sure you want to burn this secret?"
+        target: "Czy na pewno Pani chce zniszczyć ten sekret?"
+        verdict: bad
+        note: "Formal honorific 'Pani' with 3rd-person 'chce' — the forbidden formal register; informal is 2nd-sg 'chcesz'."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. 'link' is the commonly used Polish term; 'łącze' is an accepted alternative."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    pl:
+      noun:
+        target: link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pl.informality, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Skopiuj link do sekretu, aby go udostępnić."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Proszę skopiować link Pana do sekretu."
+        verdict: bad
+        note: "Formal honorific 'Pana' plus deferential infinitive 'Proszę skopiować' — the forbidden formal register; informal is the imperative 'Skopiuj'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'szyfrować', past participle 'zaszyfrowany' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    pl:
+      verb:
+        target: szyfrować
+        rule_ref: rule.terminology-consistency
+      state:
+        target: zaszyfrowany
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pl.informality, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "Your secret is encrypted with your passphrase."
+        target: "Twój sekret jest zaszyfrowany Twoją frazą dostępową."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.encrypt-bad#450020c5
+        source: "Your secret is encrypted with your passphrase."
+        target: "Sekret Pana jest zaszyfrowany frazą dostępową."
+        verdict: bad
+        note: "Formal possessive 'Pana' (formal 'your') — the forbidden formal register; informal would be 'Twój'."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Kept hyphenated as 'e-mail' in Polish."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    pl:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pl.informality, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Wprowadź swój adres e-mail."
+        verdict: good
+        rule_refs: [register.pl.informality]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Proszę podać adres e-mail Pana."
+        verdict: bad
+        note: "Formal honorific 'Pana' plus deferential 'Proszę podać' — the forbidden formal register; informal is the imperative 'Wprowadź ... swój'."

--- a/locales/pl/register.yaml
+++ b/locales/pl/register.yaml
@@ -36,6 +36,4 @@ forbidden_tokens:
   - { token: Państwa,  context: standalone_word, severity: error, note: "formal plural honorific / formal possessive 'your' (plural)" }
 exceptions: []
 rule_ref: register.pl.informality
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# baselines.pl entry exists yet and this backfill must not edit baselines.yaml,
-# while the resolver hard-fails on a dangling baseline_ref.
+baseline_ref: baselines.pl

--- a/locales/pl/register.yaml
+++ b/locales/pl/register.yaml
@@ -1,0 +1,41 @@
+id: register.pl
+source: onetimesecret/locales/guides/for-translators/pl.md
+# Polish is locked to the INFORMAL "ty" register. Grounded in the live app
+# content (onetimesecret/locales/content/pl/*.json): user-facing strings use
+# informal 2nd-person singular throughout — possessives Twój / Twoja / Twoje /
+# Twoją / Twoich (e.g. "Twój sekret został wyświetlony", "Twoja prywatność jest
+# chroniona"), object pronouns Ci / Cię ("%{sender_email} wysłał Ci sekret"),
+# and 2nd-sg verb forms (możesz, chcesz, otrzymasz, nie prosiłeś). The formal
+# Pan/Pani honorific address appears ZERO times. The prose guide concurs (§6
+# Direct Address; Summary §5).
+#
+# Because the locked register is informal, the FORBIDDEN register is the formal
+# one: the Pan/Pani honorific address forms and their case-inflected variants.
+# These are matched as standalone_word (NOT word_prefix/substring) on purpose —
+# "Pan"/"Pana" are substrings of valid Polish words present in the content
+# ("Panel", "panelu", "company", "expanded", "lifespan"), so a looser context
+# would false-positive. As standalone words they have zero legitimate use here.
+#
+# Note: the formal register also uses 3rd-person verb agreement, but those forms
+# overlap with the passive/declarative voice the informal register legitimately
+# uses for status messages ("Sekret został utworzony"), so they are not listed
+# as forbidden tokens — the honorific address words are the unambiguous markers.
+#
+# AGENT-AUTHORED; requires native-speaker (PL) sign-off — see PR label.
+form: informal
+pronoun: ty
+possessive: [Twój, Twoja, Twoje, Twojego, Twojej, Twoich, Twoją, Twoim, Twoimi]
+forbidden_tokens:
+  - { token: Pan,      context: standalone_word, severity: error, note: "formal honorific address (nominative, masc.)" }
+  - { token: Pani,     context: standalone_word, severity: error, note: "formal honorific address (fem.) / formal possessive 'your'" }
+  - { token: Pana,     context: standalone_word, severity: error, note: "formal honorific / formal possessive 'your' (gen./acc., masc.)" }
+  - { token: Panu,     context: standalone_word, severity: error, note: "formal honorific address (dative, masc.)" }
+  - { token: Panią,    context: standalone_word, severity: error, note: "formal honorific address (instr./acc., fem.)" }
+  - { token: Panem,    context: standalone_word, severity: error, note: "formal honorific address (instrumental, masc.)" }
+  - { token: Państwo,  context: standalone_word, severity: error, note: "formal plural honorific address (you, formal)" }
+  - { token: Państwa,  context: standalone_word, severity: error, note: "formal plural honorific / formal possessive 'your' (plural)" }
+exceptions: []
+rule_ref: register.pl.informality
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# baselines.pl entry exists yet and this backfill must not edit baselines.yaml,
+# while the resolver hard-fails on a dangling baseline_ref.

--- a/locales/pl/rules.yaml
+++ b/locales/pl/rules.yaml
@@ -46,7 +46,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.pl
 glossary_ref: glossary.pl
-# baseline_ref intentionally omitted: no baselines.pl entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it
-# is left out until a reviewer adds the central baselines.pl pin.
+baseline_ref: baselines.pl

--- a/locales/pl/rules.yaml
+++ b/locales/pl/rules.yaml
@@ -1,0 +1,52 @@
+id: rules.pl
+source: onetimesecret/locales/guides/for-translators/pl.md
+inherits: base
+merge_strategy: append
+# Polish locale layer. pl is a standalone shipping language (no family parent),
+# so it inherits `base` directly — mirroring locales/fr/rules.yaml but with the
+# OPPOSITE register decision: Polish is locked to the INFORMAL "ty" register.
+# That choice is grounded in the live app content
+# (onetimesecret/locales/content/pl/*.json), which uses informal 2nd-person
+# singular throughout (Twój/Twoje/Twoją possessives, możesz/chcesz/otrzymasz
+# verb forms, Ci/Cię object pronouns) and contains zero formal Pan/Pani address.
+# The prose guide agrees (§6 Direct Address, Summary §5: "Informal 'ty' form").
+#
+# rule.pl-pluralization captures the complex Polish plural system (1 / 2-4 / 5+),
+# which the guide flags as critical; it specialises the base
+# rule.pluralization-syntax. The hasło / fraza dostępowa distinction is the
+# single most critical terminology rule in the guide (§ Password vs. Passphrase).
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (PL) sign-off before merge — see PR label.
+rules:
+  - id: register.pl.informality
+    modality: MUST
+    statement: Polish content uses the informal "ty" register (ty / Twój / Twoja / Twoje / Ci / Cię) with 2nd-person singular verb forms throughout product UI and email content; the formal Pan/Pani address is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.pl-pluralization
+    modality: MUST
+    statement: Express countable strings with the three Polish plural forms (1 / 2-4 / 5+), choosing by the number's final digit (numbers ending 2-4 except 12-14 take the 2-4 form), via vue-i18n pipe syntax.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.pl-passphrase-password
+    modality: MUST
+    statement: Keep hasło (account login credential) distinct from fraza dostępowa (the passphrase protecting an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pl-secret-not-message
+    modality: MUST
+    statement: Translate the core "secret" concept as sekret consistently; do not substitute wiadomość (message) unless the source specifically refers to a message format.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pl-imperative-buttons
+    modality: SHOULD
+    statement: Use the 2nd-person-singular imperative for button and action labels (Utwórz, Zapisz, Wyślij); use passive voice or past participles for status and system messages.
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.pl
+glossary_ref: glossary.pl
+# baseline_ref intentionally omitted: no baselines.pl entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it
+# is left out until a reviewer adds the central baselines.pl pin.

--- a/locales/pt/glossary.yaml
+++ b/locales/pt/glossary.yaml
@@ -1,0 +1,176 @@
+id: glossary.pt
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+# Sense-split of the core domain terminology shared by both Portuguese variants,
+# from the pt_BR.md and pt_PT.md translator guides' terminology tables, grounded
+# against the live app content in onetimesecret/locales/content/pt_BR/*.json and
+# pt_PT/*.json. Terms common to BOTH variants live here (secret_object, passphrase,
+# burn, link, email); terms whose European form differs are carried with the
+# dominant Brazilian default here (password -> senha, encrypt -> criptografar) and
+# OVERRIDDEN in glossary.pt_PT (palavra-passe, encriptar). pt_BR inherits this
+# parent unchanged; pt_PT carries only its deltas (ADR-001 glossary inheritance).
+# Each `good` example uses the você-form register; each `bad` example demonstrates
+# a forbidden form (the tu-form register, or the wrong term).
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (pt)
+# sign-off before merge — see PR label.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. Translated as 'mensagem confidencial', never 'segredo'."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    pt:
+      noun:
+        target: mensagem confidencial
+        rule_ref: rule.pt-secret-confidencial
+    rule_refs: [register.pt.formality, rule.pt-secret-confidencial]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Sua mensagem confidencial foi criada."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt-secret-confidencial]
+      - id: ex.secret-informal-bad#250567fe
+        source: "Your secret has been created."
+        target: "O teu segredo foi criado."
+        verdict: bad
+        note: "Two violations: 'segredo' instead of 'mensagem confidencial' (rule.pt-secret-confidencial), and the tu-form possessive 'teu' (forbidden register)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects a secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    pt:
+      noun:
+        target: frase secreta
+        rule_ref: rule.pt-passphrase-password
+    rule_refs: [register.pt.formality, rule.pt-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Digite a frase secreta para visualizar esta mensagem confidencial."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Digite a senha para visualizar esta mensagem confidencial."
+        verdict: bad
+        note: "Uses 'senha' (login credential) where 'frase secreta' (secret protection) is meant — violates rule.pt-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Brazilian 'senha'; pt_PT overrides to 'palavra-passe'."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    pt:
+      noun:
+        target: senha
+        rule_ref: rule.pt-passphrase-password
+    rule_refs: [register.pt.formality, rule.pt-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Digite sua senha para entrar na conta."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt-passphrase-password]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Digite a tua senha para iniciar a sessão."
+        verdict: bad
+        note: "Tu-form possessive 'tua' — the forbidden tu-form register for the você-form pt parent."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb form for the action label, past participle for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    pt:
+      verb:
+        target: queimar
+        rule_ref: rule.terminology-consistency
+      state:
+        target: queimado
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pt.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burn this secret before it is read."
+        target: "Queimar esta mensagem confidencial antes que seja lida."
+        verdict: good
+        note: "Infinitive 'Queimar' for the button label, per rule.pt-imperative-buttons."
+        rule_refs: [register.pt.formality, rule.pt-imperative-buttons]
+      - id: ex.burn-bad#4228df6b
+        source: "Burn this secret before it is read."
+        target: "Destruir esta mensagem confidencial antes que seja lida."
+        verdict: bad
+        note: "Uses 'Destruir' instead of the glossary term 'queimar' — terminology drift."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Same form ('e-mail') in both Portuguese variants."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    pt:
+      noun:
+        target: e-mail
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pt.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address."
+        target: "Digite seu endereço de e-mail."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.terminology-consistency]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "Digite o teu endereço de e-mail."
+        verdict: bad
+        note: "Tu-form possessive 'teu' — the forbidden tu-form register for the você-form pt parent."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Same form ('link') in both Portuguese variants."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    pt:
+      noun:
+        target: link
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pt.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the secret link to share it."
+        target: "Copie o link para compartilhar sua mensagem confidencial."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.terminology-consistency]
+      - id: ex.link-bad#748809c5
+        source: "Copy the secret link to share it."
+        target: "Copia o teu link para partilhares a mensagem confidencial."
+        verdict: bad
+        note: "Tu-form possessive 'teu' plus tu-form verb 'partilhares' — the forbidden tu-form register for the você-form pt parent."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; Brazilian verb 'criptografar', past participle 'criptografado'. pt_PT overrides to 'encriptar'/'encriptado'."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    pt:
+      verb:
+        target: criptografar
+        rule_ref: rule.terminology-consistency
+      state:
+        target: criptografado
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.pt.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "Your content is encrypted at rest."
+        target: "Seu conteúdo é criptografado em repouso."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "Your content is encrypted at rest."
+        target: "O teu conteúdo é encriptado em repouso."
+        verdict: bad
+        note: "Uses the European 'encriptado' instead of the Brazilian 'criptografado', plus the tu-form possessive 'teu' — wrong term and forbidden register for the você-form pt parent."

--- a/locales/pt/register.yaml
+++ b/locales/pt/register.yaml
@@ -31,5 +31,4 @@ forbidden_tokens:
   - { token: ti,   context: standalone_word, severity: error, note: "tu-form prepositional pronoun" }
 exceptions: []
 rule_ref: register.pt.formality
-# baseline_ref deferred: baselines.pt is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt

--- a/locales/pt/register.yaml
+++ b/locales/pt/register.yaml
@@ -1,0 +1,35 @@
+id: register.pt
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+# Portuguese family-parent register: the shared/dominant Portuguese register, the
+# você-form (3rd-person-singular) direct address with seu/sua possessives. This is
+# the register the app ships dominant across the Portuguese family: the live
+# pt_BR content uses it exclusively (seu/sua = 324 occurrences, zero standalone
+# tu/teu/tua), and the live pt_PT content uses it for the majority of strings too
+# (seu/sua = 171, plus você-form imperatives like "Introduza"/"Crie"). The app
+# ships pt_BR and pt_PT, not bare pt, but this parent must carry a register so it
+# stays a valid governed locale; the você-form is the natural shared default.
+#
+# Locked to the você-form, so the forbidden register is the European tu-form
+# direct address: standalone tu and the tu-form possessives teu/tua/teus/tuas plus
+# the tu object/prepositional pronouns te/ti. These are zero in the live pt_BR
+# content, so forbidding them is safe here.
+#
+# Deliberately NOT forbidden: seu/sua/seus/suas — these ARE the você-register
+# possessives this locale uses, and are also the ordinary 3rd-person possessive
+# (cf. locales/es/register.yaml leaving su/sus free for the same reason).
+#
+# AGENT-AUTHORED; requires native-speaker (pt) sign-off before merge — see PR label.
+form: formal
+pronoun: você
+possessive: [seu, sua, seus, suas]
+forbidden_tokens:
+  - { token: tu,   context: standalone_word, severity: error, note: "tu-form subject pronoun (European informal); the você-form register does not use it" }
+  - { token: teu,  context: standalone_word, severity: error, note: "tu-form possessive (masc.)" }
+  - { token: tua,  context: standalone_word, severity: error, note: "tu-form possessive (fem.)" }
+  - { token: teus, context: standalone_word, severity: error, note: "tu-form possessive (masc. plural)" }
+  - { token: tuas, context: standalone_word, severity: error, note: "tu-form possessive (fem. plural)" }
+  - { token: ti,   context: standalone_word, severity: error, note: "tu-form prepositional pronoun" }
+exceptions: []
+rule_ref: register.pt.formality
+# baseline_ref deferred: baselines.pt is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).

--- a/locales/pt/rules.yaml
+++ b/locales/pt/rules.yaml
@@ -1,0 +1,40 @@
+id: rules.pt
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+inherits: base
+merge_strategy: append
+# Portuguese-wide layer (base-inheriting family parent), mirroring locales/fr/rules.yaml.
+# Carries the Portuguese conventions shared by every pt_* variant: the secret ->
+# "mensagem confidencial" (never "segredo") rule, the senha/palavra-passe vs
+# "frase secreta" distinction, the imperative-for-buttons rule, and the consistent
+# direct-address register. Regional variants (pt_BR, pt_PT) inherit this and add
+# only their deltas (pt_PT overrides the European-specific lexis: palavra-passe,
+# encriptar, partilhar). The app ships pt_BR and pt_PT, not bare pt; this parent is
+# populated so it remains a valid governed locale and a real inheritance base.
+#
+# AGENT-AUTHORED transcription of onetimesecret/locales/guides/for-translators/pt_BR.md
+# and pt_PT.md; requires native-speaker (pt_BR + pt_PT) sign-off before merge — see PR label.
+rules:
+  - id: register.pt.formality
+    modality: MUST
+    statement: Portuguese content uses a consistent direct-address register throughout product UI and email content; mixing registers (e.g. switching between você-form and tu-form address within a locale) is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.pt-secret-confidencial
+    modality: MUST
+    statement: Translate the noun "secret" as "mensagem confidencial" (or "conteúdo confidencial"), never as "segredo", which implies a personal secret rather than the shared protected message.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pt-passphrase-password
+    modality: MUST
+    statement: Keep the account login credential (senha / palavra-passe) distinct from "frase secreta" (the credential that protects a secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pt-imperative-buttons
+    modality: MUST
+    statement: Use the imperative for button and command labels (Criar, Visualizar, Enviar, Cancelar); use declarative/passive voice for status and informational text.
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.pt
+glossary_ref: glossary.pt
+# baseline_ref deferred: baselines.pt is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).

--- a/locales/pt/rules.yaml
+++ b/locales/pt/rules.yaml
@@ -36,5 +36,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.pt
 glossary_ref: glossary.pt
-# baseline_ref deferred: baselines.pt is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt

--- a/locales/pt_BR/glossary.yaml
+++ b/locales/pt_BR/glossary.yaml
@@ -1,0 +1,15 @@
+id: glossary.pt_BR
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+# Brazilian Portuguese glossary — intentionally empty (no regional term delta). The
+# resolver merges glossaries along the rules inheritance chain (ADR-001), keying by
+# term `key`, so an empty child inherits the full pt terminology unchanged:
+# secret_object (mensagem confidencial), passphrase (frase secreta), password
+# (senha), burn (queimar/queimado), email (e-mail), link (link), encrypt
+# (criptografar/criptografado) — 7 terms. The pt parent's defaults ARE the
+# Brazilian forms (glossary.pt was grounded against the live pt_BR content), so
+# unlike pt_PT there is NO override here. In particular password stays "senha"
+# (live pt_BR uses "senha" 78×, "palavra-passe" 0×) and encrypt stays
+# "criptografar" (live pt_BR uses "criptograf*" 9×, "encript*" 0×).
+# All inherited terms remain governed by rules.pt / register.pt.formality.
+# AGENT-AUTHORED; requires native-speaker (pt_BR) sign-off before merge — see PR label.
+terms: []

--- a/locales/pt_BR/register.yaml
+++ b/locales/pt_BR/register.yaml
@@ -33,5 +33,4 @@ forbidden_tokens:
   - { token: ti,   context: standalone_word, severity: error, note: "tu-form prepositional pronoun" }
 exceptions: []
 rule_ref: register.pt.formality
-# baseline_ref deferred: baselines.pt_BR is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt_BR

--- a/locales/pt_BR/register.yaml
+++ b/locales/pt_BR/register.yaml
@@ -1,0 +1,37 @@
+id: register.pt_BR
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+# Brazilian Portuguese register: the você-form (3rd-person-singular) direct address
+# with seu/sua possessives. Grounded in the live app content
+# (onetimesecret/locales/content/pt_BR/*.json): direct address consistently uses
+# the você-form — seu/sua/seus/suas = 324 occurrences (e.g. "Sua mensagem segura
+# foi entregue", "Seu conteúdo", "todos os seus segredos") — and the European
+# tu-form is entirely absent: standalone tu = 0, teu/tua/teus/tuas = 0. The prose
+# guide agrees ("Formality and Tone: Use 'Você'"; Principle #6 "professional yet
+# approachable voice using 'você'"). So the forbidden register is the European
+# tu-form: standalone tu, tu-form possessives teu/tua/teus/tuas, prepositional ti.
+# All zero in the live pt_BR content, so forbidding them is safe.
+#
+# This file is self-contained because the resolver loads register per-locale and
+# does NOT merge it across the rules inheritance chain (only rules.yaml inherits);
+# so pt_BR must restate the lock to keep .resolved/pt_BR.json's register populated.
+# It matches register.pt because pt_BR and the pt parent share the você-form (the
+# parent was grounded against pt_BR). Mirrors locales/fr_FR/register.yaml.
+#
+# Deliberately NOT forbidden: seu/sua/seus/suas — these ARE the você-register
+# possessives this locale uses (cf. locales/es/register.yaml leaving su/sus free).
+#
+# AGENT-AUTHORED; requires native-speaker (pt_BR) sign-off before merge — see PR label.
+form: formal
+pronoun: você
+possessive: [seu, sua, seus, suas]
+forbidden_tokens:
+  - { token: tu,   context: standalone_word, severity: error, note: "tu-form subject pronoun (European informal); pt_BR uses the você-form" }
+  - { token: teu,  context: standalone_word, severity: error, note: "tu-form possessive (masc.)" }
+  - { token: tua,  context: standalone_word, severity: error, note: "tu-form possessive (fem.)" }
+  - { token: teus, context: standalone_word, severity: error, note: "tu-form possessive (masc. plural)" }
+  - { token: tuas, context: standalone_word, severity: error, note: "tu-form possessive (fem. plural)" }
+  - { token: ti,   context: standalone_word, severity: error, note: "tu-form prepositional pronoun" }
+exceptions: []
+rule_ref: register.pt.formality
+# baseline_ref deferred: baselines.pt_BR is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).

--- a/locales/pt_BR/rules.yaml
+++ b/locales/pt_BR/rules.yaml
@@ -1,0 +1,19 @@
+id: rules.pt_BR
+source: onetimesecret/locales/guides/for-translators/pt_BR.md
+inherits: rules.pt
+merge_strategy: append
+# Brazilian Portuguese layer. The pt family parent (rules.pt / register.pt /
+# glossary.pt) was authored FROM the Brazilian conventions and live pt_BR content,
+# so pt_BR carries NO genuine regional delta: every Portuguese-wide rule from
+# rules.pt applies unchanged (você-form register, secret -> "mensagem confidencial",
+# senha/palavra-passe vs "frase secreta", imperative buttons) and every parent
+# glossary term is already the Brazilian form (senha, criptografar, compartilhar
+# via the share examples). Unlike pt_PT — whose deltas are the European lexis
+# (palavra-passe, encriptar, partilhar) — pt_BR adds no override rules; it is pure
+# inheritance. Mirrors locales/fr_FR/rules.yaml structurally.
+# AGENT-AUTHORED; requires native-speaker (pt_BR) sign-off before merge — see PR label.
+rules: []
+register_ref: register.pt_BR
+glossary_ref: glossary.pt_BR
+# baseline_ref deferred: baselines.pt_BR is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).

--- a/locales/pt_BR/rules.yaml
+++ b/locales/pt_BR/rules.yaml
@@ -15,5 +15,4 @@ merge_strategy: append
 rules: []
 register_ref: register.pt_BR
 glossary_ref: glossary.pt_BR
-# baseline_ref deferred: baselines.pt_BR is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt_BR

--- a/locales/pt_PT/glossary.yaml
+++ b/locales/pt_PT/glossary.yaml
@@ -1,0 +1,87 @@
+id: glossary.pt_PT
+source: onetimesecret/locales/guides/for-translators/pt_PT.md
+# European Portuguese glossary — delta-only. The resolver merges glossaries along
+# the rules inheritance chain (ADR-001), keying by term `key`, so this file only
+# carries the terms whose European form differs from the Brazilian pt parent.
+# Every inherited pt term (secret_object -> mensagem confidencial, passphrase ->
+# frase secreta, burn -> queimar, link -> link, email -> e-mail) flows through
+# unchanged; only the genuine deltas are overridden:
+#   - password: "palavra-passe" (parent: "senha") — live pt_PT: palavra-passe 78×, senha 0×
+#   - encrypt:  "encriptar"/"encriptado" (parent: "criptografar") — live: encript* 7×, criptograf* 0×
+# A new "share" term ("partilhar", live: partilh* 40×, compartilh* 0×) is added
+# too, recording the European sharing verb. All inherited terms remain governed by
+# rules.pt; the deltas add the pt_PT-specific rules. Good examples use the
+# guide-preferred tu-form (the register is `mixed`, so neither form is forbidden;
+# bad examples show the Brazilian term, the wrong-register violation being shown
+# via the note rather than a forbidden-token lint).
+# AGENT-AUTHORED; requires native-speaker (pt_PT) sign-off before merge — see PR label.
+terms:
+  - id: term.password_pt#01adcfc9
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential. In European Portuguese this is 'palavra-passe', never the Brazilian 'senha'."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    pt_PT:
+      noun:
+        target: palavra-passe
+        rule_ref: rule.pt_PT-palavra-passe
+    rule_refs: [register.pt.formality, rule.pt_PT-palavra-passe]
+    examples:
+      - id: ex.password-pt-good#1d706f6e
+        source: "Enter your password to sign in."
+        target: "Introduz a tua palavra-passe para iniciar sessão."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt_PT-palavra-passe]
+      - id: ex.password-pt-bad#07c9b67f
+        source: "Enter your password to sign in."
+        target: "Introduz a tua senha para iniciar sessão."
+        verdict: bad
+        note: "Uses the Brazilian 'senha' instead of the European 'palavra-passe' — violates rule.pt_PT-palavra-passe."
+  - id: term.encrypt_pt#4c804385
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. In European Portuguese the verb is 'encriptar', past participle 'encriptado', never the Brazilian 'criptografar'/'criptografado'."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    pt_PT:
+      verb:
+        target: encriptar
+        rule_ref: rule.pt_PT-encriptar
+      state:
+        target: encriptado
+        rule_ref: rule.pt_PT-encriptar
+    rule_refs: [register.pt.formality, rule.pt_PT-encriptar]
+    examples:
+      - id: ex.encrypt-pt-good#ef5eaa94
+        source: "Your content is encrypted at rest."
+        target: "O teu conteúdo é encriptado em repouso."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt_PT-encriptar]
+      - id: ex.encrypt-pt-bad#3739406f
+        source: "Your content is encrypted at rest."
+        target: "O teu conteúdo é criptografado em repouso."
+        verdict: bad
+        note: "Uses the Brazilian 'criptografado' instead of the European 'encriptado' — violates rule.pt_PT-encriptar."
+  - id: term.share_pt#043c3d4f
+    key: share
+    en: share
+    disambiguation:
+      heuristic: "The action of sharing a secret. In European Portuguese this is 'partilhar', never the Brazilian 'compartilhar'."
+      key_patterns: ["*share*", "*.send*"]
+    pt_PT:
+      verb:
+        target: partilhar
+        rule_ref: rule.pt_PT-partilhar
+    rule_refs: [register.pt.formality, rule.pt_PT-partilhar]
+    examples:
+      - id: ex.share-pt-good#450b0bf8
+        source: "Share a secret securely."
+        target: "Partilhar uma mensagem confidencial de forma segura."
+        verdict: good
+        rule_refs: [register.pt.formality, rule.pt_PT-partilhar]
+      - id: ex.share-pt-bad#20dbcd2c
+        source: "Share a secret securely."
+        target: "Compartilhar uma mensagem confidencial de forma segura."
+        verdict: bad
+        note: "Uses the Brazilian 'compartilhar' instead of the European 'partilhar' — violates rule.pt_PT-partilhar."

--- a/locales/pt_PT/register.yaml
+++ b/locales/pt_PT/register.yaml
@@ -36,5 +36,4 @@ possessive: [teu, tua, teus, tuas, seu, sua, seus, suas]
 forbidden_tokens: []
 exceptions: []
 rule_ref: register.pt.formality
-# baseline_ref deferred: baselines.pt_PT is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt_PT

--- a/locales/pt_PT/register.yaml
+++ b/locales/pt_PT/register.yaml
@@ -1,0 +1,40 @@
+id: register.pt_PT
+source: onetimesecret/locales/guides/for-translators/pt_PT.md
+# European Portuguese register — form: mixed. This is the key judgment call for the
+# pt_PT locale, and it DIFFERS from pt_BR (which is a clean você-form lock).
+#
+# The pt_PT prose guide PRESCRIBES the informal tu-form consistently ("Use 'Tu'";
+# "DO NOT MIX REGISTERS"). But the SHIPPED live content does not match its own
+# guide: onetimesecret/locales/content/pt_PT/*.json genuinely mixes both registers.
+#   - tu-form present:   teu/tua/teus/tuas = 129 occurrences (e.g. "A tua
+#     palavra-passe", "Introduz a tua palavra-passe", "Se não foste tu"), plus
+#     tu-form imperatives ("Introduz", "verifica a tua...").
+#   - você-form present: seu/sua/seus/suas = 171 occurrences (e.g. "Esqueceu-se da
+#     sua palavra-passe?", "Crie a Sua Conta"), plus você-form imperatives
+#     ("Introduza as suas credenciais", "Crie").
+# Because BOTH registers occur legitimately in the shipped content, neither the
+# tu-form tokens (tu/teu/tua...) NOR the você-form possessives (seu/sua...) can be
+# forbidden without flagging large amounts of valid live content. So this locale is
+# recorded as `form: mixed` with an EMPTY forbidden_tokens list, grounding the
+# register lock in reality rather than the guide's aspiration.
+#
+# JUDGMENT CALL for the native pt_PT reviewer: the guide wants pt_PT unified on the
+# tu-form. The shipped content is not unified. Either (a) the content should be
+# normalized to tu-form, after which this register can be tightened to
+# form: informal / pronoun: tu and forbid the você-form possessives seu/sua and the
+# você-form imperatives; or (b) the guide should be relaxed to accept the mixed
+# reality. Until that is decided by a native speaker, forbidding either side would
+# produce false positives against shipped strings, so forbidden_tokens stays empty.
+#
+# pronoun records the guide-preferred form (tu). This file is self-contained
+# because the resolver loads register per-locale and does NOT merge it across the
+# rules inheritance chain. Mirrors locales/fr_FR/register.yaml structurally.
+# AGENT-AUTHORED; requires native-speaker (pt_PT) sign-off before merge — see PR label.
+form: mixed
+pronoun: tu
+possessive: [teu, tua, teus, tuas, seu, sua, seus, suas]
+forbidden_tokens: []
+exceptions: []
+rule_ref: register.pt.formality
+# baseline_ref deferred: baselines.pt_PT is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/register.yaml's deferred-baseline handling).

--- a/locales/pt_PT/rules.yaml
+++ b/locales/pt_PT/rules.yaml
@@ -1,0 +1,37 @@
+id: rules.pt_PT
+source: onetimesecret/locales/guides/for-translators/pt_PT.md
+inherits: rules.pt
+merge_strategy: append
+# European Portuguese layer. Inherits every Portuguese-wide rule from rules.pt
+# (consistent direct-address register, secret -> "mensagem confidencial",
+# password vs "frase secreta", imperative buttons) and adds ONLY the pt_PT lexical
+# deltas, where European Portuguese differs from the Brazilian parent defaults:
+#   - password: "palavra-passe", not the Brazilian "senha"
+#   - encrypt:  "encriptar"/"encriptado", not the Brazilian "criptografar"
+#   - share:    "partilhar", not the Brazilian "compartilhar"
+# Grounded in the live app content (onetimesecret/locales/content/pt_PT/*.json):
+# "palavra-passe" 78×/"senha" 0×; "encript*" 7×/"criptograf*" 0×;
+# "partilh*" 40×/"compartilh*" 0×. Mirrors locales/fr_CA/rules.yaml (the variant
+# that overrides the parent's European default with its regional lexis), inverted:
+# here the parent default is Brazilian and pt_PT supplies the European forms.
+# AGENT-AUTHORED; requires native-speaker (pt_PT) sign-off before merge — see PR label.
+rules:
+  - id: rule.pt_PT-palavra-passe
+    modality: MUST
+    statement: European Portuguese uses "palavra-passe" for the account login password throughout UI and email content; the Brazilian "senha" is not used in pt_PT.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pt_PT-encriptar
+    modality: MUST
+    statement: European Portuguese uses "encriptar"/"encriptado" for encryption; the Brazilian "criptografar"/"criptografado" is not used in pt_PT.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.pt_PT-partilhar
+    modality: MUST
+    statement: European Portuguese uses "partilhar" for sharing; the Brazilian "compartilhar" is not used in pt_PT.
+    severity: warning
+    rule_ref: rule.terminology-consistency
+register_ref: register.pt_PT
+glossary_ref: glossary.pt_PT
+# baseline_ref deferred: baselines.pt_PT is pinned centrally by the reviewer
+# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).

--- a/locales/pt_PT/rules.yaml
+++ b/locales/pt_PT/rules.yaml
@@ -33,5 +33,4 @@ rules:
     rule_ref: rule.terminology-consistency
 register_ref: register.pt_PT
 glossary_ref: glossary.pt_PT
-# baseline_ref deferred: baselines.pt_PT is pinned centrally by the reviewer
-# (mirrors locales/fr_FR/rules.yaml's deferred-baseline handling).
+baseline_ref: baselines.pt_PT

--- a/locales/ru/glossary.yaml
+++ b/locales/ru/glossary.yaml
@@ -1,0 +1,179 @@
+id: glossary.ru
+source: onetimesecret/locales/guides/for-translators/ru.md
+# Sense-split of the core domain terminology from the Russian translator guide's
+# terminology tables (Глоссарий: Основная терминология, Термины учётной записи)
+# and the Translation Notes (§1 Core Terms, §5 Gender Agreement), grounded
+# against the live app content in onetimesecret/locales/content/ru/*.json.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (RU)
+# sign-off before merge — see PR label. Each `good` example uses the locked
+# FORMAL "вы" register and contains its term's sense target; each `bad` example
+# demonstrates a forbidden form — the informal "ты" register (твой / тебя / ты).
+#
+# Russian declines nouns across 6 cases and 3 genders and inflects verbs by
+# aspect, so each sense target uses a sensible citation stem chosen so the
+# word_prefix sense-target check (resolver/matching.py, default word_prefix)
+# matches the declined form actually used in the good example:
+#   секрет -> секрет/секрета;  кодов -> кодовая/кодовой (фраза);  пароль -> пароль;
+#   уничтож -> уничтожить/уничтожен;  ссылк -> ссылка/ссылку;  шифр -> шифрование,
+#   зашифрован -> зашифрован/зашифрована;  электронн -> электронная (почта).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application (masculine gender → создан/удалён agreement). Use секрет (neutral, technical); never substitute тайна (personal/emotional) or сообщение (message) for this sense."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    ru:
+      noun:
+        target: секрет
+        rule_ref: rule.ru-secret-not-taina
+    rule_refs: [rule.ru-register-formal, rule.ru-secret-not-taina]
+    examples:
+      - id: ex.ru-secret-good#cfa43bd9
+        source: "Your secret has been created."
+        target: "Ваш секрет создан."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-secret-bad#bd4ed190
+        source: "Your secret has been created."
+        target: "Твой секрет создан."
+        verdict: bad
+        note: "Informal possessive 'Твой' (informal 'your') — the forbidden informal register; formal would be 'Ваш'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (feminine compound: кодовая фраза), distinct from the account login пароль. Protect/compose/view-a-secret contexts signal this sense. Alternative фраза-пароль is allowed but кодовая фраза is preferred."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    ru:
+      noun:
+        target: кодов
+        rule_ref: rule.ru-passphrase-password
+    rule_refs: [rule.ru-register-formal, rule.ru-passphrase-password]
+    examples:
+      - id: ex.ru-passphrase-good#72bc3670
+        source: "Enter the passphrase to view this secret."
+        target: "Введите кодовую фразу, чтобы просмотреть этот секрет."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-passphrase-bad#cbb5b0f4
+        source: "Enter the passphrase to view this secret."
+        target: "Введи твой пароль, чтобы просмотреть этот секрет."
+        verdict: bad
+        note: "Uses 'пароль' (account password) where 'кодовая фраза' is meant — violates rule.ru-passphrase-password; also informal imperative 'Введи' and possessive 'твой'."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (masculine: пароль), distinct from a secret's кодовая фраза. Sign-in, account, and reset-password contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    ru:
+      noun:
+        target: пароль
+        rule_ref: rule.ru-passphrase-password
+    rule_refs: [rule.ru-register-formal, rule.ru-passphrase-password]
+    examples:
+      - id: ex.ru-password-good#666f89a8
+        source: "Enter your password to sign in."
+        target: "Введите Ваш пароль, чтобы войти."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-password-bad#f638c4fb
+        source: "Enter your password to sign in."
+        target: "Введи твой пароль, чтобы войти."
+        verdict: bad
+        note: "Informal imperative 'Введи' plus informal possessive 'твой' — the forbidden informal register; formal is 'Введите Ваш'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently destroying a secret before it is viewed. Verb form 'уничтожить' (perfective) for the action label; 'уничтожен' (masc. short-form participle) for the resulting state. Do not use a literal 'сжечь'."
+      key_patterns: ["*burn*", "*.destroy*"]
+    ru:
+      verb:
+        target: уничтож
+        rule_ref: rule.ru-burn-unichtozhit
+      state:
+        target: уничтожен
+        rule_ref: rule.ru-burn-unichtozhit
+    rule_refs: [rule.ru-register-formal, rule.ru-burn-unichtozhit]
+    examples:
+      - id: ex.ru-burn-good#5d56c53f
+        source: "Are you sure you want to burn this secret?"
+        target: "Вы уверены, что хотите уничтожить этот секрет?"
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-burn-bad#781d4f89
+        source: "Are you sure you want to burn this secret?"
+        target: "Ты уверен, что хочешь сжечь твой секрет?"
+        verdict: bad
+        note: "Informal 'Ты ... хочешь' and possessive 'твой' plus the literal 'сжечь' — violates the register lock and rule.ru-burn-unichtozhit; formal is 'Вы уверены, что хотите уничтожить'."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides one-time access to a secret (feminine: ссылка → создана/удалена agreement). Share/copy/reveal contexts signal this sense."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    ru:
+      noun:
+        target: ссылк
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.ru-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.ru-link-good#f5170486
+        source: "Copy the secret link to share it."
+        target: "Скопируйте секретную ссылку, чтобы поделиться ею."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-link-bad#4cc26fc6
+        source: "Copy the secret link to share it."
+        target: "Скопируй твою секретную ссылку, чтобы поделиться ею."
+        verdict: bad
+        note: "Informal imperative 'Скопируй' plus informal possessive 'твою' — the forbidden informal register; formal is 'Скопируйте'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data (шифрование, neuter). Verb 'шифровать'; participle 'зашифрован/зашифрована/зашифровано' with gender agreement for the encrypted state. Do not confuse with кодирование (encoding)."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    ru:
+      verb:
+        target: шифр
+        rule_ref: rule.terminology-consistency
+      state:
+        target: зашифрован
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.ru-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.ru-encrypt-good#218e9a77
+        source: "This message is encrypted with your passphrase."
+        target: "Это сообщение зашифровано Вашей кодовой фразой."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-encrypt-bad#af1753f8
+        source: "This message is encrypted with your passphrase."
+        target: "Это сообщение зашифровано твоей кодовой фразой."
+        verdict: bad
+        note: "Informal possessive 'твоей' (informal 'your') — the forbidden informal register; formal would be 'Вашей'."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail (account identifier and notification contexts). Rendered as электронная почта; the borrowing 'email' is also seen in tech contexts but электронная почта is the guide's standard."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    ru:
+      noun:
+        target: электронн
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.ru-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.ru-email-good#83ba8072
+        source: "Enter your email address."
+        target: "Введите Ваш адрес электронной почты."
+        verdict: good
+        rule_refs: [rule.ru-register-formal]
+      - id: ex.ru-email-bad#7231f692
+        source: "Enter your email address."
+        target: "Введи твой адрес электронной почты."
+        verdict: bad
+        note: "Informal imperative 'Введи' plus informal possessive 'твой' — the forbidden informal register; formal is 'Введите Ваш'."

--- a/locales/ru/register.yaml
+++ b/locales/ru/register.yaml
@@ -60,8 +60,4 @@ forbidden_tokens:
   - { token: твоем,  context: standalone_word, severity: error, note: "informal possessive 'your' (prep. masc./neut., е-for-ё spelling) — formal is Вашем" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# `baselines.ru` entry exists yet, this backfill must not edit the shared
-# baselines.yaml, and the resolver hard-fails on a dangling baseline_ref. A
-# reviewer adds the central baselines.ru pin at commit time (mirroring es/cs/pl),
-# after which this file can carry baseline_ref: baselines.ru.
+baseline_ref: baselines.ru

--- a/locales/ru/register.yaml
+++ b/locales/ru/register.yaml
@@ -1,0 +1,67 @@
+id: register.ru
+source: onetimesecret/locales/guides/for-translators/ru.md
+# Russian is locked to the FORMAL "вы" register (polite 2nd person, capitalized
+# Вы / Ваш when addressing the user). Grounded in the live app content
+# (onetimesecret/locales/content/ru/*.json): direct address consistently uses
+# the formal вы forms — subject pronoun Вы (84), formal possessives Ваш (65) /
+# Ваша (14) / Ваше (9) / Ваши (13), oblique pronouns Вас (22) / Вам (22) / Вами
+# (1) — e.g. "Введите Ваш пароль", "Этот секрет защищён кодовой фразой.
+# Отправитель должен передать её Вам отдельно.", "Вы можете безопасно закрыть
+# эту вкладку". The informal "ты" family (ты / твой / твоя / твоё / твои /
+# тебя / тебе / тобой) appears ZERO times as a standalone word anywhere in the
+# live content. The prose guide concurs: §4 "Formal Address (Вы)" and Pitfall
+# #4 "Informal Register Inconsistency" both record the formal "вы" form with
+# capitalization (Вы, Ваш). So the FORBIDDEN register is the informal "ты" one.
+#
+# This is the OPPOSITE register decision from the Slavic pilots pl/cs (both
+# locked INFORMAL "ty"); the register is per-locale and grounded in each app's
+# own content, not inherited by language family.
+#
+# Tokens are matched as standalone_word (NOT word_prefix/substring) on purpose,
+# exactly as in cs/pl: the bare pronoun "ты" is a substring of dozens of valid
+# Russian words present in the content — Секреты, аккаунты, минуты, почты, даты,
+# элементы, защиты, форматы, шрифты, лимиты, … — so a looser context would
+# false-positive. As standalone words the informal forms have zero legitimate
+# use in this formal corpus. Matching is Unicode-aware and casefolded
+# (resolver/matching.py: str.isalnum() treats Cyrillic as word chars), so each
+# lowercase token also catches its sentence-initial capitalized form (Ты, Твой).
+#
+# Deliberately NOT forbidden:
+#   - the informal singular imperative verb forms (e.g. "Введи" vs formal "Введите")
+#     — these are 2nd-sg verb endings that overlap nothing reliable as a
+#     standalone marker, and the live content carries no such forms; the informal
+#     pronouns/possessives below are the unambiguous standalone markers actually
+#     at risk in a register regression. (cf. pl/cs leaving 3rd-person verb
+#     agreement unlisted, es leaving su/sus unlisted.)
+#
+# AGENT-AUTHORED; requires native-speaker (RU) sign-off — see PR label.
+form: formal
+pronoun: вы
+possessive: [Ваш, Ваша, Ваше, Ваши, Вашего, Вашей, Ваших, Вашему, Вашим, Вашими, Вашем, Вашу]
+forbidden_tokens:
+  - { token: ты,     context: standalone_word, severity: error, note: "informal subject pronoun 'you' (sg.) — the register ru does NOT use; formal is Вы. standalone_word only: 'ты' is a substring of Секреты/минуты/почты/etc." }
+  - { token: тебя,   context: standalone_word, severity: error, note: "informal pronoun 'you' (gen./acc.) — formal is Вас" }
+  - { token: тебе,   context: standalone_word, severity: error, note: "informal pronoun 'you' (dat./prep.) — formal is Вам" }
+  - { token: тобой,  context: standalone_word, severity: error, note: "informal pronoun 'you' (instr.) — formal is Вами" }
+  - { token: тобою,  context: standalone_word, severity: error, note: "informal pronoun 'you' (instr., variant) — formal is Вами" }
+  - { token: твой,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. masc.) — formal is Ваш" }
+  - { token: твоя,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. fem.) — formal is Ваша" }
+  - { token: твоё,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. neut.) — formal is Ваше" }
+  - { token: твое,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. neut., е-for-ё spelling) — formal is Ваше" }
+  - { token: твои,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. pl.) — formal is Ваши" }
+  - { token: твоего, context: standalone_word, severity: error, note: "informal possessive 'your' (gen. masc./neut.) — formal is Вашего" }
+  - { token: твоей,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen./dat./instr./prep. fem.) — formal is Вашей" }
+  - { token: твоих,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen./prep. pl.) — formal is Ваших" }
+  - { token: твоему, context: standalone_word, severity: error, note: "informal possessive 'your' (dat. masc./neut.) — formal is Вашему" }
+  - { token: твоим,  context: standalone_word, severity: error, note: "informal possessive 'your' (instr. masc./neut.; dat. pl.) — formal is Вашим" }
+  - { token: твоими, context: standalone_word, severity: error, note: "informal possessive 'your' (instr. pl.) — formal is Вашими" }
+  - { token: твою,   context: standalone_word, severity: error, note: "informal possessive 'your' (acc. fem.) — formal is Вашу" }
+  - { token: твоём,  context: standalone_word, severity: error, note: "informal possessive 'your' (prep. masc./neut.) — formal is Вашем" }
+  - { token: твоем,  context: standalone_word, severity: error, note: "informal possessive 'your' (prep. masc./neut., е-for-ё spelling) — formal is Вашем" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# `baselines.ru` entry exists yet, this backfill must not edit the shared
+# baselines.yaml, and the resolver hard-fails on a dangling baseline_ref. A
+# reviewer adds the central baselines.ru pin at commit time (mirroring es/cs/pl),
+# after which this file can carry baseline_ref: baselines.ru.

--- a/locales/ru/rules.yaml
+++ b/locales/ru/rules.yaml
@@ -1,0 +1,72 @@
+id: rules.ru
+source: onetimesecret/locales/guides/for-translators/ru.md
+inherits: base
+merge_strategy: append
+# Russian locale layer. ru is a standalone shipping language (no family parent),
+# so it inherits `base` directly — mirroring locales/pl/rules.yaml and
+# locales/cs/rules.yaml (the closest Slavic pilots) in shape, but with the
+# OPPOSITE register decision: Russian is locked to the FORMAL "вы" register.
+# That choice is grounded in the live app content
+# (onetimesecret/locales/content/ru/*.json), which uses the formal вы forms
+# throughout (Вы 84x, Ваш/Ваша/Ваше/Ваши possessives 101x, Вас/Вам/Вами 45x,
+# "Введите Ваш пароль"), and contains zero standalone informal ты/твой address.
+# The prose guide agrees (§4 "Formal Address (Вы)"; Pitfall #4 "Informal
+# Register Inconsistency").
+#
+# rule.ru-pluralization captures the three-form Russian plural system (1 / 2-4 /
+# 5+, e.g. день / дня / дней), which the guide flags as critical (Notes §6,
+# Pitfall #3); it specialises the base rule.pluralization-syntax. The пароль /
+# кодовая фраза distinction is the single most critical terminology rule in the
+# guide (Глоссарий; Notes §1; "Важное различие"). The guide also stresses strict
+# gender agreement (Notes §5: секрет m / ссылка f / сообщение n) and mandatory
+# letter Ё (Notes §9), both captured below.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (RU) sign-off before merge — see PR label.
+rules:
+  - id: rule.ru-register-formal
+    modality: MUST
+    statement: Russian content uses the formal "вы" register (Вы / Ваш / Ваша / Ваше / Ваши / Вас / Вам), capitalized when directly addressing the user, throughout product UI and email content; the informal "ты" register (ты / твой / твоя / твоё / тебя / тебе) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.ru-pluralization
+    modality: MUST
+    statement: Express countable strings with the three Russian plural forms (1 / 2-4 / 5+, e.g. день / дня / дней) via vue-i18n pipe syntax; select the form by the number's last digit (ending 1 except 11 = singular; ending 2-4 except 12-14 = few; 0, 5-9, 11-14 = many) and never collapse to a single plural.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.ru-passphrase-password
+    modality: MUST
+    statement: Keep пароль (account login credential) distinct from кодовая фраза (the passphrase protecting an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ru-secret-not-taina
+    modality: MUST
+    statement: Translate the core "secret" concept as секрет (masculine, neutral technical term) consistently; do not substitute тайна (which carries a personal/emotional connotation) or сообщение (message) unless the source specifically refers to a message.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ru-burn-unichtozhit
+    modality: MUST
+    statement: Translate burn / burned consistently as уничтожить (verb) and уничтожен (state), per the agreed Russian terminology; do not use a literal "сжечь", which is awkward in a digital context.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ru-gender-agreement
+    modality: MUST
+    statement: Maintain strict gender agreement between nouns, adjectives, and short-form past participles — секрет (masc.) → создан/удалён, ссылка (fem.) → создана/удалена, сообщение/шифрование (neut.) → создано/удалено; mismatched endings are errors.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.ru-yo-letter
+    modality: MUST
+    statement: Use the letter Ё where required; do not substitute Е (всё vs все, ещё vs еще, удалён vs удален), since the substitution changes meaning or spelling.
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.ru-imperative-buttons
+    modality: SHOULD
+    statement: Use the perfective infinitive (functioning as imperative) for button and action labels (Создать, Скопировать, Подтвердить); use passive voice or short-form past participles with correct gender agreement for status and system messages (Секрет создан, Скопировано в буфер обмена).
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.ru
+glossary_ref: glossary.ru
+# baseline_ref intentionally omitted: no baselines.ru entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it
+# is left out until a reviewer adds the central baselines.ru pin.

--- a/locales/ru/rules.yaml
+++ b/locales/ru/rules.yaml
@@ -66,7 +66,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.ru
 glossary_ref: glossary.ru
-# baseline_ref intentionally omitted: no baselines.ru entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it
-# is left out until a reviewer adds the central baselines.ru pin.
+baseline_ref: baselines.ru

--- a/locales/scripts/backfill-baselines.py
+++ b/locales/scripts/backfill-baselines.py
@@ -18,6 +18,7 @@ Usage (from the translation-rules repo root):
 
 Verify after:  uv run resolver/resolve.py <L> --lint --validate-only
 """
+
 from __future__ import annotations
 
 import subprocess

--- a/locales/scripts/backfill-baselines.py
+++ b/locales/scripts/backfill-baselines.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Central baselines pass for backfilled locales.
+
+For each locale in LOCALES it:
+  1. appends a `baselines.<locale>` backfill-pin entry to baselines.yaml
+     (form/pronoun + a couple glossary invariants, justification_doc, the
+     AGENT-AUTHORED/pending-sign-off note, pinned to the current branch tip);
+  2. restores `baseline_ref: baselines.<locale>` in the locale's register.yaml
+     and rules.yaml, removing the "deferred" comment the authoring agent left.
+
+Agents could not do this themselves: baselines.yaml is a single shared file, and
+a `baseline_ref` to a missing entry dangles and fails the resolver — so it had to
+be a serialized central pass. Idempotent: skips a locale already in baselines.yaml.
+
+Usage (from the translation-rules repo root):
+  uv run locales/scripts/backfill-baselines.py nl es pl
+  uv run locales/scripts/backfill-baselines.py --rest   # every governed locale missing an entry
+
+Verify after:  uv run resolver/resolve.py <L> --lint --validate-only
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]  # repo root (…/translation-rules)
+BASELINES = ROOT / "baselines.yaml"
+PINNED_ON = "2026-06-22"
+
+# Locales whose register/glossary are NOT their own backfill source (family
+# parents already pinned, or variants that inherit). Still get an entry, but the
+# note is generic. Everything else points at the app translator guide.
+GUIDE = "onetimesecret/locales/guides/for-translators/{L}.md"
+
+
+def head_sha() -> str:
+    return subprocess.check_output(
+        ["git", "-C", str(ROOT), "rev-parse", "HEAD"], text=True
+    ).strip()
+
+
+def first_target(loc_block):
+    """Pull a representative target string from a glossary term's locale block."""
+    if not isinstance(loc_block, dict):
+        return None
+    for _sense, v in loc_block.items():
+        if isinstance(v, dict) and v.get("target"):
+            return v["target"]
+        if isinstance(v, str):
+            return v
+    return None
+
+
+def invariants_for(locale: str) -> list[str]:
+    reg = yaml.safe_load((ROOT / "locales" / locale / "register.yaml").read_text())
+    inv = [f"register.form={reg.get('form')} ({reg.get('pronoun')})"]
+    glo_path = ROOT / "locales" / locale / "glossary.yaml"
+    glo = yaml.safe_load(glo_path.read_text()) if glo_path.exists() else {}
+    for term in (glo.get("terms") or [])[:2]:
+        key = term.get("key")
+        tgt = first_target(term.get(locale))
+        if key and tgt:
+            inv.append(f"glossary.{key}={tgt}")
+    return inv
+
+
+def baselines_block(locale: str, sha: str) -> str:
+    inv = invariants_for(locale)
+    inv_yaml = "\n".join(f"      - {line}" for line in inv)
+    return (
+        f"  {locale}:\n"
+        f"    commit: {sha}\n"
+        f"    pinned_on: {PINNED_ON}\n"
+        f"    invariants:\n"
+        f"{inv_yaml}\n"
+        f"    justification_doc: {GUIDE.format(L=locale)}\n"
+        f'    note: "Backfill pin for the {locale} structured-rules layer. No retro '
+        f"exists; source of truth is the app-repo translator guide. AGENT-AUTHORED "
+        f"content pending native-speaker sign-off. Commit is the branch tip at "
+        f'authoring time, not a curated content commit."\n'
+    )
+
+
+def existing_keys() -> set[str]:
+    doc = yaml.safe_load(BASELINES.read_text())
+    return set((doc.get("baselines") or {}).keys())
+
+
+def restore_baseline_ref(locale: str) -> None:
+    """Drop the agent's 'baseline_ref deferred' comment lines and add the key."""
+    for fn in ("register.yaml", "rules.yaml"):
+        p = ROOT / "locales" / locale / fn
+        lines = p.read_text().splitlines()
+        kept = [
+            ln
+            for ln in lines
+            if not (ln.lstrip().startswith("#") and "baseline" in ln.lower())
+        ]
+        if not any(ln.startswith("baseline_ref:") for ln in kept):
+            while kept and kept[-1].strip() == "":
+                kept.pop()
+            kept.append(f"baseline_ref: baselines.{locale}")
+        p.write_text("\n".join(kept) + "\n")
+
+
+def main(argv: list[str]) -> int:
+    have = existing_keys()
+    if argv == ["--rest"]:
+        governed = sorted(
+            d.name
+            for d in (ROOT / "locales").iterdir()
+            if (d / "register.yaml").exists()
+        )
+        locales = [L for L in governed if L not in have]
+    else:
+        locales = argv
+    if not locales:
+        print("nothing to do")
+        return 0
+
+    sha = head_sha()
+    blocks = []
+    for L in locales:
+        if L in have:
+            print(f"skip {L}: already in baselines.yaml")
+            continue
+        if not (ROOT / "locales" / L / "register.yaml").exists():
+            print(f"skip {L}: not governed")
+            continue
+        blocks.append(baselines_block(L, sha))
+        restore_baseline_ref(L)
+        print(f"added baselines.{L} + restored baseline_ref")
+
+    if blocks:
+        text = BASELINES.read_text()
+        if not text.endswith("\n"):
+            text += "\n"
+        BASELINES.write_text(text + "".join(blocks))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/locales/sl_SI/glossary.yaml
+++ b/locales/sl_SI/glossary.yaml
@@ -1,0 +1,174 @@
+id: glossary.sl_SI
+source: onetimesecret/locales/guides/for-translators/sl_SI.md
+# Sense-split of the core domain terminology from the Slovenian translator guide's
+# terminology tables (Osnovna terminologija, Core Terminology) and the live app
+# content in onetimesecret/locales/content/sl_SI/*.json. Targets and worked
+# examples are AGENT-AUTHORED and require native-speaker (SL) sign-off before
+# merge — see PR label. Each `good` example uses the locked FORMAL "vi" register
+# (vaš/vaša/vaše + vi-imperatives) and contains its term's sense target as a
+# word-prefix; each `bad` example demonstrates a forbidden form — the informal
+# "ti" register (tvoj* possessive / 2nd-singular). Slovenian nouns decline across
+# 6 cases and 3 genders; sense targets use a sensible citation form (nominative
+# singular noun / infinitive verb) and good examples keep that form so the
+# word_prefix sense-target check holds.
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application (skrivnost, feminine). Never substitute sporočilo (message) for this sense."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    sl_SI:
+      noun:
+        target: skrivnost
+        rule_ref: rule.sl_SI-secret-not-message
+    rule_refs: [register.sl_SI.formality, rule.sl_SI-secret-not-message]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been viewed."
+        target: "Vaša skrivnost je bila ogledana."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.secret-informal-bad#250567fe
+        source: "Your secret has been viewed."
+        target: "Tvoja skrivnost je bila ogledana."
+        verdict: bad
+        note: "Informal possessive 'Tvoja' (informal 'your') — the forbidden informal 'ti' register; formal would be 'Vaša'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login geslo). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    sl_SI:
+      noun:
+        target: pristopna fraza
+        rule_ref: rule.sl_SI-passphrase-password
+    rule_refs: [register.sl_SI.formality, rule.sl_SI-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Your passphrase is required to view this secret."
+        target: "Vaša pristopna fraza je obvezna za ogled te skrivnosti."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Your passphrase is required to view this secret."
+        target: "Tvoja pristopna fraza je obvezna za ogled te skrivnosti."
+        verdict: bad
+        note: "Informal possessive 'Tvoja' (informal 'your') — the forbidden informal 'ti' register; formal would be 'Vaša'."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (geslo, neuter — distinct from a secret's pristopna fraza). Sign-in, account, and reset-password contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    sl_SI:
+      noun:
+        target: geslo
+        rule_ref: rule.sl_SI-passphrase-password
+    rule_refs: [register.sl_SI.formality, rule.sl_SI-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Vnesite svoje geslo za prijavo."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Vnesi tvoje geslo za prijavo."
+        verdict: bad
+        note: "Informal 2nd-singular imperative 'Vnesi' plus informal possessive 'tvoje' — the forbidden informal 'ti' register; formal is the vi-imperative 'Vnesite ... svoje'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of destroying a secret before it is viewed. The guide standardised on trajno izbrisati ('permanently delete') for the verb; trajno izbrisana/-o is the resulting state, gender-agreeing with the noun (skrivnost f. -> izbrisana)."
+      key_patterns: ["*burn*", "*.destroy*"]
+    sl_SI:
+      verb:
+        target: trajno izbrisati
+        rule_ref: rule.terminology-consistency
+      state:
+        target: trajno izbrisana
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.sl_SI.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Are you sure you want to burn this secret?"
+        target: "Ali ste prepričani, da želite trajno izbrisati to skrivnost?"
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.burn-bad#4228df6b
+        source: "Are you sure you want to burn this secret?"
+        target: "Ali si prepričan, da želiš trajno izbrisati to skrivnost?"
+        verdict: bad
+        note: "Informal 2nd-singular verbs 'si'/'želiš' (and masc. 'prepričan') — the forbidden informal 'ti' register; formal is 'ste prepričani'/'želite'."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. povezava (feminine) is the established Slovenian term throughout the content."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    sl_SI:
+      noun:
+        target: povezava
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.sl_SI.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Your secure link is ready to share."
+        target: "Vaša varna povezava je pripravljena za deljenje."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.link-bad#748809c5
+        source: "Your secure link is ready to share."
+        target: "Tvoja varna povezava je pripravljena za deljenje."
+        verdict: bad
+        note: "Informal possessive 'Tvoja' (informal 'your') — the forbidden informal 'ti' register; formal would be 'Vaša'."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'šifrirati', past participle 'šifrirano' for the encrypted state (gender-agreeing with the noun). Diacritic š is essential — never 'sifrirano'."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    sl_SI:
+      verb:
+        target: šifrirati
+        rule_ref: rule.terminology-consistency
+      state:
+        target: šifrirano
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.sl_SI.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "To sporočilo je šifrirano z vašo pristopno frazo."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "To sporočilo je šifrirano s tvojo pristopno frazo."
+        verdict: bad
+        note: "Informal possessive 'tvojo' (informal 'your') — the forbidden informal 'ti' register; formal would be 'vašo'."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Rendered hyphenated as 'e-pošta' (feminine) in Slovenian."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    sl_SI:
+      noun:
+        target: e-pošta
+        rule_ref: rule.terminology-consistency
+    rule_refs: [register.sl_SI.formality, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Your email has been updated."
+        target: "Vaša e-pošta je bila uspešno posodobljena."
+        verdict: good
+        rule_refs: [register.sl_SI.formality]
+      - id: ex.email-bad#5c29e476
+        source: "Your email has been updated."
+        target: "Tvoja e-pošta je bila uspešno posodobljena."
+        verdict: bad
+        note: "Informal possessive 'Tvoja' (informal 'your') — the forbidden informal 'ti' register; formal would be 'Vaša'."

--- a/locales/sl_SI/register.yaml
+++ b/locales/sl_SI/register.yaml
@@ -1,0 +1,55 @@
+id: register.sl_SI
+source: onetimesecret/locales/guides/for-translators/sl_SI.md
+# Slovenian is locked to the FORMAL "vi" register (vljudnostna oblika / polite
+# 2nd-person plural honorific address) — the OPPOSITE register decision from the
+# informal-locked pilots (pl "ty", es "tú", fr). Grounded in the live app content
+# (onetimesecret/locales/content/sl_SI/*.json): direct address uses the formal vi
+# throughout — formal possessives vaš / vaša / vaše / vašega / vašo / vašim
+# (e.g. "Vaša skrivnost je bila ogledana", "Vaše varno sporočilo je bilo
+# dostavljeno.", "Vse vaše skrivnosti bodo trajno izbrisane"), the formal subject
+# pronoun vi ("Če te spremembe niste opravili vi, nemudoma zavarujte svoj
+# račun."), and formal vi-imperatives (Vnesite, Preverite, Izberite, Poskusite,
+# Kliknite, Poskrbite, Nadaljujte). The informal "ti" possessive tvoj/tvoja/tvoje
+# and informal object pronouns tebe/tebi appear ZERO times. The prose guide
+# concurs: "Vljiva oblika 'vi' za profesionalni ton namesto neformalne 'ti'"
+# (Posebne ugotovitve) and Voice and Tone §"Polite Address Forms": "Always use
+# polite vi forms ... never informal ti."
+#
+# Because the locked register is FORMAL, the FORBIDDEN register is the INFORMAL
+# "ti": the informal 2nd-singular possessive (tvoj and its case/gender-inflected
+# forms) and the informal object/oblique pronouns (tebe, tebi, teboj/tabo).
+# These are matched as standalone_word (NOT word_prefix/substring) on purpose —
+# they are unambiguous as whole words and have zero legitimate use here.
+#
+# Deliberately NOT forbidden: the bare informal subject pronoun "ti". In Slovenian
+# "ti / Ti" is a homograph of the legitimate masc.-plural demonstrative/pronoun
+# "these / those / they", which appears in valid live content
+# ("Ti podatki pomagajo prilagoditi vaš račun..."). Forbidding standalone "ti"
+# would false-positive on that valid prose (cf. the prompt's warning to forbid
+# only tokens unambiguous as standalone words). The informal possessive tvoj* and
+# object pronouns tebe/tebi carry no such ambiguity and are the unambiguous
+# markers of the forbidden informal register.
+#
+# AGENT-AUTHORED; requires native-speaker (SL) sign-off — see PR label.
+form: formal
+pronoun: vi
+possessive: [vaš, vaša, vaše, vašega, vaši, vašo, vašem, vašim, vaših, vašimi]
+forbidden_tokens:
+  - { token: tvoj,    context: standalone_word, severity: error, note: "informal possessive 'your' (nom., masc. sg.) — the informal 'ti' register sl_SI does NOT use" }
+  - { token: tvoja,   context: standalone_word, severity: error, note: "informal possessive 'your' (fem. sg. / neut.-nom.pl.)" }
+  - { token: tvoje,   context: standalone_word, severity: error, note: "informal possessive 'your' (neut. sg. / fem.-acc. etc.)" }
+  - { token: tvojega, context: standalone_word, severity: error, note: "informal possessive 'your' (masc./neut. gen. sg.)" }
+  - { token: tvojo,   context: standalone_word, severity: error, note: "informal possessive 'your' (fem. acc. sg.)" }
+  - { token: tvoji,   context: standalone_word, severity: error, note: "informal possessive 'your' (dat./loc. fem. sg., nom. pl., etc.)" }
+  - { token: tvojem,  context: standalone_word, severity: error, note: "informal possessive 'your' (masc./neut. loc. sg.)" }
+  - { token: tvojim,  context: standalone_word, severity: error, note: "informal possessive 'your' (masc./neut. instr. sg., dat. pl.)" }
+  - { token: tvojih,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen./loc. pl.)" }
+  - { token: tebe,    context: standalone_word, severity: error, note: "informal object pronoun 'you' (gen./acc. sg.) — informal 'ti' register" }
+  - { token: tebi,    context: standalone_word, severity: error, note: "informal object pronoun 'you' (dat./loc. sg.) — informal 'ti' register" }
+  - { token: teboj,   context: standalone_word, severity: error, note: "informal object pronoun 'you' (instr. sg., 's teboj') — informal 'ti' register" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# baselines.sl_SI entry exists yet, and a dangling baseline_ref hard-fails the
+# resolver. The pin is for a reviewer to add to baselines.yaml centrally at commit
+# time (mirroring fr/de_AT), after which this and rules.yaml can carry it.

--- a/locales/sl_SI/register.yaml
+++ b/locales/sl_SI/register.yaml
@@ -49,7 +49,5 @@ forbidden_tokens:
   - { token: teboj,   context: standalone_word, severity: error, note: "informal object pronoun 'you' (instr. sg., 's teboj') — informal 'ti' register" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# baselines.sl_SI entry exists yet, and a dangling baseline_ref hard-fails the
-# resolver. The pin is for a reviewer to add to baselines.yaml centrally at commit
 # time (mirroring fr/de_AT), after which this and rules.yaml can carry it.
+baseline_ref: baselines.sl_SI

--- a/locales/sl_SI/rules.yaml
+++ b/locales/sl_SI/rules.yaml
@@ -1,0 +1,55 @@
+id: rules.sl_SI
+source: onetimesecret/locales/guides/for-translators/sl_SI.md
+inherits: base
+merge_strategy: append
+# Slovenian locale layer. sl_SI is a standalone shipping language (no family
+# parent), so it inherits `base` directly — mirroring locales/pl/rules.yaml and
+# locales/es/rules.yaml. Unlike those informal-locked pilots, Slovenian is locked
+# to the FORMAL "vi" register. That choice is grounded in the live app content
+# (onetimesecret/locales/content/sl_SI/*.json), which uses formal 2nd-person
+# plural throughout (vaš/vaša/vaše possessives, the subject pronoun vi, and
+# vi-imperatives Vnesite/Preverite/Izberite) and contains zero informal "ti"
+# possessive (tvoj*) or object pronouns (tebe/tebi). The prose guide agrees
+# (Posebne ugotovitve: "Vljiva oblika 'vi' ... namesto neformalne 'ti'"; Voice
+# and Tone §"Polite Address Forms").
+#
+# rule.sl_SI-pluralization captures Slovenian's rare DUAL number (dvojina): three
+# count forms 1 / 2 / 3+ (dan / dni / dni), which the guide flags as critical;
+# it specialises the base rule.pluralization-syntax. The geslo / pristopna fraza
+# distinction is the single most critical terminology rule in the guide
+# (Posebne ugotovitve; Core Terminology §"Password vs Passphrase").
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (SL) sign-off before merge — see PR label.
+rules:
+  - id: register.sl_SI.formality
+    modality: MUST
+    statement: Slovenian content uses the formal "vi" register (polite 2nd-person plural — vi / vaš / vaša / vaše, vi-imperatives) throughout product UI and email content; the informal "ti" address (tvoj* possessives, tebe/tebi object pronouns, 2nd-singular verb forms) is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.sl_SI-pluralization
+    modality: MUST
+    statement: Express countable strings with Slovenian's three number forms — singular (1), DUAL/dvojina (2), and plural (3+) — never collapsing the dual into the plural, via vue-i18n pipe syntax.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.sl_SI-passphrase-password
+    modality: MUST
+    statement: Keep geslo (account login credential, neuter) distinct from pristopna fraza (the passphrase protecting an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.sl_SI-secret-not-message
+    modality: MUST
+    statement: Translate the core "secret" concept as skrivnost (feminine) consistently; do not substitute sporočilo (message) unless the source specifically refers to a message format.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.sl_SI-imperative-buttons
+    modality: SHOULD
+    statement: Use the formal vi-imperative for button and action labels (Pošljite, Izberite, Preverite); use past participles with correct gender agreement for status and system messages (skrivnost ustvarjena, geslo spremenjeno).
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.sl_SI
+glossary_ref: glossary.sl_SI
+# baseline_ref intentionally omitted: no baselines.sl_SI entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it is
+# left out until a reviewer adds the central baselines.sl_SI pin.

--- a/locales/sl_SI/rules.yaml
+++ b/locales/sl_SI/rules.yaml
@@ -49,7 +49,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.sl_SI
 glossary_ref: glossary.sl_SI
-# baseline_ref intentionally omitted: no baselines.sl_SI entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it is
-# left out until a reviewer adds the central baselines.sl_SI pin.
+baseline_ref: baselines.sl_SI

--- a/locales/sv_SE/glossary.yaml
+++ b/locales/sv_SE/glossary.yaml
@@ -1,0 +1,178 @@
+id: glossary.sv_SE
+source: onetimesecret/locales/guides/for-translators/sv_SE.md
+# Sense-split of the core domain terminology from the Swedish translator guide's
+# terminology tables (onetimesecret/locales/guides/for-translators/sv_SE.md),
+# grounded against the live app content in
+# onetimesecret/locales/content/sv_SE/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (SV) sign-off before merge — see PR
+# label. Each `good` example uses the informal du register and contains its
+# term's sense target (word_prefix); each `bad` example demonstrates a forbidden
+# form (the formal ni register, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Common gender: en hemlighet."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    sv_SE:
+      noun:
+        target: hemlighet
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.sv-secret-created-good#5e95e373
+        source: "Your secret has been created."
+        target: "Din hemlighet har skapats."
+        verdict: good
+        note: "Informal possessive 'Din' per the du register; declarative voice for status. 'hemlighet' is the glossary noun."
+        rule_refs: [rule.register-lock]
+      - id: ex.sv-secret-formal-bad#7c64675d
+        source: "Your secret has been created."
+        target: "Er hemlighet har skapats."
+        verdict: bad
+        note: "Formal possessive 'Er' (the ni-register V-form) used for direct address — the forbidden formal register; du-reform Swedish uses 'Din'."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense. Compound word: lösenfras."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    sv_SE:
+      noun:
+        target: lösenfras
+        rule_ref: rule.sv-passphrase-password
+    rule_refs: [rule.register-lock, rule.sv-passphrase-password]
+    examples:
+      - id: ex.sv-passphrase-good#48571f1f
+        source: "Enter the passphrase to view this secret."
+        target: "Ange lösenfrasen för att visa denna hemlighet."
+        verdict: good
+        note: "Active imperative 'Ange'; uses 'lösenfras' (compound, one word), not 'lösenord'. Grounded in live phrasing ('Dubbelkolla den lösenfrasen')."
+        rule_refs: [rule.register-lock, rule.sv-passphrase-password]
+      - id: ex.sv-passphrase-bad#06928aa2
+        source: "Enter the passphrase to view this secret."
+        target: "Ange lösenordet för att visa denna hemlighet."
+        verdict: bad
+        note: "Uses 'lösenord' (account credential) where 'lösenfras' (secret protection) is meant — violates rule.sv-passphrase-password."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense. Compound word: lösenord (neuter: ett lösenord)."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    sv_SE:
+      noun:
+        target: lösenord
+        rule_ref: rule.sv-passphrase-password
+    rule_refs: [rule.register-lock, rule.sv-passphrase-password]
+    examples:
+      - id: ex.sv-password-good#1a96853b
+        source: "Enter your password to sign in."
+        target: "Ange ditt lösenord för att logga in."
+        verdict: good
+        note: "Informal possessive 'ditt' per the du register; 'logga in' per the UI glossary; 'lösenord' (compound, one word)."
+        rule_refs: [rule.register-lock]
+      - id: ex.sv-password-bad#3480118c
+        source: "Enter your password to sign in."
+        target: "Ange ert lösenord för att logga in."
+        verdict: bad
+        note: "Formal possessive 'ert' (the ni-register V-form) instead of informal 'ditt' — the forbidden formal register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. The Swedish guide standardised on 'radera permanent' (delete permanently) rather than a literal burn; past participle 'raderad permanent' for the resulting state."
+      key_patterns: ["*burn*", "*.destroy*"]
+    sv_SE:
+      verb:
+        target: radera
+        rule_ref: rule.sv-burn-radera-permanent
+      state:
+        target: raderad
+        rule_ref: rule.sv-burn-radera-permanent
+    rule_refs: [rule.register-lock, rule.sv-burn-radera-permanent]
+    examples:
+      - id: ex.sv-burn-good#b453b5dd
+        source: "Burn this secret before it is read."
+        target: "Radera denna hemlighet permanent innan den läses."
+        verdict: good
+        note: "Active imperative 'Radera ... permanent' for the action label, per the guide's burn -> 'radera permanent' choice. Grounded in live string 'Radera denna hemlighet permanent'."
+        rule_refs: [rule.register-lock, rule.sv-burn-radera-permanent]
+      - id: ex.sv-burn-bad#f9b1e46b
+        source: "Burn this secret before it is read."
+        target: "Bränn denna hemlighet innan den läses."
+        verdict: bad
+        note: "Uses literal 'Bränn' (burn) instead of the glossary term 'radera permanent' — terminology drift."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Common gender: en länk."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    sv_SE:
+      noun:
+        target: länk
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.sv-link-good#d7117069
+        source: "Copy the secret link to share it."
+        target: "Kopiera din hemliga länk för att dela den."
+        verdict: good
+        note: "Active imperative 'Kopiera' plus informal possessive 'din'; uses 'länk' per the glossary."
+        rule_refs: [rule.register-lock]
+      - id: ex.sv-link-bad#fc48f282
+        source: "Copy the secret link to share it."
+        target: "Kopiera er hemliga länk för att dela den."
+        verdict: bad
+        note: "Formal possessive 'er' (the ni-register V-form) instead of informal 'din' — the forbidden formal register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'kryptera', past participle 'krypterad' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    sv_SE:
+      verb:
+        target: kryptera
+        rule_ref: rule.terminology-consistency
+      state:
+        target: krypterad
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.sv-encrypt-good#d6dbd00b
+        source: "This message is encrypted with your passphrase."
+        target: "Detta meddelande är krypterat med din lösenfras."
+        verdict: good
+        note: "Informal possessive 'din'; 'krypterat' (neuter agreement of 'krypterad') for the encrypted state; 'lösenfras' for secret protection."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.sv-encrypt-bad#b0971de5
+        source: "This message is encrypted with your passphrase."
+        target: "Detta meddelande är krypterat med er lösenfras."
+        verdict: bad
+        note: "Formal possessive 'er' (the ni-register V-form) instead of informal 'din' — the forbidden formal register."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Compound/hyphenated: e-post."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    sv_SE:
+      noun:
+        target: e-post
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.sv-email-good#3126ee9c
+        source: "Enter your email address."
+        target: "Ange din e-postadress."
+        verdict: good
+        note: "Informal possessive 'din' per the du register; 'e-post' per the glossary. Grounded in live phrasing ('Kontrollera din e-post')."
+        rule_refs: [rule.register-lock]
+      - id: ex.sv-email-bad#7f46f2c6
+        source: "Enter your email address."
+        target: "Ange er e-postadress."
+        verdict: bad
+        note: "Formal possessive 'er' (the ni-register V-form) instead of informal 'din' — the forbidden formal register."

--- a/locales/sv_SE/register.yaml
+++ b/locales/sv_SE/register.yaml
@@ -36,7 +36,4 @@ forbidden_tokens:
   - { token: Ni, context: standalone_word, severity: error, note: "formal 2nd-person pronoun, capitalized/polite form; standalone_word only for the same false-positive reason" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref: baselines.sv_SE is intentionally omitted — baselines.yaml has no
-# sv_SE entry yet and is off-limits to this change. A dangling baseline_ref would
-# fail the resolver; a human reviewer pins the baseline centrally (mirroring the
-# fr/de_AT baselines entries), after which this and rules.yaml can carry it.
+baseline_ref: baselines.sv_SE

--- a/locales/sv_SE/register.yaml
+++ b/locales/sv_SE/register.yaml
@@ -1,0 +1,42 @@
+id: register.sv_SE
+source: onetimesecret/locales/guides/for-translators/sv_SE.md
+# Swedish is locked to the INFORMAL `du` register. This is grounded in the live
+# app content (onetimesecret/locales/content/sv_SE/*.json): direct address is
+# overwhelmingly informal — the subject pronoun `du` appears as a standalone
+# word 131 times (e.g. "Behöver du ett konto?", "Glömt ditt lösenord?", "När du
+# är inloggad...") and the informal possessives din/ditt/dina appear 295 times
+# (e.g. "Skapa ditt konto", "Ange dina uppgifter", "Kontrollera din e-post").
+# The translator guide agrees explicitly: "Informell 'du'-form används
+# universellt sedan du-reformen (1960-talet)" and "Use informal du universally"
+# (sv_SE.md). This is the du-reform: modern Swedish has effectively no enforced
+# T/V distinction; the formal `ni`/`Ni` is rare and can read as stilted or even
+# impolite, so it is the FORBIDDEN form here.
+#
+# Forbidden tokens are kept deliberately SMALL because Swedish has no enforced
+# T/V split to police, and most candidate formal tokens are ambiguous as
+# substrings:
+#   * `ni`/`Ni` (formal 2nd-person pronoun) — forbidden as standalone_word. This
+#     is the one unambiguous, zero-false-positive choice: standalone `ni`/`Ni`
+#     occurs ZERO times in the live content, while the bigram "ni" is extremely
+#     common INSIDE valid words (Inställningar, Organisation, Användning, NIST,
+#     verifiering, autentisering — the productive -ning suffix). standalone_word
+#     context confines the rule to the bare pronoun and avoids every such word.
+#   * The formal possessive/object `er`/`Er`/`ert`/`era` is deliberately NOT
+#     forbidden. Even as standalone_word it false-positives: the live content
+#     uses the plural-suffix notation "session(er)" / "nivå(er)" where `(er)` is
+#     a bare token, and `era` collides with unrelated words. Following the es.md
+#     precedent (do not forbid a token that appears in valid content), it is
+#     left to the glossary/voice rules rather than a register token.
+# AGENT-AUTHORED; requires native-speaker (SV) sign-off — see PR label.
+form: informal
+pronoun: du
+possessive: [din, ditt, dina]
+forbidden_tokens:
+  - { token: ni, context: standalone_word, severity: error, note: "formal 2nd-person pronoun (the V-form du-reform Swedish does not use); standalone_word only — the bigram 'ni' is ubiquitous inside valid words (Inställningar, Organisation, verifiering)" }
+  - { token: Ni, context: standalone_word, severity: error, note: "formal 2nd-person pronoun, capitalized/polite form; standalone_word only for the same false-positive reason" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref: baselines.sv_SE is intentionally omitted — baselines.yaml has no
+# sv_SE entry yet and is off-limits to this change. A dangling baseline_ref would
+# fail the resolver; a human reviewer pins the baseline centrally (mirroring the
+# fr/de_AT baselines entries), after which this and rules.yaml can carry it.

--- a/locales/sv_SE/rules.yaml
+++ b/locales/sv_SE/rules.yaml
@@ -1,0 +1,47 @@
+id: rules.sv_SE
+source: onetimesecret/locales/guides/for-translators/sv_SE.md
+inherits: base
+merge_strategy: append
+# Swedish locale layer. sv_SE is the only Swedish variant in the repo, so it
+# inherits `base` directly (no family `sv` parent), mirroring how
+# locales/es/rules.yaml and locales/nl/rules.yaml inherit base. Carries the
+# Swedish conventions transcribed from
+# onetimesecret/locales/guides/for-translators/sv_SE.md and grounded in the live
+# app content under onetimesecret/locales/content/sv_SE/: the informal `du`
+# register lock (du-reform), the lösenord / lösenfras distinction, the
+# burn -> "radera permanent" terminology choice, and the Swedish compound-word
+# orthography rule. Every rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live sv_SE
+# content; requires native-speaker (SV) sign-off before merge — see PR label.
+rules:
+  - id: rule.sv-register-informal
+    modality: MUST
+    statement: Swedish content uses the informal du register (du / din / ditt / dina) throughout product UI and email content, per the du-reform; the formal ni / Ni address form is forbidden.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.sv-passphrase-password
+    modality: MUST
+    statement: Keep lösenord (account login / authentication credential) distinct from lösenfras (protection of an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.sv-burn-radera-permanent
+    modality: MUST
+    statement: Translate burn / burned consistently as "radera permanent" (action) and "raderad permanent" (state), per the agreed Swedish terminology; do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.sv-compound-words
+    modality: MUST
+    statement: Write Swedish compound words as a single word with no space or hyphen (lösenord, lösenfras, användargränssnitt), never split (NOT "lösen ord"); splitting is an orthography error that also breaks terminology consistency.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.sv-active-imperative-voice
+    modality: SHOULD
+    statement: Use the active imperative for buttons and user actions (Skapa, Radera, Logga in) and declarative past participles with correct gender agreement for status messages (Skapad, Raderad, Utgången).
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.sv_SE
+glossary_ref: glossary.sv_SE
+# baseline_ref: baselines.sv_SE is intentionally omitted until a human reviewer
+# adds the baselines.sv_SE entry to baselines.yaml centrally — a dangling
+# reference fails the resolver, and this task must not edit baselines.yaml.

--- a/locales/sv_SE/rules.yaml
+++ b/locales/sv_SE/rules.yaml
@@ -42,6 +42,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.sv_SE
 glossary_ref: glossary.sv_SE
-# baseline_ref: baselines.sv_SE is intentionally omitted until a human reviewer
-# adds the baselines.sv_SE entry to baselines.yaml centrally — a dangling
-# reference fails the resolver, and this task must not edit baselines.yaml.
+baseline_ref: baselines.sv_SE

--- a/locales/tr/glossary.yaml
+++ b/locales/tr/glossary.yaml
@@ -1,0 +1,188 @@
+id: glossary.tr
+source: onetimesecret/locales/guides/for-translators/tr.md
+# Sense-split of the core domain terminology from the Turkish translator guide's
+# terminology tables (tr.md §Sözlük, §Özel Hususlar, §Key Terminology Reference),
+# grounded against the live app content in onetimesecret/locales/content/tr/.
+# Targets and worked examples are AGENT-AUTHORED and require native-speaker (TR)
+# sign-off before merge — see PR label.
+#
+# Each `good` example uses the chosen formal `siz` register (formal 2pl agreement
+# suffixes -sınız/-siniz, -ınız/-iniz; standalone `siz` where natural) and
+# contains the term's target; each `bad` example demonstrates a forbidden form —
+# the informal `sen` register (standalone `sen`/`senin` pronouns or informal 2sg
+# agreement) or the wrong/forbidden term (e.g. "sır", "sil", "şifre" for
+# passphrase).
+#
+# Turkish citation-form note: Turkish suffixes attach to the noun stem, so every
+# target below is given in its bare citation form and every good example places
+# the term in head position, so the lint word_prefix check (sense target must
+# appear, any suffix allowed) is satisfied by suffixed forms like "gizli
+# mesajınız", "bağlantıyı", "parolanızı", "e-postanızı".
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as 'gizli mesaj', never 'sır'."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    tr:
+      noun:
+        target: gizli mesaj
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created."
+        target: "Gizli mesajınız oluşturuldu."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2pl possessive suffix '-ınız' on the term 'gizli mesaj'; passive/declarative voice 'oluşturuldu' for a status message."
+      - id: ex.secret-sir-bad#250567fe
+        source: "Your secret has been created."
+        target: "Sırrın oluşturuldu."
+        verdict: bad
+        note: "Uses 'sır' (personal/intimate connotation) instead of 'gizli mesaj', AND the informal 2sg possessive '-ın' ('sırrın') instead of the formal '-ınız' — violates both rule.tr-secret-noun and the register lock."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    tr:
+      noun:
+        target: güvenlik ifadesi
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Bu gizli mesajı görüntülemek için güvenlik ifadesini girin."
+        verdict: good
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+        note: "Formal imperative 'girin' (-in); uses 'güvenlik ifadesi' (secret protection), distinct from the account 'parola'. Grounded in live content (00-common.json: 'Güvenlik ifadesini buraya girin')."
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Bu gizli mesajı görüntülemek için şifreyi gir."
+        verdict: bad
+        note: "Uses 'şifre' (account credential) where 'güvenlik ifadesi' (secret protection) is meant, AND the informal bare-stem imperative 'gir' instead of formal 'girin' — violates rule.tr-passphrase-password and the register lock."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    tr:
+      noun:
+        target: parola
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Reset your password."
+        target: "Parolanızı sıfırlayın."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2pl possessive '-ınız' plus formal imperative 'sıfırlayın'; 'parola' is the account credential. Grounded in live content (email.json: 'Parolanızı Sıfırlayın')."
+      - id: ex.password-bad#83a8f72f
+        source: "Reset your password."
+        target: "Parolanı sıfırla."
+        verdict: bad
+        note: "Informal 2sg possessive '-ın' ('parolanı') plus informal bare-stem imperative 'sıfırla' — the forbidden informal register; should be 'Parolanızı sıfırlayın'."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting a secret before it is viewed. Verb 'yakmak' / imperative 'yak...' for the action; past participle 'yakıldı' for the resulting status. Not 'sil' (delete)."
+      key_patterns: ["*burn*", "*.destroy*"]
+    tr:
+      verb:
+        target: yak
+        rule_ref: rule.terminology-consistency
+      state:
+        target: yakıldı
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "The secret was burned."
+        target: "Gizli mesaj yakıldı."
+        verdict: good
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+        note: "State 'yakıldı' (passive/declarative for a status message) plus the noun 'gizli mesaj'. Grounded in live content (secret-manage.json: 'Yakıldı', 'gizli mesaj yakıldı')."
+      - id: ex.burn-bad#4228df6b
+        source: "The secret was burned."
+        target: "Sırrın silindi."
+        verdict: bad
+        note: "Uses 'sil' (generic delete) instead of the 'yak' metaphor and 'sır' instead of 'gizli mesaj', plus informal 2sg '-ın' — terminology drift and register violation."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. 'bağlantı' (native, preferred) — 'link' is also attested in the guide but stay consistent on 'bağlantı'."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    tr:
+      noun:
+        target: bağlantı
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy this link."
+        target: "Bu bağlantıyı kopyalayıp yapıştırın."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal imperative 'yapıştırın' (-ın); 'bağlantı' with accusative suffix '-yı'. Grounded in live content (email.json: 'Veya bu bağlantıyı kopyalayıp yapıştırın')."
+      - id: ex.link-bad#748809c5
+        source: "Copy this link."
+        target: "Bu bağlantıyı kopyala."
+        verdict: bad
+        note: "Informal bare-stem imperative 'kopyala' instead of the formal 'kopyalayın' — the forbidden informal register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; verb 'şifrele' (process 'şifreleme'), past participle 'şifrelenmiş' for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    tr:
+      verb:
+        target: şifrele
+        rule_ref: rule.terminology-consistency
+      state:
+        target: şifrelenmiş
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Bu mesaj güvenlik ifadenizle şifrelenmiştir."
+        verdict: good
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+        note: "State 'şifrelenmiş' (word_prefix of the target) plus formal 2pl possessive '-iniz' on 'güvenlik ifadesi'. Grounded in live content (secret-manage.json: 'Bu mesaj güvenlik ifadenizle şifrelenmiştir.')."
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Bu mesaj senin şifrenle şifrelenmiştir."
+        verdict: bad
+        note: "Informal possessive pronoun 'senin' (forbidden register) plus 'şifre' (account credential) where 'güvenlik ifadesi' (passphrase) is meant."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Written with a hyphen: e-posta."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    tr:
+      noun:
+        target: e-posta
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Verify your email address."
+        target: "E-posta adresinizi doğrulayın."
+        verdict: good
+        rule_refs: [rule.register-lock]
+        note: "Formal 2pl possessive '-iniz' ('adresiniz') plus formal imperative 'doğrulayın'; 'e-posta' (word_prefix). Grounded in live content (email.json: 'Lütfen aşağıdaki bağlantıya tıklayarak e-posta adresinizi doğrulayın')."
+      - id: ex.email-bad#5c29e476
+        source: "Verify your email address."
+        target: "E-posta adresini doğrula."
+        verdict: bad
+        note: "Informal 2sg possessive '-in' ('adresini') plus informal bare-stem imperative 'doğrula' — the forbidden informal register; should be 'E-posta adresinizi doğrulayın'."

--- a/locales/tr/register.yaml
+++ b/locales/tr/register.yaml
@@ -52,8 +52,4 @@ forbidden_tokens:
   - { token: senin, context: standalone_word, severity: error, note: "informal 2sg possessive pronoun ('your'); standalone_word avoids matching unrelated agglutinated words" }
 exceptions: []
 rule_ref: rule.tr-register-formal
-# baseline_ref: baselines.tr is intentionally omitted — no `baselines.tr` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
-# human reviewer pins the baseline centrally at commit time (mirroring the fr /
-# de_AT entries), after which this and rules.yaml can carry baseline_ref:
-# baselines.tr. (Deferred, cf. locales/es/register.yaml.)
+baseline_ref: baselines.tr

--- a/locales/tr/register.yaml
+++ b/locales/tr/register.yaml
@@ -1,0 +1,59 @@
+id: register.tr
+source: onetimesecret/locales/guides/for-translators/tr.md
+# Turkish is locked to the FORMAL `siz` register. Grounded in the live app content
+# (onetimesecret/locales/content/tr/*.json) and the prose guide (tr.md §5 "Formal
+# Address": use formal "siz", not informal "sen").
+#
+# How the T/V distinction surfaces in Turkish: it is carried MAINLY by verb-suffix
+# and possessive-suffix agreement, not by standalone subject pronouns (which
+# Turkish normally drops). The live content is uniformly formal 2nd-person-plural:
+#   - formal 2pl verb suffixes everywhere: gönderebilirsiniz, başlıyorsunuz,
+#     görmezden gelebilirsiniz, hoş geldiniz, göreceksiniz, kapatabilirsiniz;
+#   - formal 2pl possessive suffix -ınız/-iniz: parolanız, hesabınız, mesajınız,
+#     e-posta adresiniz, güvenlik ifadeniz;
+#   - the standalone formal subject pronoun `siz` appears 10x (e.g. "Bu gizli
+#     mesajı siz oluşturdunuz", "Bu değişikliği siz yapmadıysanız").
+# The informal register is entirely absent: zero standalone occurrences of the
+# informal pronoun `sen` or its case forms (senin / seni / sana / sende / senden)
+# across all 20 content files. So the FORBIDDEN register is the informal `sen`
+# register.
+#
+# WHY forbidden_tokens are only the standalone informal PRONOUN forms (and not the
+# informal verb/possessive suffixes): Turkish is agglutinative with vowel harmony,
+# and the informal-2sg markers are suffixes, not free words. The informal verb
+# suffix -sın/-sin and possessive -ın/-in are substrings of countless valid formal
+# and 3rd-person words (e.g. -sınız/-iniz themselves contain them), so a substring
+# token would mass-false-positive on legitimate formal content. They cannot be
+# expressed as a safe standalone_word token either. The suffix-level distinction is
+# therefore captured as a prose rule in rules.yaml (rule.tr-register-formal), not
+# here. forbidden_tokens below are limited to the unambiguous standalone informal
+# pronoun/possessive WORDS, matched as standalone_word so Turkish suffixed words
+# that merely contain "sen"/"siz" as a substring (e.g. "gönderen", "sizin",
+# "size") never trip the check.
+#
+# Deliberately NOT forbidden:
+#   - `siz` and its suffixed forms (sizin, size, sizi, sizden, ...): these ARE the
+#     chosen formal register and must be allowed.
+#   - the bare imperative stem (e.g. "gönder"): Turkish formal imperatives use the
+#     -ın/-iniz ending (gönderin), but the bare 2sg stem doubles as the dictionary
+#     citation/button-label form in some UIs; flagging it lexically is unsafe, so
+#     it is left to the prose rule and native review (see judgment notes).
+# Left-free token note: `seni`/`sana`/`sende`/`senden` (informal oblique case
+# forms) are NOT listed because they do not occur in the live content and adding
+# rarely-needed forms risks brittleness; `sen` + `senin` cover the address core. A
+# native reviewer may extend this list.
+#
+# AGENT-AUTHORED; requires native-speaker (TR) sign-off — see PR label.
+form: formal
+pronoun: siz
+possessive: [sizin]
+forbidden_tokens:
+  - { token: sen,   context: standalone_word, severity: error, note: "informal 2sg subject pronoun (the V/T form this locale forbids); standalone_word so it does not match substrings inside formal words like 'gönderen' or 'sona'" }
+  - { token: senin, context: standalone_word, severity: error, note: "informal 2sg possessive pronoun ('your'); standalone_word avoids matching unrelated agglutinated words" }
+exceptions: []
+rule_ref: rule.tr-register-formal
+# baseline_ref: baselines.tr is intentionally omitted — no `baselines.tr` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
+# human reviewer pins the baseline centrally at commit time (mirroring the fr /
+# de_AT entries), after which this and rules.yaml can carry baseline_ref:
+# baselines.tr. (Deferred, cf. locales/es/register.yaml.)

--- a/locales/tr/rules.yaml
+++ b/locales/tr/rules.yaml
@@ -68,8 +68,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.tr
 glossary_ref: glossary.tr
-# baseline_ref: baselines.tr is intentionally omitted until a human reviewer adds
-# the `baselines.tr` entry to baselines.yaml centrally — a dangling reference
-# fails the resolver, and this task must not edit baselines.yaml. Add it together
-# with the baselines.yaml `tr` block when that lands. (Deferred, cf.
 # locales/es/rules.yaml.)
+baseline_ref: baselines.tr

--- a/locales/tr/rules.yaml
+++ b/locales/tr/rules.yaml
@@ -1,0 +1,75 @@
+id: rules.tr
+source: onetimesecret/locales/guides/for-translators/tr.md
+inherits: base
+merge_strategy: append
+# Turkish locale layer. tr is a standalone shipping language (no family parent),
+# so it inherits `base` directly — mirroring locales/fr/rules.yaml and
+# locales/es/rules.yaml. Carries the Turkish conventions transcribed from
+# onetimesecret/locales/guides/for-translators/tr.md and grounded in the live app
+# content under onetimesecret/locales/content/tr/:
+#   - the formal `siz` register lock (the T/V distinction is carried mainly by
+#     verb-suffix and possessive-suffix agreement, not standalone pronouns — see
+#     rule.tr-register-formal and the comment in register.yaml);
+#   - the secret -> "gizli mesaj" (NOT "sır") noun choice;
+#   - the parola/şifre vs güvenlik ifadesi (password vs passphrase) distinction;
+#   - the burn -> "yak/yakmak" metaphor (NOT "sil");
+#   - the active-imperative / passive-status voice split.
+# Every rule_ref points at an existing base rule id.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (TR) sign-off before merge
+# — see PR label.
+rules:
+  - id: rule.tr-register-formal
+    modality: MUST
+    statement: >-
+      Turkish content uses the formal `siz` register throughout product UI and
+      email content. Because the Turkish T/V distinction is carried mainly by
+      agreement suffixes rather than standalone pronouns, this means: use the
+      formal 2nd-person-plural verb suffixes (-sınız/-siniz/-sunuz, imperatives
+      in -ın/-in/-ınız/-iniz, e.g. "girin", "gönderebilirsiniz") and the formal
+      2pl possessive suffix (-ınız/-iniz, e.g. "parolanız", "hesabınız"). The
+      informal 2sg register is forbidden — no informal pronouns (sen / senin) and
+      no informal 2sg agreement suffixes (-sın/-sin verb, bare-stem imperatives,
+      -ın/-in 2sg possessive used for direct address).
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.tr-secret-noun
+    modality: MUST
+    statement: >-
+      Translate the noun "secret" as "gizli mesaj" (confidential message), never
+      "sır". "Sır" carries personal/intimate connotations in Turkish that are
+      unfit for a neutral security product; use "gizli" for the adjective sense.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.tr-passphrase-password
+    modality: MUST
+    statement: >-
+      Keep "parola" / "şifre" (account login / authentication credential)
+      distinct from "güvenlik ifadesi" (protection of an individual secret);
+      never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.tr-burn-yak
+    modality: MUST
+    statement: >-
+      Translate burn / burned consistently with the "yak" metaphor — verb
+      "yakmak" / imperative "yak..." and past participle/state "yakıldı" — not
+      the generic "sil" (delete); do not vary across strings.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.tr-active-passive-voice
+    modality: SHOULD
+    statement: >-
+      Use the active imperative for buttons and user actions (Gizli mesaj
+      oluştur, Değişiklikleri kaydet, Mesajı gönder) and the passive/declarative
+      voice for status and informational messages (Gizli mesaj oluşturuldu,
+      Değişiklikler kaydedildi, Gizli mesaj yakıldı).
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.tr
+glossary_ref: glossary.tr
+# baseline_ref: baselines.tr is intentionally omitted until a human reviewer adds
+# the `baselines.tr` entry to baselines.yaml centrally — a dangling reference
+# fails the resolver, and this task must not edit baselines.yaml. Add it together
+# with the baselines.yaml `tr` block when that lands. (Deferred, cf.
+# locales/es/rules.yaml.)

--- a/locales/uk/glossary.yaml
+++ b/locales/uk/glossary.yaml
@@ -1,0 +1,182 @@
+id: glossary.uk
+source: onetimesecret/locales/guides/for-translators/uk.md
+# Sense-split of the core domain terminology from the Ukrainian translator guide's
+# terminology tables (Основна термінологія, Послідовність термінології, Функції
+# безпеки), grounded against the live app content in
+# onetimesecret/locales/content/uk/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (UK) sign-off before merge — see PR
+# label. Each `good` example uses the locked FORMAL "ви" register and contains
+# its term's sense target; each `bad` example demonstrates a forbidden form — the
+# informal "ти"/"твій" register, or the wrong term.
+#
+# Ukrainian nouns/verbs inflect heavily (7 cases, 3 genders, aspect). Sense
+# targets use a sensible citation stem (nominative noun / infinitive verb), and
+# each good example keeps a word that BEGINS with that stem so the word_prefix
+# sense-target lint check holds (e.g. target stem "таємниц" matches "таємницю").
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself — created, shared, burned, viewed, or expired. The central concept of the application. Noun таємниц(я); never секрет. Use the adjective таємн(ий/а/е) for 'secret link/message/content', never секретний. Never substitute повідомлення (message) for the entity sense."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    uk:
+      noun:
+        target: таємниц
+        rule_ref: rule.uk-secret-not-sekret
+      adjective:
+        target: таємн
+        rule_ref: rule.uk-secret-not-sekret
+    rule_refs: [rule.uk-register-formal, rule.uk-secret-not-sekret]
+    examples:
+      - id: ex.uk-secret-created-good#88891f6b
+        source: "Your secret has been created."
+        target: "Вашу таємницю створено."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+      - id: ex.uk-secret-informal-bad#6c34a4bc
+        source: "Your secret has been created."
+        target: "Твій секрет створено."
+        verdict: bad
+        note: "Informal possessive 'Твій' (forbidden ти register; formal is Вашу/Ваш) AND 'секрет' instead of таємниця — violates rule.uk-secret-not-sekret."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login пароль). Compose/protect-a-secret contexts signal this sense. Citation form 'парольна фраза'."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    uk:
+      noun:
+        target: парольн
+        rule_ref: rule.uk-passphrase-password
+    rule_refs: [rule.uk-register-formal, rule.uk-passphrase-password]
+    examples:
+      - id: ex.uk-passphrase-good#d847753a
+        source: "Your passphrase is required to view this secret."
+        target: "Для перегляду цієї таємниці потрібна Ваша парольна фраза."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+      - id: ex.uk-passphrase-bad#33953ae2
+        source: "Your passphrase is required to view this secret."
+        target: "Для перегляду цієї таємниці потрібен твій пароль."
+        verdict: bad
+        note: "Uses 'пароль' (account password) where парольна фраза is meant — violates rule.uk-passphrase-password; also informal possessive 'твій' (forbidden ти register)."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account/login authentication credential (distinct from a secret's парольна фраза). Sign-in, account, and reset-password contexts signal this sense. Citation form 'пароль'."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    uk:
+      noun:
+        target: парол
+        rule_ref: rule.uk-passphrase-password
+    rule_refs: [rule.uk-register-formal, rule.uk-passphrase-password]
+    examples:
+      - id: ex.uk-password-good#c33e0e3c
+        source: "Enter your password to sign in."
+        target: "Введіть Ваш пароль, щоб увійти."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+      - id: ex.uk-password-bad#8c30c587
+        source: "Enter your password to sign in."
+        target: "Введи свій пароль, щоб увійти."
+        verdict: bad
+        note: "Informal singular imperative 'Введи' (forbidden ти register; formal is Введіть). The good form keeps the formal plural imperative."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of destroying a secret before it is viewed; emphasises permanence. Verb знищити for the action; знищено the resulting state; спалити is an accepted synonym per the guide."
+      key_patterns: ["*burn*", "*.destroy*"]
+    uk:
+      verb:
+        target: знищ
+        rule_ref: rule.terminology-consistency
+      state:
+        target: знищено
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.uk-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.uk-burn-good#2dd01fb1
+        source: "Are you sure you want to burn this secret?"
+        target: "Ви впевнені, що хочете знищити цю таємницю?"
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+        note: "Verbatim from live content (secret-manage.json) — formal 'Ви ... хочете'."
+      - id: ex.uk-burn-bad#beee21af
+        source: "Are you sure you want to burn this secret?"
+        target: "Ти впевнений, що хочеш знищити цю таємницю?"
+        verdict: bad
+        note: "Informal pronoun 'Ти' with 2nd-sg 'хочеш' (forbidden ти register); formal is 'Ви ... хочете'."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Citation form 'посилання' (neuter noun); pairs with the adjective таємн- ('таємне посилання', never секретне)."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    uk:
+      noun:
+        target: посилання
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.uk-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.uk-link-good#733cc71a
+        source: "Copy the secret link to share it."
+        target: "Скопіюйте таємне посилання, щоб поділитися ним."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+      - id: ex.uk-link-bad#08560f54
+        source: "Copy the secret link to share it."
+        target: "Скопіюй своє секретне посилання, щоб поділитися ним."
+        verdict: bad
+        note: "Informal singular imperative 'Скопіюй' (forbidden ти register; formal is Скопіюйте) AND 'секретне' instead of таємне — violates rule.uk-secret-not-sekret."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. Verb зашифрувати; past participle зашифрований/зашифровано for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    uk:
+      verb:
+        target: зашифр
+        rule_ref: rule.terminology-consistency
+      state:
+        target: зашифровано
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.uk-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.uk-encrypt-good#fe4b74cc
+        source: "Your message is encrypted with your passphrase."
+        target: "Це повідомлення зашифровано Вашою парольною фразою."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+        note: "Verbatim from live content (secret-manage.json) — formal possessive 'Вашою'."
+      - id: ex.uk-encrypt-bad#d15fb7b2
+        source: "Your message is encrypted with your passphrase."
+        target: "Це повідомлення зашифровано твоєю парольною фразою."
+        verdict: bad
+        note: "Informal possessive 'твоєю' (forbidden ти register); formal is Вашою."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail (account identifier, notifications). Human-facing term is електронна пошта / електронна адреса; the bare English 'email' appears mainly in meta keys, not prose."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    uk:
+      noun:
+        target: електронн
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.uk-register-formal, rule.terminology-consistency]
+    examples:
+      - id: ex.uk-email-good#a342d634
+        source: "Enter your email address."
+        target: "Введіть Вашу електронну адресу."
+        verdict: good
+        rule_refs: [rule.uk-register-formal]
+        note: "Verbatim-style from live content (session-auth-extended.json: 'Введіть Вашу електронну адресу') — formal imperative + possessive."
+      - id: ex.uk-email-bad#874d9899
+        source: "Enter your email address."
+        target: "Введи свою електронну адресу."
+        verdict: bad
+        note: "Informal singular imperative 'Введи' (forbidden ти register); formal is Введіть."

--- a/locales/uk/register.yaml
+++ b/locales/uk/register.yaml
@@ -1,0 +1,71 @@
+id: register.uk
+source: onetimesecret/locales/guides/for-translators/uk.md
+# Ukrainian is locked to the FORMAL "ви" register (polite 2nd-person plural used
+# as singular address). Grounded in the live app content
+# (onetimesecret/locales/content/uk/*.json):
+#   - the formal possessive "Ваш" family is pervasive — Ваш / Ваша / Ваше / Ваші
+#     and case forms Вашого / Вашої / Вашому / Вашій / Вашу / Вашим / Ваших /
+#     Вашою / Вашими appear ~280 times across all 17 files (e.g.
+#     "Введіть Вашу електронну адресу", "Це повідомлення зашифровано Вашою
+#     парольною фразою.", "Ваш секрет залишатиметься доступним");
+#   - the formal address pronoun "ви / вам / вас / вами" appears 126 times
+#     (e.g. "Ви впевнені, що хочете знищити цю таємницю?", "Ми показуємо вам
+#     значення, щоб ви могли його перевірити");
+#   - imperatives are the formal -іть/-те plural form throughout — Введіть,
+#     Виберіть, Натисніть, Створіть, Поділіться — never the informal singular
+#     (Введи, Вибери, Натисни);
+#   - the informal "ти" register is ENTIRELY ABSENT: zero standalone "ти" and
+#     zero informal possessives (твій / твоя / твоє / твої / твого / тобі /
+#     тебе) anywhere in the live content.
+# The prose guide concurs: the Contextual Rules table ("Звернення до користувача
+# | Друга особа ... 'ви' (неформальне 'ти' уникати)") and Quality Checklist
+# item 8 ("Використовується ввічлива форма 'ви' ... не неформальне 'ти'").
+#
+# Because the locked register is formal, the FORBIDDEN register is the INFORMAL
+# "ти" one: the informal address pronoun (ти / тебе / тобі / тобою) and the
+# informal possessive "твій" family. These have zero legitimate use in this
+# formal corpus — the formal counterparts are ви/вас/вам and Ваш respectively.
+#
+# Tokens are matched as standalone_word (NOT word_prefix/substring) on purpose:
+# "ти" is a 2-letter substring of countless valid Ukrainian words (читати,
+# платити, налаштування, активний, ...), so a looser context would massively
+# false-positive; the informal possessives likewise share stems with unrelated
+# words. As standalone words the informal forms are unambiguous register markers
+# that never occur in the live content. Matching is casefolded, so each lowercase
+# token also catches its sentence-initial capitalized form (Ти, Твій, ...).
+#
+# Deliberately NOT forbidden: the informal 2nd-person-singular VERB and IMPERATIVE
+# endings (e.g. -еш/-иш finite forms, the -и/-й singular imperative Введи/Натисни).
+# Ukrainian verb endings are not separable standalone words and overlap with valid
+# vocabulary and with 3rd-person/plural forms the formal register legitimately
+# uses, so forbidding them would false-positive. The informal pronouns and
+# possessives above are the unambiguous standalone markers and carry the lock.
+#
+# AGENT-AUTHORED; requires native-speaker (UK) sign-off — see PR label.
+form: formal
+pronoun: ви
+possessive: [Ваш, Ваша, Ваше, Ваші, Вашого, Вашої, Вашому, Вашій, Вашу, Вашим, Ваших, Вашою, Вашими]
+forbidden_tokens:
+  - { token: ти,     context: standalone_word, severity: error, note: "informal address pronoun 'you' (nom.) — the register uk does NOT use; formal is ви. Substring of many words (читати, платити), so standalone_word only" }
+  - { token: тебе,   context: standalone_word, severity: error, note: "informal address pronoun 'you' (gen./acc.) — formal is вас" }
+  - { token: тобі,   context: standalone_word, severity: error, note: "informal address pronoun 'you' (dat./loc.) — formal is вам" }
+  - { token: тобою,  context: standalone_word, severity: error, note: "informal address pronoun 'you' (instr.) — formal is вами" }
+  - { token: твій,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. masc.) — formal is Ваш" }
+  - { token: твоя,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. fem.) — formal is Ваша" }
+  - { token: твоє,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. neut.) — formal is Ваше" }
+  - { token: твої,   context: standalone_word, severity: error, note: "informal possessive 'your' (nom. pl.) — formal is Ваші" }
+  - { token: твого,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen./acc. masc./neut.) — formal is Вашого" }
+  - { token: твоєї,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen. fem.) — formal is Вашої" }
+  - { token: твоєму, context: standalone_word, severity: error, note: "informal possessive 'your' (dat./loc. masc./neut.) — formal is Вашому" }
+  - { token: твоїй,  context: standalone_word, severity: error, note: "informal possessive 'your' (dat./loc. fem.) — formal is Вашій" }
+  - { token: твою,   context: standalone_word, severity: error, note: "informal possessive 'your' (acc. fem.) — formal is Вашу" }
+  - { token: твоїм,  context: standalone_word, severity: error, note: "informal possessive 'your' (instr. masc./neut. / dat. pl.) — formal is Вашим" }
+  - { token: твоєю,  context: standalone_word, severity: error, note: "informal possessive 'your' (instr. fem.) — formal is Вашою" }
+  - { token: твоїх,  context: standalone_word, severity: error, note: "informal possessive 'your' (gen./loc. pl.) — formal is Ваших" }
+  - { token: твоїми, context: standalone_word, severity: error, note: "informal possessive 'your' (instr. pl.) — formal is Вашими" }
+exceptions: []
+rule_ref: rule.register-lock
+# baseline_ref intentionally omitted (optional per register.schema.json): no
+# `baselines.uk` entry exists yet, this backfill must not edit baselines.yaml,
+# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
+# central baselines.uk pin at commit time, after which this file can carry it.

--- a/locales/uk/register.yaml
+++ b/locales/uk/register.yaml
@@ -65,7 +65,4 @@ forbidden_tokens:
   - { token: твоїми, context: standalone_word, severity: error, note: "informal possessive 'your' (instr. pl.) — formal is Вашими" }
 exceptions: []
 rule_ref: rule.register-lock
-# baseline_ref intentionally omitted (optional per register.schema.json): no
-# `baselines.uk` entry exists yet, this backfill must not edit baselines.yaml,
-# and the resolver hard-fails on a dangling baseline_ref. A reviewer adds the
-# central baselines.uk pin at commit time, after which this file can carry it.
+baseline_ref: baselines.uk

--- a/locales/uk/rules.yaml
+++ b/locales/uk/rules.yaml
@@ -1,0 +1,62 @@
+id: rules.uk
+source: onetimesecret/locales/guides/for-translators/uk.md
+inherits: base
+merge_strategy: append
+# Ukrainian locale layer. uk is a standalone shipping language (no family
+# parent), so it inherits `base` directly — mirroring the Slavic pilots
+# locales/pl/ and locales/cs/, but with the OPPOSITE register decision: Ukrainian
+# is locked to the FORMAL "ви" register. That choice is grounded in the live app
+# content (onetimesecret/locales/content/uk/*.json), which uses the formal "Ваш"
+# possessive family (~280x) and the formal "ви/вам/вас" address pronoun (126x)
+# throughout, formal -іть imperatives (Введіть/Виберіть/Натисніть), and contains
+# ZERO informal "ти"/"твій" forms. The prose guide agrees (Contextual Rules:
+# "ввічлива форма 'ви' ... неформальне 'ти' уникати"; Quality Checklist item 8).
+#
+# rule.uk-pluralization captures the complex Ukrainian plural system (1 / 2-4 /
+# 5+, e.g. день / дні / днів), which the guide flags as critical (Узгодження за
+# числом); it specialises the base rule.pluralization-syntax. The single most
+# critical terminology rules in the guide are секрет→таємниця (avoid "секрет",
+# which still appears as a register-regression in the live secret-manage.json)
+# and password vs passphrase (пароль for account login vs парольна фраза for the
+# credential protecting a secret). Ukrainian declines nouns across 7 cases and
+# requires gender agreement on adjectives (таємний/таємна/таємне), both flagged.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live content;
+# requires native-speaker (UK) sign-off before merge — see PR label.
+rules:
+  - id: rule.uk-register-formal
+    modality: MUST
+    statement: Ukrainian content uses the formal "ви" register (ви / вам / вас / вами) with the formal possessive "Ваш" family and formal -іть/-те plural imperatives throughout product UI and email content; the informal "ти" register (ти / тебе / тобі, твій / твоя / твоє) is forbidden for direct address.
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.uk-pluralization
+    modality: MUST
+    statement: Express countable strings with the three Ukrainian plural forms (1 / 2-4 / 5+, e.g. день / дні / днів), choosing the form by the count's final digit (numbers ending 2-4 except 12-14 take the 2-4 form), via vue-i18n pipe syntax; never collapse to a single plural.
+    severity: error
+    rule_ref: rule.pluralization-syntax
+  - id: rule.uk-secret-not-sekret
+    modality: MUST
+    statement: Translate the core "secret" concept as the noun таємниця and the adjective таємний/таємна/таємне (gender-agreeing); never use секрет/секретний (too personal a connotation), and never substitute повідомлення (message) unless the source specifically refers to a message.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.uk-passphrase-password
+    modality: MUST
+    statement: Keep пароль (account login credential) distinct from парольна фраза (the passphrase protecting an individual secret); never use one where the other is meant.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.uk-gender-case-agreement
+    modality: MUST
+    statement: Agree adjectives and participles with their noun in gender (masc./fem./neut.) and inflect through all seven cases as the syntax requires (таємне повідомлення, таємного посилання, таємним посиланням); do not leave a single fixed form as a calque from English.
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.uk-imperative-buttons
+    modality: SHOULD
+    statement: Use the formal plural imperative for button and action labels (Створіть, Введіть, Збережіть, Поділіться); use passive voice or past-tense impersonal forms with correct gender agreement for status and system messages (Таємницю створено, Зміни збережено).
+    severity: info
+    rule_ref: rule.message-voice
+register_ref: register.uk
+glossary_ref: glossary.uk
+# baseline_ref intentionally omitted: no baselines.uk entry exists yet and this
+# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
+# dangling baseline_ref, and the field is optional per rules.schema.json, so it
+# is left out until a reviewer adds the central baselines.uk pin.

--- a/locales/uk/rules.yaml
+++ b/locales/uk/rules.yaml
@@ -56,7 +56,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.uk
 glossary_ref: glossary.uk
-# baseline_ref intentionally omitted: no baselines.uk entry exists yet and this
-# backfill must not edit the shared baselines.yaml. The resolver hard-fails on a
-# dangling baseline_ref, and the field is optional per rules.schema.json, so it
-# is left out until a reviewer adds the central baselines.uk pin.
+baseline_ref: baselines.uk

--- a/locales/vi/glossary.yaml
+++ b/locales/vi/glossary.yaml
@@ -1,0 +1,254 @@
+id: glossary.vi
+source: onetimesecret/locales/guides/for-translators/vi.md
+# Sense-split of the core domain terminology from the Vietnamese translator
+# guide's terminology tables (onetimesecret/locales/guides/for-translators/vi.md
+# §"Thuật ngữ cơ bản", §"Thuật ngữ liên quan đến tài khoản"), grounded against
+# the live app content in onetimesecret/locales/content/vi/*.json. Targets and
+# worked examples are AGENT-AUTHORED and require native-speaker (VI) sign-off
+# before merge — see PR label.
+#
+# Vietnamese IS space-delimited, so the resolver's default word_prefix sense
+# match works normally. Each `good` example below: (a) uses `bạn` as the address
+# where direct address appears (the neutral register lock); (b) is verified clean
+# of register.vi forbidden_tokens; and (c) contains one of its term's sense
+# targets at a word boundary. Multi-syllable citation forms (cụm mật khẩu, xóa
+# vĩnh viễn) appear as a contiguous substring in head/word-boundary position so
+# word_prefix matches. Each `bad` example demonstrates a wrong form (a forbidden
+# kinship/intimate address pronoun, or terminology drift).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Render as `bí mật`."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    vi:
+      noun:
+        target: bí mật
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your secret has been created securely."
+        target: "Bí mật của bạn đã được tạo an toàn."
+        verdict: good
+        note: "Verbatim from live content; neutral address 'của bạn'; past-marker 'đã' for status; term 'bí mật' in head position."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-created-bad#93b6aa32
+        source: "Your secret has been created securely."
+        target: "Bí mật của em đã được tạo an toàn."
+        verdict: bad
+        note: "Uses kinship pronoun 'em' (younger person) as the generic address instead of 'bạn' — the forbidden register (rule.vi-register-ban)."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense — protection/safety of information. Render as `an toàn` (safe/secure); reserve `bí mật` for the product-noun sense."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    vi:
+      adjective:
+        target: an toàn
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "Someone sent you a secure message."
+        target: "An toàn hơn khi bạn chia sẻ thông tin nhạy cảm qua liên kết này."
+        verdict: good
+        note: "Grounded in live 'giao tiếp an toàn'/'tin nhắn an toàn'; adjective 'an toàn' in head position; neutral address 'bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "Someone sent you a secure message."
+        target: "An toàn hơn khi anh chia sẻ thông tin nhạy cảm qua liên kết này."
+        verdict: bad
+        note: "Uses kinship pronoun 'anh' (older male) as the generic address instead of 'bạn' — forbidden register (rule.vi-register-ban)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual secret (distinct from the account login password). `cụm` = phrase/cluster. Compose/protect-a-secret contexts signal this sense."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    vi:
+      noun:
+        target: cụm mật khẩu
+        rule_ref: rule.vi-passphrase-password
+    rule_refs: [rule.register-lock, rule.vi-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Enter the passphrase to view this secret."
+        target: "Cụm mật khẩu sẽ được người gửi cung cấp cho bạn riêng."
+        verdict: good
+        note: "Grounded in live 'Người gửi sẽ cung cấp cụm mật khẩu cho bạn riêng'; term 'cụm mật khẩu' (secret protection) in head position, not 'mật khẩu'; neutral address 'bạn'."
+        rule_refs: [rule.register-lock, rule.vi-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this secret."
+        target: "Mật khẩu sẽ được người gửi cung cấp cho em riêng."
+        verdict: bad
+        note: "Uses 'mật khẩu' (account credential) where 'cụm mật khẩu' (secret protection) is meant AND kinship pronoun 'em' for the generic address — violates rule.vi-passphrase-password and the register lock."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a secret's passphrase). Sign-in, account, and reset contexts signal this sense."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    vi:
+      noun:
+        target: mật khẩu
+        rule_ref: rule.vi-passphrase-password
+    rule_refs: [rule.register-lock, rule.vi-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to sign in."
+        target: "Mật khẩu của bạn dùng để đăng nhập vào tài khoản."
+        verdict: good
+        note: "Grounded in live 'Nhập mật khẩu của bạn'; account term 'mật khẩu' in head position; neutral possessive 'của bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "Mật khẩu của ông dùng để đăng nhập vào tài khoản."
+        verdict: bad
+        note: "Uses kinship pronoun 'ông' (older male / sir) as the generic address instead of 'bạn' — the forbidden register."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of permanently deleting a secret before it is viewed. Rendered as `xóa vĩnh viễn` (delete permanently), not the literal `đốt` (set on fire); same phrase for the action and the resulting state (with `đã` for past)."
+      key_patterns: ["*burn*", "*.destroy*"]
+    vi:
+      action:
+        target: xóa vĩnh viễn
+        rule_ref: rule.terminology-consistency
+      state:
+        target: đã xóa vĩnh viễn
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "A burned secret cannot be recovered."
+        target: "Xóa vĩnh viễn bí mật này thì bạn không thể khôi phục lại."
+        verdict: good
+        note: "Action term 'xóa vĩnh viễn' in head position (grounded in live 'bị xóa vĩnh viễn'); neutral address 'bạn'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.burn-bad#4228df6b
+        source: "A burned secret cannot be recovered."
+        target: "Đốt bí mật này thì em không thể khôi phục lại."
+        verdict: bad
+        note: "Uses literal 'đốt' (set on fire) instead of the glossary term 'xóa vĩnh viễn' (terminology drift) AND kinship pronoun 'em' as the generic address."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The URL that provides access to a secret. Rendered as `liên kết`."
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    vi:
+      noun:
+        target: liên kết
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "Copy the link to share it."
+        target: "Liên kết bí mật của bạn sẽ hết hạn sau một ngày."
+        verdict: good
+        note: "Verbatim from live content; term 'liên kết' in head position; neutral possessive 'của bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.link-bad#748809c5
+        source: "Copy the link to share it."
+        target: "Liên kết bí mật của cậu sẽ hết hạn sau một ngày."
+        verdict: bad
+        note: "Uses intimate pronoun 'cậu' (casual peer) as the generic address instead of 'bạn' — the forbidden register."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data. `mã hóa` for the verb/action, `đã mã hóa` for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    vi:
+      verb:
+        target: mã hóa
+        rule_ref: rule.terminology-consistency
+      state:
+        target: đã mã hóa
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "Mã hóa tin nhắn này bằng cụm mật khẩu của bạn."
+        verdict: good
+        note: "Grounded in live 'Tin nhắn này được mã hóa bằng cụm mật khẩu của bạn'; verb 'mã hóa' in head position; 'cụm mật khẩu' not 'mật khẩu'; neutral 'của bạn'."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "Mã hóa tin nhắn này bằng mật khẩu của ông."
+        verdict: bad
+        note: "Uses 'mật khẩu' (account credential) where 'cụm mật khẩu' (secret protection) is meant AND kinship pronoun 'ông' as the generic address — violates rule.vi-passphrase-password and the register lock."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Kept as `email` (loanword)."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    vi:
+      noun:
+        target: email
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Check your email."
+        target: "Kiểm tra email của bạn."
+        verdict: good
+        note: "Verbatim from live content; subject-less imperative 'Kiểm tra'; term 'email' present; neutral possessive 'của bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.email-bad#5c29e476
+        source: "Check your email."
+        target: "Kiểm tra email của mày."
+        verdict: bad
+        note: "Uses the rude/intimate pronoun 'mày' (disrespectful 'you') as the generic address instead of 'bạn' — never appropriate for UI (rule.vi-register-ban)."
+  - id: term.account#3a541ed7
+    key: account
+    en: account
+    disambiguation:
+      heuristic: "The user's profile / login account. Sign-up, sign-in, settings, and billing contexts. Rendered as `tài khoản`."
+      key_patterns: ["*account*", "*.signup*", "*.profile*", "*.billing*"]
+    vi:
+      noun:
+        target: tài khoản
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.account-good#943273f4
+        source: "You requested a sign-in link for your account."
+        target: "Tài khoản của bạn đã yêu cầu một liên kết đăng nhập."
+        verdict: good
+        note: "Grounded in live 'Bạn đã yêu cầu liên kết đăng nhập cho tài khoản... của bạn'; term 'tài khoản' in head position; neutral 'của bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.account-bad#e35ea31d
+        source: "You requested a sign-in link for your account."
+        target: "Tài khoản của bà đã yêu cầu một liên kết đăng nhập."
+        verdict: bad
+        note: "Uses kinship pronoun 'bà' (older female / madam) as the generic address instead of 'bạn' — the forbidden register."
+  - id: term.secure#952acf0e
+    key: secure
+    en: secure
+    disambiguation:
+      heuristic: "The state/quality of being protected — 'secure', 'safety'. Rendered as `an toàn` (also `bảo mật` for the security-feature noun); distinct from the product noun `bí mật`."
+      key_patterns: ["*secure*", "*safety*", "*.protect*"]
+    vi:
+      adjective:
+        target: an toàn
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secure-good#87313cf3
+        source: "A secure link will be sent to your inbox."
+        target: "An toàn nhất là khi bạn nhận liên kết qua hộp thư email của bạn."
+        verdict: good
+        note: "Grounded in live 'Một liên kết an toàn sẽ được gửi đến hộp thư email của bạn'; adjective 'an toàn' in head position; neutral address 'bạn'."
+        rule_refs: [rule.register-lock]
+      - id: ex.secure-bad#fc1e2db0
+        source: "A secure link will be sent to your inbox."
+        target: "An toàn nhất là khi ngài nhận liên kết qua hộp thư email của ngài."
+        verdict: bad
+        note: "Uses deferential pronoun 'ngài' (sir/lord) as the generic address instead of 'bạn' — over-formal/hierarchical, the forbidden register."

--- a/locales/vi/register.yaml
+++ b/locales/vi/register.yaml
@@ -1,0 +1,80 @@
+id: register.vi
+source: onetimesecret/locales/guides/for-translators/vi.md
+# Vietnamese has NO T/V (informal/formal) split. Address is carried by a
+# kinship-pronoun system (anh/chị/em/ông/bà/cô/chú/bác/cậu… chosen by the
+# relative age/sex/status of speaker and addressee), plus intimate/rude pronouns
+# (mày/tao/tớ). For neutral software UI the standard, age- and status-neutral
+# 2nd-person address is "bạn" ("you", friendly-neutral) — it sidesteps the
+# kinship hierarchy entirely. Grounded in the live app content
+# (onetimesecret/locales/content/vi/*.json): "bạn" is the pervasive address
+# (~265 occurrences: "Nhập mật khẩu của bạn", "Kiểm tra email của bạn", "Bí mật
+# của bạn đã được tạo an toàn", "Bạn có chắc chắn muốn xóa..."), and zero
+# kinship/intimate 2nd-person address pronouns appear as the generic UI "you".
+# The prose guide agrees (§"Hướng dẫn dịch thuật" #5, §"UI Element Conventions",
+# §"Key Points"): use "bạn" for neutral, respectful-but-friendly address;
+# imperatives drop the subject (the understood "bạn"). So the register is locked
+# to "bạn"; the FORBIDDEN register is the hierarchical/intimate kinship address.
+#
+# form: other — "bạn" is neutral-friendly and Vietnamese has no T/V axis, so
+# none of formal|informal|mixed fits; this mirrors the ja keigo precedent of
+# form:other + a register_spec extension. (One could argue "informal" since
+# "bạn" is warmer than "quý khách"; "other" is chosen because the real policy is
+# pronoun-class selection, not a T/V level — documented in register_spec.)
+#
+# forbidden_tokens — TOKENIZATION NOTE: Vietnamese IS space-delimited (syllables
+# separated by spaces), so the resolver's `standalone_word` mode (needle bounded
+# by non-word chars) segments correctly here, UNLIKE Japanese. Each token below
+# was verified with resolver.matching.find_spans(..., "standalone_word") against
+# every string value in the full live vi content to have ZERO false positives:
+#   chị, em, ông, bà, mày, tao, ngài, cậu, tớ  -> 0 standalone hits each.
+# DELIBERATELY LEFT OUT (would false-positive as standalone words, verified):
+#   - "anh"  : appears in "tiếng Anh" (the English language) — 2 standalone hits;
+#   - "cô"   : 0 live hits now, but it is a frequent syllable (cô lập, cô đọng)
+#              and too collision-prone to lock as a generic standalone token;
+#   - "chú"  : appears in "ghi chú" (note) / "chú ý" (attention) — 5 hits;
+#   - "bác"  : 0 live hits but is the syllable in "bác bỏ" (to reject) etc.
+# These intimate/kinship pronouns are still part of the forbidden register and
+# are recorded in register_spec.forbidden_pronouns (free-form, not lint-scanned)
+# so the policy is complete even though they cannot be safely auto-flagged.
+#
+# AGENT-AUTHORED; requires native-speaker (VI) sign-off — see PR label.
+form: other
+pronoun: bạn
+forbidden_tokens:
+  - { token: chị,  context: standalone_word, severity: error, note: "kinship 2nd-person (older female); not the neutral generic UI address — use bạn. Zero live hits." }
+  - { token: em,   context: standalone_word, severity: error, note: "kinship 2nd-person (younger person); intimate/hierarchical, not generic UI address — use bạn. Zero live hits." }
+  - { token: ông,  context: standalone_word, severity: error, note: "kinship 2nd-person (older male / sir); hierarchical, not generic UI address — use bạn. Zero standalone hits (note: the syllable in 'không' is NOT a standalone_word match)." }
+  - { token: bà,   context: standalone_word, severity: error, note: "kinship 2nd-person (older female / madam); hierarchical, not generic UI address — use bạn. Zero standalone hits." }
+  - { token: ngài, context: standalone_word, severity: error, note: "deferential 2nd-person (sir/lord); over-formal/hierarchical, not the neutral UI address — use bạn. Zero live hits." }
+  - { token: cậu,  context: standalone_word, severity: error, note: "intimate 2nd-person (peer/young male, casual); too familiar for UI — use bạn. Zero live hits." }
+  - { token: tớ,   context: standalone_word, severity: error, note: "intimate 1st/2nd-person (close-friend register); too familiar for UI — use bạn. Zero live hits." }
+  - { token: mày,  context: standalone_word, severity: error, note: "rude/intimate 2nd-person (disrespectful); never appropriate for UI — use bạn. Zero live hits." }
+  - { token: tao,  context: standalone_word, severity: error, note: "rude/intimate 1st-person paired with mày; never appropriate for UI. Zero live hits." }
+exceptions: []
+rule_ref: rule.register-lock
+# register_spec — the FREE-FORM extension where the full address policy lives,
+# including the kinship/intimate pronouns that cannot be safely tokenized
+# (anh/cô/chú/bác) but are still forbidden as the generic UI "you".
+register_spec:
+  system: kinship_pronoun
+  address_pronoun: bạn
+  description: >-
+    Vietnamese has no T/V split; 2nd-person address is a kinship-pronoun system.
+    Product UI is locked to the neutral, age/status-neutral "bạn" ("you"),
+    friendly-neutral. Imperatives drop the subject (understood "bạn"). "quý
+    khách" (deferential "valued customer") is acceptable in marketing/billing
+    prose per the prose guide but "bạn" is the default; both avoid the kinship
+    hierarchy.
+  forbidden_pronouns:
+    tokenized:    [chị, em, ông, bà, ngài, cậu, tớ, mày, tao]   # also in forbidden_tokens (zero false positives)
+    not_tokenized: [anh, cô, chú, bác]                           # forbidden as generic address but unsafe to substring/word-match (collide with tiếng Anh, ghi chú, cô lập, bác bỏ); enforced by this spec + rule.register-lock, not forbidden_tokens
+  notes: >-
+    Use "bạn" (or "quý khách" in customer-facing marketing/billing). Do NOT use
+    hierarchical/intimate kinship pronouns (anh/chị/em/ông/bà/cô/chú/bác/ngài)
+    or rude/intimate pronouns (mày/tao/tớ/cậu) as the generic 2nd-person UI
+    address. All tone marks and diacritics must be preserved.
+# baseline_ref: baselines.vi is intentionally omitted — no `baselines.vi` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
+# human reviewer adds the pin centrally to baselines.yaml at commit time
+# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
+# carry `baseline_ref: baselines.vi`.

--- a/locales/vi/register.yaml
+++ b/locales/vi/register.yaml
@@ -73,8 +73,4 @@ register_spec:
     hierarchical/intimate kinship pronouns (anh/chị/em/ông/bà/cô/chú/bác/ngài)
     or rude/intimate pronouns (mày/tao/tớ/cậu) as the generic 2nd-person UI
     address. All tone marks and diacritics must be preserved.
-# baseline_ref: baselines.vi is intentionally omitted — no `baselines.vi` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. A
-# human reviewer adds the pin centrally to baselines.yaml at commit time
-# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
-# carry `baseline_ref: baselines.vi`.
+baseline_ref: baselines.vi

--- a/locales/vi/rules.yaml
+++ b/locales/vi/rules.yaml
@@ -1,0 +1,52 @@
+id: rules.vi
+source: onetimesecret/locales/guides/for-translators/vi.md
+inherits: base
+merge_strategy: append
+# Vietnamese locale layer, inheriting base directly (standalone language, no
+# regional parent). Carries the Vietnamese-wide conventions transcribed from the
+# translator guide (onetimesecret/locales/guides/for-translators/vi.md) and
+# grounded in the live app content (onetimesecret/locales/content/vi/*.json):
+# the "bạn" neutral-address register lock, the "cụm mật khẩu" (passphrase) vs
+# "mật khẩu" (password) distinction, the "bí mật" terminology, the
+# burn -> "xóa vĩnh viễn" choice, and the mandatory tone/diacritic preservation.
+#
+# Rule-item ids are BARE dotted (no #hex). Every rule_ref points at an existing
+# base rule id.
+#
+# AGENT-AUTHORED transcription; requires native-speaker (VI) sign-off — see PR
+# label.
+rules:
+  - id: rule.vi-register-ban
+    modality: MUST
+    statement: "Vietnamese content addresses the user with the neutral, age/status-neutral 2nd-person pronoun `bạn` (friendly-neutral 'you') throughout product UI and email content; imperatives drop the subject (the understood `bạn`). Vietnamese has no T/V split, so the lock is a pronoun-class choice, not a formality level. The hierarchical/intimate kinship pronouns (`anh`/`chị`/`em`/`ông`/`bà`/`cô`/`chú`/`bác`/`ngài`) and rude/intimate pronouns (`mày`/`tao`/`tớ`/`cậu`) are forbidden as the generic UI address. `quý khách` (deferential 'valued customer') is acceptable in customer-facing marketing/billing prose."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.vi-passphrase-password
+    modality: MUST
+    statement: "Keep `mật khẩu` (account login / authentication credential) distinct from `cụm mật khẩu` (the credential protecting an individual secret; `cụm` = phrase/cluster); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.vi-secret-bi-mat
+    modality: MUST
+    statement: "Render the product concept 'secret' (the protected entity) as `bí mật`. Use `an toàn` for the 'secure' state/adjective and `mã hóa` / `đã mã hóa` for encrypt/encrypted; do not conflate these senses."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.vi-burn-xoa-vinh-vien
+    modality: MUST
+    statement: "Render 'burn' (permanently delete a secret before it is viewed) as `xóa vĩnh viễn` (delete permanently), the natural digital-Vietnamese phrasing, not a literal 'đốt' (set on fire)."
+    severity: warning
+    rule_ref: rule.terminology-consistency
+  - id: rule.vi-diacritics-tones
+    modality: MUST
+    statement: "Preserve all Vietnamese tone marks and diacritics (vowel modifications ă â ê ô ơ ư and the six tones). They are essential to meaning (e.g. ma/má/mà/mả/mã/mạ); never substitute unaccented Latin letters. Maintain syllable spacing — compounds are written with spaces (mã hóa, bảo mật, tài khoản), never joined like German compounds."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.vi-message-voice
+    modality: SHOULD
+    statement: "Use subject-less imperatives for actions/buttons (Nhập…, Chia sẻ…, Sao chép…, Xác nhận…) and the past-tense marker `đã` for completed-state status messages (đã tạo, đã xem, đã xóa vĩnh viễn, đã hết hạn). Keep a professional but direct, friendly tone."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.vi
+glossary_ref: glossary.vi
+# baseline_ref: baselines.vi intentionally omitted (no baselines.vi entry yet);
+# a reviewer adds the pin centrally — see note in register.yaml.

--- a/locales/vi/rules.yaml
+++ b/locales/vi/rules.yaml
@@ -48,5 +48,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.vi
 glossary_ref: glossary.vi
-# a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.vi

--- a/locales/vi/rules.yaml
+++ b/locales/vi/rules.yaml
@@ -48,5 +48,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.vi
 glossary_ref: glossary.vi
-# baseline_ref: baselines.vi intentionally omitted (no baselines.vi entry yet);
 # a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.vi

--- a/locales/zh/glossary.yaml
+++ b/locales/zh/glossary.yaml
@@ -1,0 +1,240 @@
+id: glossary.zh
+source: onetimesecret/locales/guides/for-translators/zh.md
+# Sense-split of the core domain terminology from the Simplified Chinese
+# translator guide's terminology tables (onetimesecret/locales/guides/for-
+# translators/zh.md §Standard Terminology Reference, §Core Translation
+# Principles), grounded against the live app content in
+# onetimesecret/locales/content/zh/*.json. Targets and worked examples are
+# AGENT-AUTHORED and require native-speaker (ZH) sign-off before merge — see PR
+# label.
+#
+# CJK TOKENIZATION NOTE (ja pilot lesson): SPEC §2.3 lint check 2 requires every
+# `good` example's target to contain a sense target in `word_prefix` mode. With
+# no spaces in Chinese, "word boundary" = start-of-string or a non-word char
+# (Chinese punctuation 。，、 / ASCII space / interpolation %{} braces) — a Han
+# left-neighbour is a word char and blocks the match. So each `good` example
+# below places its sense target in HEAD position (or right after punctuation),
+# e.g. 内容已被截断 rather than 您的内容已被截断. Each `good` example uses the polite
+# 您 register and is verified clean against register.zh forbidden_tokens (no 你);
+# each `bad` example demonstrates a forbidden form (informal 你 register, the
+# banned 秘密 term, or the wrong term).
+terms:
+  - id: term.secret_object#c0902808
+    key: secret_object
+    en: secret
+    disambiguation:
+      heuristic: "The protected entity itself (the noun) — created, shared, burned, viewed, or expired. The central concept of the application. Three-tier by context: 内容 (UI/functional — buttons, labels, status, API), 机密内容 (descriptive/docs), 机密信息 (marketing). NEVER 秘密."
+      key_patterns: ["*secret*", "*.burn*", "*.share*", "*.reveal*"]
+    zh:
+      ui:
+        target: 内容
+        rule_ref: rule.zh-secret-no-mimi
+      docs:
+        target: 机密内容
+        rule_ref: rule.zh-secret-no-mimi
+      marketing:
+        target: 机密信息
+        rule_ref: rule.zh-secret-no-mimi
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-created-good#0492a4bc
+        source: "Your content has been truncated."
+        target: "内容已被截断。"
+        verdict: good
+        note: "Verbatim from live content (内容已被截断); UI tier 内容 in head position; declarative status voice. (No 您 needed — status string with no direct address; clean against forbidden 你.)"
+        rule_refs: [rule.register-lock, rule.zh-secret-no-mimi]
+      - id: ex.secret-mimi-bad#8ae96971
+        source: "Your secret has been created."
+        target: "你的秘密已创建。"
+        verdict: bad
+        note: "Uses banned 秘密 instead of the tiered 内容/机密内容/机密信息 AND informal 你的 (forbidden register) — violates both rule.zh-secret-no-mimi and rule.zh-register-formal."
+  - id: term.secret_adjective#a3a1d7c9
+    key: secret_adjective
+    en: secure
+    disambiguation:
+      heuristic: "The adjective/state sense of secret/secure — protection of information. Render as 加密的 (encrypted) or 安全的 (secure); reserve the tiered 内容/机密内容/机密信息 for the product-noun sense."
+      key_patterns: ["*secure*", "*secured*", "*.protect*"]
+    zh:
+      adjective:
+        target: 加密的
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.secret-adjective-good#d1b19ed2
+        source: "The encrypted message is protected; your privacy is safe."
+        target: "加密的信息受到保护，您的隐私是安全的。"
+        verdict: good
+        note: "Adjective sense 加密的 in head position; polite 您的; declarative voice."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.secret-adjective-bad#0ad15f16
+        source: "The encrypted message is protected; your privacy is safe."
+        target: "你的机密信息受到保护。"
+        verdict: bad
+        note: "Uses the marketing product-noun tier 机密信息 for the general adjective sense where 加密的 is meant (terminology drift) AND informal 你的 (forbidden register)."
+  - id: term.secret_link#6d74a4a6
+    key: secret_link
+    en: secret link
+    disambiguation:
+      heuristic: "The product feature: a one-time-access URL. Render as 一次性链接 (one-time link) to emphasize single-use, NEVER 秘密链接. Plain 'link' (the bare URL) is the separate term 链接."
+      key_patterns: ["*secretLink*", "*.share*", "*.url*"]
+    zh:
+      noun:
+        target: 一次性链接
+        rule_ref: rule.zh-secret-link
+    rule_refs: [rule.register-lock, rule.zh-secret-link]
+    examples:
+      - id: ex.secret-link-good#48e437df
+        source: "A one-time link can only be used once, then disappears forever."
+        target: "一次性链接只能使用一次，然后永久消失。"
+        verdict: good
+        note: "Verbatim from live content; feature term 一次性链接 in head position. (Status/description, no direct address; clean against forbidden 你.)"
+        rule_refs: [rule.register-lock, rule.zh-secret-link]
+      - id: ex.secret-link-bad#ce81861f
+        source: "Share your one-time link."
+        target: "分享你的秘密链接。"
+        verdict: bad
+        note: "Uses 秘密链接 instead of 一次性链接 (violates rule.zh-secret-link, also leans on the banned 秘密) AND informal 你的 (forbidden register)."
+  - id: term.passphrase#44591635
+    key: passphrase
+    en: passphrase
+    disambiguation:
+      heuristic: "The credential that protects an individual piece of content (distinct from the account login password). Compose/protect-content contexts signal this sense. Render as 口令."
+      key_patterns: ["*passphrase*", "*.protect*"]
+    zh:
+      noun:
+        target: 口令
+        rule_ref: rule.zh-passphrase-password
+    rule_refs: [rule.register-lock, rule.zh-passphrase-password]
+    examples:
+      - id: ex.passphrase-good#c9b8d63f
+        source: "Please check your passphrase."
+        target: "口令有误，请检查您的口令。"
+        verdict: good
+        note: "Grounded in live content (请检查您的口令); 口令 (content protection), not 密码, in head position; polite 您的."
+        rule_refs: [rule.register-lock, rule.zh-passphrase-password]
+      - id: ex.passphrase-bad#b2e929e0
+        source: "Enter the passphrase to view this content."
+        target: "输入你的密码以查看此内容。"
+        verdict: bad
+        note: "Uses 密码 (account credential) where 口令 (content protection) is meant (violates rule.zh-passphrase-password) AND informal 你的 (forbidden register)."
+  - id: term.password#3e4e76cc
+    key: password
+    en: password
+    disambiguation:
+      heuristic: "The account / login authentication credential (distinct from a content's passphrase). Sign-in, account, and reset contexts signal this sense. Render as 密码."
+      key_patterns: ["*password*", "*.login*", "*.signin*", "*.auth*"]
+    zh:
+      noun:
+        target: 密码
+        rule_ref: rule.zh-passphrase-password
+    rule_refs: [rule.register-lock, rule.zh-passphrase-password]
+    examples:
+      - id: ex.password-good#ed4d76e5
+        source: "Enter your password to confirm."
+        target: "密码更改后，请使用您的新密码登录。"
+        verdict: good
+        note: "Grounded in live content (您的密码已成功更改); account term 密码 in head position; polite 您的."
+        rule_refs: [rule.register-lock, rule.zh-passphrase-password]
+      - id: ex.password-bad#83a8f72f
+        source: "Enter your password to sign in."
+        target: "输入你的口令以登录。"
+        verdict: bad
+        note: "Uses 口令 (content protection) where 密码 (account credential) is meant (violates rule.zh-passphrase-password) AND informal 你的 (forbidden register)."
+  - id: term.burn#8a886c8d
+    key: burn
+    en: burn
+    disambiguation:
+      heuristic: "The action of deleting content before it is viewed. Rendered as 销毁 (action, emphasizing permanence), 已销毁 for the resulting state. Not a literal 燃烧."
+      key_patterns: ["*burn*", "*.destroy*"]
+    zh:
+      action:
+        target: 销毁
+        rule_ref: rule.zh-burn-xiaohui
+      state:
+        target: 已销毁
+        rule_ref: rule.zh-burn-xiaohui
+    rule_refs: [rule.register-lock, rule.zh-burn-xiaohui]
+    examples:
+      - id: ex.burn-good#4bf35a91
+        source: "Burning this content deletes it before viewing."
+        target: "销毁内容将在查看前将其删除，您将无法恢复。"
+        verdict: good
+        note: "Grounded in live content (销毁内容将在查看前将其删除); action term 销毁 in head position; polite 您将."
+        rule_refs: [rule.register-lock, rule.zh-burn-xiaohui]
+      - id: ex.burn-bad#4228df6b
+        source: "A burned secret cannot be recovered."
+        target: "你燃烧的秘密无法恢复。"
+        verdict: bad
+        note: "Uses literal 燃烧 instead of 销毁 (terminology drift, rule.zh-burn-xiaohui), banned 秘密, AND informal 你 (forbidden register)."
+  - id: term.link#b48578dd
+    key: link
+    en: link
+    disambiguation:
+      heuristic: "The bare URL that provides access to content. Rendered as 链接. (The product feature 'secret link' is the separate term 一次性链接.)"
+      key_patterns: ["*link*", "*.url*", "*.share*"]
+    zh:
+      noun:
+        target: 链接
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.link-good#77be696f
+        source: "The link has been created and not yet viewed."
+        target: "链接已创建，尚未被查看。"
+        verdict: good
+        note: "Verbatim from live content; term 链接 in head position; declarative status voice. (No direct address; clean against forbidden 你.)"
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.link-bad#748809c5
+        source: "A secure link will be sent to your email."
+        target: "安全链接将发送到你的邮箱。"
+        verdict: bad
+        note: "Informal 你的 (forbidden register) — should be the polite 您的 (live content: 安全链接将发送到您的邮箱。). Term 链接 is correct, register is not."
+  - id: term.encrypt#a4d3564b
+    key: encrypt
+    en: encrypt
+    disambiguation:
+      heuristic: "The security method of encrypting data; 加密 for the verb/action, 已加密 for the encrypted state."
+      key_patterns: ["*encrypt*", "*.cipher*"]
+    zh:
+      action:
+        target: 加密
+        rule_ref: rule.terminology-consistency
+      state:
+        target: 已加密
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.encrypt-good#791f7805
+        source: "This message is encrypted with your passphrase."
+        target: "加密保护此消息时，使用了您的口令。"
+        verdict: good
+        note: "Grounded in live 此消息已使用您的口令加密。; action 加密 in head position; polite 您的; 口令 (not 密码)."
+        rule_refs: [rule.register-lock, rule.terminology-consistency, rule.zh-passphrase-password]
+      - id: ex.encrypt-bad#450020c5
+        source: "This message is encrypted with your passphrase."
+        target: "此消息已使用你的密码加密。"
+        verdict: bad
+        note: "Informal 你的 (forbidden register) AND 密码 (account credential) where 口令 is meant — violates rule.zh-register-formal and rule.zh-passphrase-password."
+  - id: term.email#8c4fb076
+    key: email
+    en: email
+    disambiguation:
+      heuristic: "The user's email address / electronic mail. Account identifier and notification contexts. Rendered as 邮箱 (or 电子邮件); 邮箱地址 for the address."
+      key_patterns: ["*email*", "*.mail*", "*.notification*"]
+    zh:
+      noun:
+        target: 邮箱
+        rule_ref: rule.terminology-consistency
+    rule_refs: [rule.register-lock, rule.terminology-consistency]
+    examples:
+      - id: ex.email-good#9138348f
+        source: "Enter your email address below."
+        target: "邮箱地址请填写在下方，我们将向您发送验证链接。"
+        verdict: good
+        note: "Grounded in live 在下方输入您的邮箱地址…; term 邮箱 in head position (word_prefix of 邮箱地址); polite 您."
+        rule_refs: [rule.register-lock, rule.terminology-consistency]
+      - id: ex.email-bad#5c29e476
+        source: "Enter your email address."
+        target: "请输入你的邮箱地址。"
+        verdict: bad
+        note: "Informal 你的 (forbidden register) — should be the polite 您的 (live content: 您的邮箱地址). Term 邮箱 is correct, register is not."

--- a/locales/zh/register.yaml
+++ b/locales/zh/register.yaml
@@ -56,8 +56,4 @@ register_spec:
     binary formal lock unambiguous. The guide's UI voice (imperative buttons,
     declarative status, no exclamation marks) is the prescribed style, not a
     register violation.
-# baseline_ref: baselines.zh is intentionally omitted — no `baselines.zh` entry
-# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
-# pin is for a human reviewer to add to baselines.yaml centrally at commit time
-# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
-# carry `baseline_ref: baselines.zh`.
+baseline_ref: baselines.zh

--- a/locales/zh/register.yaml
+++ b/locales/zh/register.yaml
@@ -1,0 +1,63 @@
+id: register.zh
+source: onetimesecret/locales/guides/for-translators/zh.md
+# Simplified Chinese is locked to the FORMAL/polite second-person register: 您
+# (polite "you") and its possessive 您的, never the neutral/informal 你 / 你的.
+# Chinese DOES have a politeness pronoun distinction (您 polite vs 你 neutral),
+# unlike Japanese keigo — so this is modelled as a true binary register lock
+# (form: formal), not the ja register_spec-only shape.
+#
+# Grounded in the live app content (onetimesecret/locales/content/zh/*.json):
+# direct address is overwhelmingly the polite 您 — 398 occurrences across 19
+# files (e.g. "您的密码已成功更改", "请检查您的口令", "安全链接将发送到您的邮箱。",
+# "此消息已使用您的口令加密。") with the possessive 您的 alone appearing 236 times.
+# The informal 你 has ZERO occurrences anywhere in the live content (and 你们 /
+# 您们 are likewise absent). So the FORBIDDEN register is the informal 你 form.
+#
+# TOKENIZATION NOTE (CJK, per the ja pilot's lesson): Chinese has no spaces, so
+# `standalone_word` / `word_prefix` word boundaries (which key off alnum chars —
+# and CJK characters ARE alnum to Python's str.isalnum) do NOT segment Chinese;
+# every Han character is a "word char". The casual marker 你 must therefore be
+# matched as `substring`. This is SAFE here: 你 was verified to have ZERO
+# occurrences of any kind in the full live zh content (it is not a substring of
+# any character actually used — 您, 其他, 他, 她 etc. do not contain 你), so the
+# substring match carries no false-positive risk. (Contrast 您, which IS a real
+# substring of valid possessives like 您的 / 您们 and so must NOT be forbidden.)
+# Every `good` glossary example uses 您 and is verified clean against this token.
+#
+# AGENT-AUTHORED; requires native-speaker (ZH) sign-off — see PR label.
+form: formal
+pronoun: 您
+possessive: [您的]
+forbidden_tokens:
+  - { token: 你, context: substring, severity: error, note: "informal/neutral 2nd-person pronoun; the app uses the polite 您 exclusively (zero 你 in live content). substring is safe — 你 has zero occurrences of any kind in live zh content (no false positives)." }
+exceptions: []
+rule_ref: rule.zh-register-formal
+# register_spec — documents the 您/你 politeness policy (free-form extension).
+# The lock IS expressible as a binary form: formal / forbidden_tokens above; this
+# block records the policy prose and the deliberately-not-forbidden tokens so a
+# reviewer can see the reasoning, mirroring the ja pilot's register_spec.
+register_spec:
+  system: politeness_pronoun
+  level: polite
+  description: "Formal/polite address: 您 (and possessive 您的) throughout product UI and email content. The neutral/informal 你 is forbidden for direct address."
+  target_forms:
+    pronoun: [您]
+    possessive: [您的]
+  forbidden_forms:
+    informal_pronoun: [你, 你的]   # 你 is also tokenized above (zero false positives in live content)
+  not_forbidden:
+    polite_substring: "您 is NOT forbidden — it is the affirmed register and is also a substring of valid possessives (您的, 236 live hits)."
+  voice_by_context:
+    buttons_and_actions: "Imperative/direct verb form (例: 保存更改, 删除文件, 发送消息) — concise label form."
+    status_and_notifications: "Passive/declarative (例: 已保存更改, 已销毁, 已复制) — no exclamation marks."
+    explanatory_text: "Polite 您-address, professional yet concise."
+  notes: >-
+    Live content uses 您 exclusively (398 hits) and 你 never (0 hits), making the
+    binary formal lock unambiguous. The guide's UI voice (imperative buttons,
+    declarative status, no exclamation marks) is the prescribed style, not a
+    register violation.
+# baseline_ref: baselines.zh is intentionally omitted — no `baselines.zh` entry
+# exists in baselines.yaml yet, and a dangling reference fails the resolver. The
+# pin is for a human reviewer to add to baselines.yaml centrally at commit time
+# (mirroring the fr / de_AT baselines entries); this and rules.yaml can then
+# carry `baseline_ref: baselines.zh`.

--- a/locales/zh/rules.yaml
+++ b/locales/zh/rules.yaml
@@ -46,5 +46,5 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.zh
 glossary_ref: glossary.zh
-# baseline_ref: baselines.zh intentionally omitted (no baselines.zh entry yet);
 # a reviewer adds the pin centrally — see note in register.yaml.
+baseline_ref: baselines.zh

--- a/locales/zh/rules.yaml
+++ b/locales/zh/rules.yaml
@@ -46,5 +46,4 @@ rules:
     rule_ref: rule.message-voice
 register_ref: register.zh
 glossary_ref: glossary.zh
-# a reviewer adds the pin centrally — see note in register.yaml.
 baseline_ref: baselines.zh

--- a/locales/zh/rules.yaml
+++ b/locales/zh/rules.yaml
@@ -1,0 +1,50 @@
+id: rules.zh
+source: onetimesecret/locales/guides/for-translators/zh.md
+inherits: base
+merge_strategy: append
+# Simplified Chinese locale layer, inheriting base directly (standalone language,
+# no regional parent). Carries the Chinese-wide conventions transcribed from the
+# translator guide (onetimesecret/locales/guides/for-translators/zh.md, richer
+# than zh-cn.md): the polite 您 register lock, the banned-秘密 three-tier
+# terminology system (内容 UI / 机密内容 docs / 机密信息 marketing), the 口令
+# (passphrase) vs 密码 (password) distinction, the burn -> 销毁 choice, the
+# secret-link -> 一次性链接 (not 秘密链接) choice, and the no-exclamation-mark
+# punctuation rule.
+#
+# AGENT-AUTHORED transcription of the prose guide, grounded in live zh content;
+# requires native-speaker (ZH) sign-off before merge — see PR label.
+rules:
+  - id: rule.zh-register-formal
+    modality: MUST
+    statement: "Chinese content uses the polite/formal 您 register (您 / 您的) for direct address throughout product UI and email content; the neutral/informal 你 (你 / 你的) is forbidden. Live content uses 您 exclusively (398 hits) and 你 never (0 hits)."
+    severity: error
+    rule_ref: rule.register-lock
+  - id: rule.zh-secret-no-mimi
+    modality: MUST
+    statement: "Never render the product concept 'secret' as 秘密 (which carries personal/emotional connotations of something deliberately concealed). Use the three-tier system by context: 内容 (UI / buttons / labels / status / API), 机密内容 (FAQ / help / explanatory docs), 机密信息 (marketing / pricing / landing copy)."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.zh-secret-link
+    modality: MUST
+    statement: "Translate the product feature 'secret link' as 一次性链接 (one-time link), never 秘密链接; this emphasizes the core single-use characteristic. Plain 'link' (the URL) is 链接."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.zh-passphrase-password
+    modality: MUST
+    statement: "Keep 密码 (account login / authentication credential) distinct from 口令 (the credential that protects an individual piece of content); never use one where the other is meant."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.zh-burn-xiaohui
+    modality: MUST
+    statement: "Translate burn / burned consistently as 销毁 (action) and 已销毁 (state), per the agreed Chinese terminology (emphasizing permanence); do not vary across strings or use a literal 燃烧."
+    severity: error
+    rule_ref: rule.terminology-consistency
+  - id: rule.zh-punctuation-no-exclamation
+    modality: SHOULD
+    statement: "Avoid exclamation marks (！ / !) except in quoted source material; maintain a professional, calm tone. Use declarative status forms (已复制, not 已复制！). No semicolons or abbreviations."
+    severity: warning
+    rule_ref: rule.message-voice
+register_ref: register.zh
+glossary_ref: glossary.zh
+# baseline_ref: baselines.zh intentionally omitted (no baselines.zh entry yet);
+# a reviewer adds the pin centrally — see note in register.yaml.

--- a/resolver/index.json
+++ b/resolver/index.json
@@ -51,10 +51,878 @@
     },
     {
       "file": "baselines.yaml",
+      "id": "baselines.ar",
+      "json_pointer": "/baselines/ar",
+      "key": "ar",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.bg",
+      "json_pointer": "/baselines/bg",
+      "key": "bg",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.ca_ES",
+      "json_pointer": "/baselines/ca_ES",
+      "key": "ca_ES",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.cs",
+      "json_pointer": "/baselines/cs",
+      "key": "cs",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.da_DK",
+      "json_pointer": "/baselines/da_DK",
+      "key": "da_DK",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.de",
+      "json_pointer": "/baselines/de",
+      "key": "de",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
       "id": "baselines.de_AT",
       "json_pointer": "/baselines/de_AT",
       "key": "de_AT",
       "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.el_GR",
+      "json_pointer": "/baselines/el_GR",
+      "key": "el_GR",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.eo",
+      "json_pointer": "/baselines/eo",
+      "key": "eo",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.es",
+      "json_pointer": "/baselines/es",
+      "key": "es",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.fr",
+      "json_pointer": "/baselines/fr",
+      "key": "fr",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.fr_CA",
+      "json_pointer": "/baselines/fr_CA",
+      "key": "fr_CA",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.fr_FR",
+      "json_pointer": "/baselines/fr_FR",
+      "key": "fr_FR",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.he",
+      "json_pointer": "/baselines/he",
+      "key": "he",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.hu",
+      "json_pointer": "/baselines/hu",
+      "key": "hu",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.it_IT",
+      "json_pointer": "/baselines/it_IT",
+      "key": "it_IT",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.ja",
+      "json_pointer": "/baselines/ja",
+      "key": "ja",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.ko",
+      "json_pointer": "/baselines/ko",
+      "key": "ko",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.mi_NZ",
+      "json_pointer": "/baselines/mi_NZ",
+      "key": "mi_NZ",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.nl",
+      "json_pointer": "/baselines/nl",
+      "key": "nl",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.pl",
+      "json_pointer": "/baselines/pl",
+      "key": "pl",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.pt",
+      "json_pointer": "/baselines/pt",
+      "key": "pt",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.pt_BR",
+      "json_pointer": "/baselines/pt_BR",
+      "key": "pt_BR",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.pt_PT",
+      "json_pointer": "/baselines/pt_PT",
+      "key": "pt_PT",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.ru",
+      "json_pointer": "/baselines/ru",
+      "key": "ru",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.sl_SI",
+      "json_pointer": "/baselines/sl_SI",
+      "key": "sl_SI",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.sv_SE",
+      "json_pointer": "/baselines/sv_SE",
+      "key": "sv_SE",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.tr",
+      "json_pointer": "/baselines/tr",
+      "key": "tr",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.uk",
+      "json_pointer": "/baselines/uk",
+      "key": "uk",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.vi",
+      "json_pointer": "/baselines/vi",
+      "key": "vi",
+      "kind": "baselines"
+    },
+    {
+      "file": "baselines.yaml",
+      "id": "baselines.zh",
+      "json_pointer": "/baselines/zh",
+      "key": "zh",
+      "kind": "baselines"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "ex.account-bad#e35ea31d",
+      "json_pointer": "/terms/8/examples/1/id",
+      "key": "account-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "ex.account-good#943273f4",
+      "json_pointer": "/terms/8/examples/0/id",
+      "key": "account-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-burn-bad#9c05c3f5",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "bg-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-burn-good#ea986f21",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "bg-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-email-bad#6b702dc7",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "bg-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-email-good#e42808a9",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "bg-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-encrypt-bad#57e988e1",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "bg-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-encrypt-good#d508bd58",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "bg-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-link-bad#2757d4ea",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "bg-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-link-good#1ef8fbbd",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "bg-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-passphrase-bad#cc9cda26",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "bg-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-passphrase-good#55aacc0b",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "bg-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-password-bad#cdaff119",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "bg-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-password-good#8b52a40e",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "bg-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-secret-created-good#c6051398",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "bg-secret-created-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-secret-informal-bad#bd906d47",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "bg-secret-informal-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-view-bad#ec589de3",
+      "json_pointer": "/terms/7/examples/1/id",
+      "key": "bg-view-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "ex.bg-view-good#3c1c5e01",
+      "json_pointer": "/terms/7/examples/0/id",
+      "key": "bg-view-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.burn-ar-bad#32a14a8e",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "burn-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.burn-ar-good#e7a88b0a",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "burn-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.burn-bad#4228df6b",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.burn-eo-bad#15b49cf4",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "burn-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.burn-eo-good#089f5752",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "burn-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.burn-good#4bf35a91",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-burn-bad#2c40cacc",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "cs-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-burn-good#f26982cb",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "cs-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-email-bad#b3bdd885",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "cs-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-email-good#8107ddbe",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "cs-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-encrypt-bad#1cd2cd00",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "cs-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-encrypt-good#432c330c",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "cs-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-link-bad#e5456c40",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "cs-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-link-good#05120873",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "cs-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-passphrase-bad#5a0d845f",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "cs-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-passphrase-good#b85c7e37",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "cs-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-password-bad#22813f4b",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "cs-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-password-good#cf3d9571",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "cs-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-secret-bad#b2dacf1e",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "cs-secret-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "ex.cs-secret-good#8934f759",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "cs-secret-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-account-bad#ce635187",
+      "json_pointer": "/terms/9/examples/1/id",
+      "key": "da-account-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-account-good#62139390",
+      "json_pointer": "/terms/9/examples/0/id",
+      "key": "da-account-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-burn-bad#58783aa9",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "da-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-burn-good#c7a6deb6",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "da-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-email-bad#77a68ca7",
+      "json_pointer": "/terms/7/examples/1/id",
+      "key": "da-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-email-good#0172a3eb",
+      "json_pointer": "/terms/7/examples/0/id",
+      "key": "da-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-encrypt-bad#13a754db",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "da-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-encrypt-good#c301792d",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "da-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-link-bad#2406b826",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "da-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-link-good#8b060627",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "da-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-passphrase-bad#8fe56e31",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "da-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-passphrase-good#334a5d30",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "da-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-password-bad#79fc26f9",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "da-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-password-good#5e33fc2b",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "da-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secret-adj-bad#5cd4b493",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "da-secret-adj-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secret-adj-good#adfffec4",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "da-secret-adj-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secret-besked-good#c88621fd",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "da-secret-besked-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secret-hemmelighed-bad#15bc854c",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "da-secret-hemmelighed-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secure-bad#e89c8df6",
+      "json_pointer": "/terms/8/examples/1/id",
+      "key": "da-secure-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "ex.da-secure-good#aae1ab1e",
+      "json_pointer": "/terms/8/examples/0/id",
+      "key": "da-secure-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-burn-bad#8809bfb6",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "el-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-burn-good#d1ccd8e5",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "el-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-email-bad#d9ad35fe",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "el-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-email-good#140a569e",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "el-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-encrypt-bad#8de90e86",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "el-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-encrypt-good#007c98bc",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "el-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-link-bad#0c6efdb8",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "el-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-link-good#7826a9ed",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "el-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-passphrase-bad#41b2bf7d",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "el-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-passphrase-good#85ccc80c",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "el-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-password-bad#af9d3f0e",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "el-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-password-good#7767d48d",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "el-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-secret-bad#f9b09970",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "el-secret-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "ex.el-secret-good#7e44f10e",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "el-secret-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.email-ar-bad#502767b7",
+      "json_pointer": "/terms/7/examples/1/id",
+      "key": "email-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.email-ar-good#a223699d",
+      "json_pointer": "/terms/7/examples/0/id",
+      "key": "email-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.email-bad#5c29e476",
+      "json_pointer": "/terms/8/examples/1/id",
+      "key": "email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/fr_CA/glossary.yaml",
+      "id": "ex.email-ca-bad#b8f4c2e2",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "email-ca-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/fr_CA/glossary.yaml",
+      "id": "ex.email-ca-good#75bba47a",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "email-ca-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.email-eo-bad#f14d7622",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "email-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.email-eo-good#f833f9a1",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "email-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.email-good#9138348f",
+      "json_pointer": "/terms/8/examples/0/id",
+      "key": "email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.encrypt-ar-bad#733c7a4c",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "encrypt-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.encrypt-ar-good#809cd2fe",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "encrypt-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.encrypt-bad#450020c5",
+      "json_pointer": "/terms/7/examples/1/id",
+      "key": "encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.encrypt-eo-bad#4c030a54",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "encrypt-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.encrypt-eo-good#3b2e4546",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "encrypt-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.encrypt-good#791f7805",
+      "json_pointer": "/terms/7/examples/0/id",
+      "key": "encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.encrypt-pt-bad#3739406f",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "encrypt-pt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.encrypt-pt-good#ef5eaa94",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "encrypt-pt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.link-ar-bad#e924b748",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "link-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.link-ar-good#039b97e8",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "link-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.link-bad#748809c5",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.link-eo-bad#d7e18628",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "link-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.link-eo-good#6d172607",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "link-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.link-good#77be696f",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "link-good",
+      "kind": "ex"
     },
     {
       "file": "locales/de_AT/glossary.yaml",
@@ -71,10 +939,346 @@
       "kind": "ex"
     },
     {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.passphrase-ar-bad#d2a8ac1a",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "passphrase-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.passphrase-ar-good#d05796a6",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "passphrase-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.passphrase-bad#b2e929e0",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.passphrase-eo-bad#77a18aea",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "passphrase-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.passphrase-eo-good#5de3e893",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "passphrase-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.passphrase-good#c9b8d63f",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.password-ar-bad#8bb34a0b",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "password-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.password-ar-good#a2b33525",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "password-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.password-bad#83a8f72f",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.password-eo-bad#173fed0d",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "password-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.password-eo-good#251da90f",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "password-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.password-good#ed4d76e5",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.password-pt-bad#07c9b67f",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "password-pt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.password-pt-good#1d706f6e",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "password-pt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/de/glossary.yaml",
+      "id": "ex.payload-bad#cb733e1d",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "payload-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/de/glossary.yaml",
+      "id": "ex.payload-good#b71c6282",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "payload-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-burn-bad#781d4f89",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "ru-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-burn-good#5d56c53f",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "ru-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-email-bad#7231f692",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "ru-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-email-good#83ba8072",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "ru-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-encrypt-bad#af1753f8",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "ru-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-encrypt-good#218e9a77",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "ru-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-link-bad#4cc26fc6",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "ru-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-link-good#f5170486",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "ru-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-passphrase-bad#cbb5b0f4",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "ru-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-passphrase-good#72bc3670",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "ru-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-password-bad#f638c4fb",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "ru-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-password-good#666f89a8",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "ru-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-secret-bad#bd4ed190",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "ru-secret-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "ex.ru-secret-good#cfa43bd9",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "ru-secret-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.secret-adj-ar-bad#a3b42fcc",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "secret-adj-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.secret-adj-ar-good#79cfea86",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "secret-adj-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/mi_NZ/glossary.yaml",
+      "id": "ex.secret-adj-bad#ccab3c56",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "secret-adj-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/mi_NZ/glossary.yaml",
+      "id": "ex.secret-adj-good#10b14bad",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "secret-adj-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-adjective-bad#0ad15f16",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "secret-adjective-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/nl/glossary.yaml",
+      "id": "ex.secret-adjective-bad#9e2f01b7",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "secret-adjective-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/nl/glossary.yaml",
+      "id": "ex.secret-adjective-good#7c1d5a40",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "secret-adjective-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-adjective-good#d1b19ed2",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "secret-adjective-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.secret-ar-bad#15c07d9e",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-ar-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "ex.secret-ar-good#8b8e9f9a",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "secret-ar-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/mi_NZ/glossary.yaml",
+      "id": "ex.secret-bad#36c87b0a",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ja/glossary.yaml",
+      "id": "ex.secret-casual-bad#297307d4",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-casual-bad",
+      "kind": "ex"
+    },
+    {
       "file": "locales/de_AT/glossary.yaml",
       "id": "ex.secret-created#e4355c4f",
       "json_pointer": "/terms/0/examples/0/id",
       "key": "secret-created",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "ex.secret-created-bad#93b6aa32",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-created-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-created-good#0492a4bc",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "secret-created-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.secret-eo-bad#eba80e66",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-eo-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "ex.secret-eo-good#c24bc788",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "secret-eo-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pl/glossary.yaml",
+      "id": "ex.secret-formal-bad#c6306bcd",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-formal-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/nl/glossary.yaml",
+      "id": "ex.secret-geheim-bad#250567fe",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-geheim-bad",
       "kind": "ex"
     },
     {
@@ -85,6 +1289,13 @@
       "kind": "ex"
     },
     {
+      "file": "locales/mi_NZ/glossary.yaml",
+      "id": "ex.secret-good#d81de1d4",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "secret-good",
+      "kind": "ex"
+    },
+    {
       "file": "locales/de_AT/glossary.yaml",
       "id": "ex.secret-informal#40c23f2d",
       "json_pointer": "/terms/0/examples/2/id",
@@ -92,11 +1303,522 @@
       "kind": "ex"
     },
     {
+      "file": "locales/sl_SI/glossary.yaml",
+      "id": "ex.secret-informal-bad#250567fe",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-informal-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-link-bad#ce81861f",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "secret-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-link-good#48e437df",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "secret-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "ex.secret-mimi-bad#8ae96971",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-mimi-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/tr/glossary.yaml",
+      "id": "ex.secret-sir-bad#250567fe",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "secret-sir-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "ex.secure-bad#fc1e2db0",
+      "json_pointer": "/terms/9/examples/1/id",
+      "key": "secure-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "ex.secure-good#87313cf3",
+      "json_pointer": "/terms/9/examples/0/id",
+      "key": "secure-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.share-pt-bad#20dbcd2c",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "share-pt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "ex.share-pt-good#450b0bf8",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "share-pt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-burn-bad#f9b1e46b",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "sv-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-burn-good#b453b5dd",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "sv-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-email-bad#7f46f2c6",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "sv-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-email-good#3126ee9c",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "sv-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-encrypt-bad#b0971de5",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "sv-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-encrypt-good#d6dbd00b",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "sv-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-link-bad#fc48f282",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "sv-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-link-good#d7117069",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "sv-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-passphrase-bad#06928aa2",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "sv-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-passphrase-good#48571f1f",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "sv-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-password-bad#3480118c",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "sv-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-password-good#1a96853b",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "sv-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-secret-created-good#5e95e373",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "sv-secret-created-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "ex.sv-secret-formal-bad#7c64675d",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "sv-secret-formal-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-burn-bad#beee21af",
+      "json_pointer": "/terms/3/examples/1/id",
+      "key": "uk-burn-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-burn-good#2dd01fb1",
+      "json_pointer": "/terms/3/examples/0/id",
+      "key": "uk-burn-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-email-bad#874d9899",
+      "json_pointer": "/terms/6/examples/1/id",
+      "key": "uk-email-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-email-good#a342d634",
+      "json_pointer": "/terms/6/examples/0/id",
+      "key": "uk-email-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-encrypt-bad#d15fb7b2",
+      "json_pointer": "/terms/5/examples/1/id",
+      "key": "uk-encrypt-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-encrypt-good#fe4b74cc",
+      "json_pointer": "/terms/5/examples/0/id",
+      "key": "uk-encrypt-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-link-bad#08560f54",
+      "json_pointer": "/terms/4/examples/1/id",
+      "key": "uk-link-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-link-good#733cc71a",
+      "json_pointer": "/terms/4/examples/0/id",
+      "key": "uk-link-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-passphrase-bad#33953ae2",
+      "json_pointer": "/terms/1/examples/1/id",
+      "key": "uk-passphrase-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-passphrase-good#d847753a",
+      "json_pointer": "/terms/1/examples/0/id",
+      "key": "uk-passphrase-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-password-bad#8c30c587",
+      "json_pointer": "/terms/2/examples/1/id",
+      "key": "uk-password-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-password-good#c33e0e3c",
+      "json_pointer": "/terms/2/examples/0/id",
+      "key": "uk-password-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-secret-created-good#88891f6b",
+      "json_pointer": "/terms/0/examples/0/id",
+      "key": "uk-secret-created-good",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "ex.uk-secret-informal-bad#6c34a4bc",
+      "json_pointer": "/terms/0/examples/1/id",
+      "key": "uk-secret-informal-bad",
+      "kind": "ex"
+    },
+    {
+      "file": "locales/ar/glossary.yaml",
+      "id": "glossary.ar",
+      "json_pointer": "/id",
+      "key": "glossary.ar",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "glossary.bg",
+      "json_pointer": "/id",
+      "key": "glossary.bg",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/ca_ES/glossary.yaml",
+      "id": "glossary.ca_ES",
+      "json_pointer": "/id",
+      "key": "glossary.ca_ES",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/cs/glossary.yaml",
+      "id": "glossary.cs",
+      "json_pointer": "/id",
+      "key": "glossary.cs",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/da_DK/glossary.yaml",
+      "id": "glossary.da_DK",
+      "json_pointer": "/id",
+      "key": "glossary.da_DK",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/de/glossary.yaml",
+      "id": "glossary.de",
+      "json_pointer": "/id",
+      "key": "glossary.de",
+      "kind": "glossary"
+    },
+    {
       "file": "locales/de_AT/glossary.yaml",
       "id": "glossary.de_AT",
       "json_pointer": "/id",
       "key": "glossary.de_AT",
       "kind": "glossary"
+    },
+    {
+      "file": "locales/el_GR/glossary.yaml",
+      "id": "glossary.el_GR",
+      "json_pointer": "/id",
+      "key": "glossary.el_GR",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/eo/glossary.yaml",
+      "id": "glossary.eo",
+      "json_pointer": "/id",
+      "key": "glossary.eo",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/es/glossary.yaml",
+      "id": "glossary.es",
+      "json_pointer": "/id",
+      "key": "glossary.es",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/fr/glossary.yaml",
+      "id": "glossary.fr",
+      "json_pointer": "/id",
+      "key": "glossary.fr",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/fr_CA/glossary.yaml",
+      "id": "glossary.fr_CA",
+      "json_pointer": "/id",
+      "key": "glossary.fr_CA",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/fr_FR/glossary.yaml",
+      "id": "glossary.fr_FR",
+      "json_pointer": "/id",
+      "key": "glossary.fr_FR",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/he/glossary.yaml",
+      "id": "glossary.he",
+      "json_pointer": "/id",
+      "key": "glossary.he",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/hu/glossary.yaml",
+      "id": "glossary.hu",
+      "json_pointer": "/id",
+      "key": "glossary.hu",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/it_IT/glossary.yaml",
+      "id": "glossary.it_IT",
+      "json_pointer": "/id",
+      "key": "glossary.it_IT",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/ja/glossary.yaml",
+      "id": "glossary.ja",
+      "json_pointer": "/id",
+      "key": "glossary.ja",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/ko/glossary.yaml",
+      "id": "glossary.ko",
+      "json_pointer": "/id",
+      "key": "glossary.ko",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/mi_NZ/glossary.yaml",
+      "id": "glossary.mi_NZ",
+      "json_pointer": "/id",
+      "key": "glossary.mi_NZ",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/nl/glossary.yaml",
+      "id": "glossary.nl",
+      "json_pointer": "/id",
+      "key": "glossary.nl",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/pl/glossary.yaml",
+      "id": "glossary.pl",
+      "json_pointer": "/id",
+      "key": "glossary.pl",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/pt/glossary.yaml",
+      "id": "glossary.pt",
+      "json_pointer": "/id",
+      "key": "glossary.pt",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/pt_BR/glossary.yaml",
+      "id": "glossary.pt_BR",
+      "json_pointer": "/id",
+      "key": "glossary.pt_BR",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "glossary.pt_PT",
+      "json_pointer": "/id",
+      "key": "glossary.pt_PT",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/ru/glossary.yaml",
+      "id": "glossary.ru",
+      "json_pointer": "/id",
+      "key": "glossary.ru",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/sl_SI/glossary.yaml",
+      "id": "glossary.sl_SI",
+      "json_pointer": "/id",
+      "key": "glossary.sl_SI",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/sv_SE/glossary.yaml",
+      "id": "glossary.sv_SE",
+      "json_pointer": "/id",
+      "key": "glossary.sv_SE",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/tr/glossary.yaml",
+      "id": "glossary.tr",
+      "json_pointer": "/id",
+      "key": "glossary.tr",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/uk/glossary.yaml",
+      "id": "glossary.uk",
+      "json_pointer": "/id",
+      "key": "glossary.uk",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "glossary.vi",
+      "json_pointer": "/id",
+      "key": "glossary.vi",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "glossary.zh",
+      "json_pointer": "/id",
+      "key": "glossary.zh",
+      "kind": "glossary"
+    },
+    {
+      "file": "locales/ar/register.yaml",
+      "id": "register.ar",
+      "json_pointer": "/id",
+      "key": "register.ar",
+      "kind": "register"
+    },
+    {
+      "file": "locales/bg/register.yaml",
+      "id": "register.bg",
+      "json_pointer": "/id",
+      "key": "register.bg",
+      "kind": "register"
+    },
+    {
+      "file": "locales/ca_ES/register.yaml",
+      "id": "register.ca_ES",
+      "json_pointer": "/id",
+      "key": "register.ca_ES",
+      "kind": "register"
+    },
+    {
+      "file": "locales/cs/register.yaml",
+      "id": "register.cs",
+      "json_pointer": "/id",
+      "key": "register.cs",
+      "kind": "register"
+    },
+    {
+      "file": "locales/da_DK/register.yaml",
+      "id": "register.da_DK",
+      "json_pointer": "/id",
+      "key": "register.da_DK",
+      "kind": "register"
+    },
+    {
+      "file": "locales/de/register.yaml",
+      "id": "register.de",
+      "json_pointer": "/id",
+      "key": "register.de",
+      "kind": "register"
     },
     {
       "file": "locales/de_AT/register.yaml",
@@ -110,6 +1832,300 @@
       "id": "register.de_AT.formality",
       "json_pointer": "/rules/0/id",
       "key": "register.de_AT.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/el_GR/register.yaml",
+      "id": "register.el_GR",
+      "json_pointer": "/id",
+      "key": "register.el_GR",
+      "kind": "register"
+    },
+    {
+      "file": "locales/el_GR/rules.yaml",
+      "id": "register.el_GR.formality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.el_GR.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/register.yaml",
+      "id": "register.eo",
+      "json_pointer": "/id",
+      "key": "register.eo",
+      "kind": "register"
+    },
+    {
+      "file": "locales/es/register.yaml",
+      "id": "register.es",
+      "json_pointer": "/id",
+      "key": "register.es",
+      "kind": "register"
+    },
+    {
+      "file": "locales/fr/register.yaml",
+      "id": "register.fr",
+      "json_pointer": "/id",
+      "key": "register.fr",
+      "kind": "register"
+    },
+    {
+      "file": "locales/fr/rules.yaml",
+      "id": "register.fr.formality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.fr.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr_CA/register.yaml",
+      "id": "register.fr_CA",
+      "json_pointer": "/id",
+      "key": "register.fr_CA",
+      "kind": "register"
+    },
+    {
+      "file": "locales/fr_FR/register.yaml",
+      "id": "register.fr_FR",
+      "json_pointer": "/id",
+      "key": "register.fr_FR",
+      "kind": "register"
+    },
+    {
+      "file": "locales/he/register.yaml",
+      "id": "register.he",
+      "json_pointer": "/id",
+      "key": "register.he",
+      "kind": "register"
+    },
+    {
+      "file": "locales/hu/register.yaml",
+      "id": "register.hu",
+      "json_pointer": "/id",
+      "key": "register.hu",
+      "kind": "register"
+    },
+    {
+      "file": "locales/it_IT/register.yaml",
+      "id": "register.it_IT",
+      "json_pointer": "/id",
+      "key": "register.it_IT",
+      "kind": "register"
+    },
+    {
+      "file": "locales/ja/register.yaml",
+      "id": "register.ja",
+      "json_pointer": "/id",
+      "key": "register.ja",
+      "kind": "register"
+    },
+    {
+      "file": "locales/ko/register.yaml",
+      "id": "register.ko",
+      "json_pointer": "/id",
+      "key": "register.ko",
+      "kind": "register"
+    },
+    {
+      "file": "locales/mi_NZ/register.yaml",
+      "id": "register.mi_NZ",
+      "json_pointer": "/id",
+      "key": "register.mi_NZ",
+      "kind": "register"
+    },
+    {
+      "file": "locales/nl/register.yaml",
+      "id": "register.nl",
+      "json_pointer": "/id",
+      "key": "register.nl",
+      "kind": "register"
+    },
+    {
+      "file": "locales/nl/rules.yaml",
+      "id": "register.nl.formality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.nl.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/register.yaml",
+      "id": "register.pl",
+      "json_pointer": "/id",
+      "key": "register.pl",
+      "kind": "register"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "register.pl.informality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.pl.informality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt/register.yaml",
+      "id": "register.pt",
+      "json_pointer": "/id",
+      "key": "register.pt",
+      "kind": "register"
+    },
+    {
+      "file": "locales/pt/rules.yaml",
+      "id": "register.pt.formality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.pt.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_BR/register.yaml",
+      "id": "register.pt_BR",
+      "json_pointer": "/id",
+      "key": "register.pt_BR",
+      "kind": "register"
+    },
+    {
+      "file": "locales/pt_PT/register.yaml",
+      "id": "register.pt_PT",
+      "json_pointer": "/id",
+      "key": "register.pt_PT",
+      "kind": "register"
+    },
+    {
+      "file": "locales/ru/register.yaml",
+      "id": "register.ru",
+      "json_pointer": "/id",
+      "key": "register.ru",
+      "kind": "register"
+    },
+    {
+      "file": "locales/sl_SI/register.yaml",
+      "id": "register.sl_SI",
+      "json_pointer": "/id",
+      "key": "register.sl_SI",
+      "kind": "register"
+    },
+    {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "register.sl_SI.formality",
+      "json_pointer": "/rules/0/id",
+      "key": "register.sl_SI.formality",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/register.yaml",
+      "id": "register.sv_SE",
+      "json_pointer": "/id",
+      "key": "register.sv_SE",
+      "kind": "register"
+    },
+    {
+      "file": "locales/tr/register.yaml",
+      "id": "register.tr",
+      "json_pointer": "/id",
+      "key": "register.tr",
+      "kind": "register"
+    },
+    {
+      "file": "locales/uk/register.yaml",
+      "id": "register.uk",
+      "json_pointer": "/id",
+      "key": "register.uk",
+      "kind": "register"
+    },
+    {
+      "file": "locales/vi/register.yaml",
+      "id": "register.vi",
+      "json_pointer": "/id",
+      "key": "register.vi",
+      "kind": "register"
+    },
+    {
+      "file": "locales/zh/register.yaml",
+      "id": "register.zh",
+      "json_pointer": "/id",
+      "key": "register.zh",
+      "kind": "register"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-acronyms-latin",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.ar-acronyms-latin",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-address-masculine",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.ar-address-masculine",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-burn-final-deletion",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.ar-burn-final-deletion",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.ar-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-register-msa",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.ar-register-msa",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rule.ar-secret-sirr",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.ar-secret-sirr",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-burn-deletion-clarity",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.bg-burn-deletion-clarity",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-imperative-buttons",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.bg-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.bg-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-pluralization",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.bg-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.bg-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rule.bg-secret-tayna-not-sekret",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.bg-secret-tayna-not-sekret",
       "kind": "rules"
     },
     {
@@ -127,10 +2143,136 @@
       "kind": "rules"
     },
     {
-      "file": "locales/de/rules.yaml",
-      "id": "rule.de-sie",
+      "file": "locales/ca_ES/rules.yaml",
+      "id": "rule.ca_ES-burn-destruir",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.ca_ES-burn-destruir",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ca_ES/rules.yaml",
+      "id": "rule.ca_ES-encrypt-xifrar",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.ca_ES-encrypt-xifrar",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ca_ES/rules.yaml",
+      "id": "rule.ca_ES-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.ca_ES-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ca_ES/rules.yaml",
+      "id": "rule.ca_ES-register-informal",
       "json_pointer": "/rules/0/id",
-      "key": "rule.de-sie",
+      "key": "rule.ca_ES-register-informal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-burn-trvale-smazat",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.cs-burn-trvale-smazat",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-diacritics",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.cs-diacritics",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-imperative-buttons",
+      "json_pointer": "/rules/6/id",
+      "key": "rule.cs-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.cs-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-pluralization",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.cs-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-register-informal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.cs-register-informal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rule.cs-secret-not-message",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.cs-secret-not-message",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-burn-oedelaeg",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.da-burn-oedelaeg",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-compound-hyphen",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.da-compound-hyphen",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.da-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-register-informal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.da-register-informal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-secret-besked",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.da-secret-besked",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rule.da-voice-imperative-status",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.da-voice-imperative-status",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/de/rules.yaml",
+      "id": "rule.de-du",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.de-du",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/de/rules.yaml",
+      "id": "rule.de-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.de-passphrase-password",
       "kind": "rules"
     },
     {
@@ -138,6 +2280,272 @@
       "id": "rule.destructive-action-object",
       "json_pointer": "/rules/7/id",
       "key": "rule.destructive-action-object",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/el_GR/rules.yaml",
+      "id": "rule.el-burn-oristiki-diagrafi",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.el-burn-oristiki-diagrafi",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/el_GR/rules.yaml",
+      "id": "rule.el-monotonic-accents",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.el-monotonic-accents",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/el_GR/rules.yaml",
+      "id": "rule.el-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.el-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-accusative",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.eo-accusative",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-address-vi",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.eo-address-vi",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-burn-forbruligi",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.eo-burn-forbruligi",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-diacritics",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.eo-diacritics",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.eo-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rule.eo-verb-forms",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.eo-verb-forms",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/es/rules.yaml",
+      "id": "rule.es-burn-destruir",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.es-burn-destruir",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/es/rules.yaml",
+      "id": "rule.es-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.es-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/es/rules.yaml",
+      "id": "rule.es-register-informal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.es-register-informal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr/rules.yaml",
+      "id": "rule.fr-infinitive-buttons",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.fr-infinitive-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr/rules.yaml",
+      "id": "rule.fr-passphrase-password",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.fr-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr/rules.yaml",
+      "id": "rule.fr-punctuation-nbsp",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.fr-punctuation-nbsp",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr_CA/rules.yaml",
+      "id": "rule.fr_CA-courriel",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.fr_CA-courriel",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-burn-permanent-deletion",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.he-burn-permanent-deletion",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-button-imperative",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.he-button-imperative",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-no-niqqud",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.he-no-niqqud",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.he-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-register-gender",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.he-register-gender",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rule.he-secret-sod",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.he-secret-sod",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/hu/rules.yaml",
+      "id": "rule.hu-burn-permanent-deletion",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.hu-burn-permanent-deletion",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/hu/rules.yaml",
+      "id": "rule.hu-diacritics-vowel-harmony",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.hu-diacritics-vowel-harmony",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/hu/rules.yaml",
+      "id": "rule.hu-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.hu-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/hu/rules.yaml",
+      "id": "rule.hu-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.hu-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/it_IT/rules.yaml",
+      "id": "rule.it-active-passive-voice",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.it-active-passive-voice",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/it_IT/rules.yaml",
+      "id": "rule.it-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.it-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/it_IT/rules.yaml",
+      "id": "rule.it-register-informal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.it-register-informal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/it_IT/rules.yaml",
+      "id": "rule.it-secret-noun",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.it-secret-noun",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ja/rules.yaml",
+      "id": "rule.ja-button-imperative",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.ja-button-imperative",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ja/rules.yaml",
+      "id": "rule.ja-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.ja-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ja/rules.yaml",
+      "id": "rule.ja-register-teineigo",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.ja-register-teineigo",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ja/rules.yaml",
+      "id": "rule.ja-secret-katakana",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.ja-secret-katakana",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ko/rules.yaml",
+      "id": "rule.ko-button-imperative",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.ko-button-imperative",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ko/rules.yaml",
+      "id": "rule.ko-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.ko-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ko/rules.yaml",
+      "id": "rule.ko-register-politeness",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.ko-register-politeness",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ko/rules.yaml",
+      "id": "rule.ko-secret-message",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.ko-secret-message",
       "kind": "rules"
     },
     {
@@ -155,6 +2563,83 @@
       "kind": "rules"
     },
     {
+      "file": "locales/mi_NZ/rules.yaml",
+      "id": "rule.mi_NZ-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.mi_NZ-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/mi_NZ/rules.yaml",
+      "id": "rule.mi_NZ-register-number",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.mi_NZ-register-number",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/mi_NZ/rules.yaml",
+      "id": "rule.mi_NZ-secret-karere-huna",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.mi_NZ-secret-karere-huna",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/mi_NZ/rules.yaml",
+      "id": "rule.mi_NZ-voice-imperative-status",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.mi_NZ-voice-imperative-status",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/nl/rules.yaml",
+      "id": "rule.nl-active-passive-voice",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.nl-active-passive-voice",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/nl/rules.yaml",
+      "id": "rule.nl-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.nl-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/nl/rules.yaml",
+      "id": "rule.nl-secret-noun",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.nl-secret-noun",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "rule.pl-imperative-buttons",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.pl-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "rule.pl-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.pl-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "rule.pl-pluralization",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.pl-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "rule.pl-secret-not-message",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.pl-secret-not-message",
+      "kind": "rules"
+    },
+    {
       "file": "base.yaml",
       "id": "rule.pluralization-syntax",
       "json_pointer": "/rules/3/id",
@@ -169,10 +2654,108 @@
       "kind": "rules"
     },
     {
+      "file": "locales/pt/rules.yaml",
+      "id": "rule.pt-imperative-buttons",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.pt-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt/rules.yaml",
+      "id": "rule.pt-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.pt-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt/rules.yaml",
+      "id": "rule.pt-secret-confidencial",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.pt-secret-confidencial",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_PT/rules.yaml",
+      "id": "rule.pt_PT-encriptar",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.pt_PT-encriptar",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_PT/rules.yaml",
+      "id": "rule.pt_PT-palavra-passe",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.pt_PT-palavra-passe",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_PT/rules.yaml",
+      "id": "rule.pt_PT-partilhar",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.pt_PT-partilhar",
+      "kind": "rules"
+    },
+    {
       "file": "base.yaml",
       "id": "rule.register-lock",
       "json_pointer": "/rules/0/id",
       "key": "rule.register-lock",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-burn-unichtozhit",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.ru-burn-unichtozhit",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-gender-agreement",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.ru-gender-agreement",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-imperative-buttons",
+      "json_pointer": "/rules/7/id",
+      "key": "rule.ru-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.ru-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-pluralization",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.ru-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.ru-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-secret-not-taina",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.ru-secret-not-taina",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rule.ru-yo-letter",
+      "json_pointer": "/rules/6/id",
+      "key": "rule.ru-yo-letter",
       "kind": "rules"
     },
     {
@@ -183,10 +2766,269 @@
       "kind": "rules"
     },
     {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "rule.sl_SI-imperative-buttons",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.sl_SI-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "rule.sl_SI-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.sl_SI-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "rule.sl_SI-pluralization",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.sl_SI-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "rule.sl_SI-secret-not-message",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.sl_SI-secret-not-message",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rule.sv-active-imperative-voice",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.sv-active-imperative-voice",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rule.sv-burn-radera-permanent",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.sv-burn-radera-permanent",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rule.sv-compound-words",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.sv-compound-words",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rule.sv-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.sv-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rule.sv-register-informal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.sv-register-informal",
+      "kind": "rules"
+    },
+    {
       "file": "base.yaml",
       "id": "rule.terminology-consistency",
       "json_pointer": "/rules/6/id",
       "key": "rule.terminology-consistency",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rule.tr-active-passive-voice",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.tr-active-passive-voice",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rule.tr-burn-yak",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.tr-burn-yak",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rule.tr-passphrase-password",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.tr-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rule.tr-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.tr-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rule.tr-secret-noun",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.tr-secret-noun",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-gender-case-agreement",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.uk-gender-case-agreement",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-imperative-buttons",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.uk-imperative-buttons",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-passphrase-password",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.uk-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-pluralization",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.uk-pluralization",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.uk-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rule.uk-secret-not-sekret",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.uk-secret-not-sekret",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-burn-xoa-vinh-vien",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.vi-burn-xoa-vinh-vien",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-diacritics-tones",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.vi-diacritics-tones",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-message-voice",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.vi-message-voice",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-passphrase-password",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.vi-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-register-ban",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.vi-register-ban",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rule.vi-secret-bi-mat",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.vi-secret-bi-mat",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-burn-xiaohui",
+      "json_pointer": "/rules/4/id",
+      "key": "rule.zh-burn-xiaohui",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-passphrase-password",
+      "json_pointer": "/rules/3/id",
+      "key": "rule.zh-passphrase-password",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-punctuation-no-exclamation",
+      "json_pointer": "/rules/5/id",
+      "key": "rule.zh-punctuation-no-exclamation",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-register-formal",
+      "json_pointer": "/rules/0/id",
+      "key": "rule.zh-register-formal",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-secret-link",
+      "json_pointer": "/rules/2/id",
+      "key": "rule.zh-secret-link",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rule.zh-secret-no-mimi",
+      "json_pointer": "/rules/1/id",
+      "key": "rule.zh-secret-no-mimi",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ar/rules.yaml",
+      "id": "rules.ar",
+      "json_pointer": "/id",
+      "key": "rules.ar",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/bg/rules.yaml",
+      "id": "rules.bg",
+      "json_pointer": "/id",
+      "key": "rules.bg",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ca_ES/rules.yaml",
+      "id": "rules.ca_ES",
+      "json_pointer": "/id",
+      "key": "rules.ca_ES",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/cs/rules.yaml",
+      "id": "rules.cs",
+      "json_pointer": "/id",
+      "key": "rules.cs",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/da_DK/rules.yaml",
+      "id": "rules.da_DK",
+      "json_pointer": "/id",
+      "key": "rules.da_DK",
       "kind": "rules"
     },
     {
@@ -204,7 +3046,259 @@
       "kind": "rules"
     },
     {
-      "file": "locales/de_AT/glossary.yaml",
+      "file": "locales/el_GR/rules.yaml",
+      "id": "rules.el_GR",
+      "json_pointer": "/id",
+      "key": "rules.el_GR",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/eo/rules.yaml",
+      "id": "rules.eo",
+      "json_pointer": "/id",
+      "key": "rules.eo",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/es/rules.yaml",
+      "id": "rules.es",
+      "json_pointer": "/id",
+      "key": "rules.es",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr/rules.yaml",
+      "id": "rules.fr",
+      "json_pointer": "/id",
+      "key": "rules.fr",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr_CA/rules.yaml",
+      "id": "rules.fr_CA",
+      "json_pointer": "/id",
+      "key": "rules.fr_CA",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/fr_FR/rules.yaml",
+      "id": "rules.fr_FR",
+      "json_pointer": "/id",
+      "key": "rules.fr_FR",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/he/rules.yaml",
+      "id": "rules.he",
+      "json_pointer": "/id",
+      "key": "rules.he",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/hu/rules.yaml",
+      "id": "rules.hu",
+      "json_pointer": "/id",
+      "key": "rules.hu",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/it_IT/rules.yaml",
+      "id": "rules.it_IT",
+      "json_pointer": "/id",
+      "key": "rules.it_IT",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ja/rules.yaml",
+      "id": "rules.ja",
+      "json_pointer": "/id",
+      "key": "rules.ja",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ko/rules.yaml",
+      "id": "rules.ko",
+      "json_pointer": "/id",
+      "key": "rules.ko",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/mi_NZ/rules.yaml",
+      "id": "rules.mi_NZ",
+      "json_pointer": "/id",
+      "key": "rules.mi_NZ",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/nl/rules.yaml",
+      "id": "rules.nl",
+      "json_pointer": "/id",
+      "key": "rules.nl",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pl/rules.yaml",
+      "id": "rules.pl",
+      "json_pointer": "/id",
+      "key": "rules.pl",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt/rules.yaml",
+      "id": "rules.pt",
+      "json_pointer": "/id",
+      "key": "rules.pt",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_BR/rules.yaml",
+      "id": "rules.pt_BR",
+      "json_pointer": "/id",
+      "key": "rules.pt_BR",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/pt_PT/rules.yaml",
+      "id": "rules.pt_PT",
+      "json_pointer": "/id",
+      "key": "rules.pt_PT",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/ru/rules.yaml",
+      "id": "rules.ru",
+      "json_pointer": "/id",
+      "key": "rules.ru",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sl_SI/rules.yaml",
+      "id": "rules.sl_SI",
+      "json_pointer": "/id",
+      "key": "rules.sl_SI",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/sv_SE/rules.yaml",
+      "id": "rules.sv_SE",
+      "json_pointer": "/id",
+      "key": "rules.sv_SE",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/tr/rules.yaml",
+      "id": "rules.tr",
+      "json_pointer": "/id",
+      "key": "rules.tr",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/uk/rules.yaml",
+      "id": "rules.uk",
+      "json_pointer": "/id",
+      "key": "rules.uk",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/rules.yaml",
+      "id": "rules.vi",
+      "json_pointer": "/id",
+      "key": "rules.vi",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/zh/rules.yaml",
+      "id": "rules.zh",
+      "json_pointer": "/id",
+      "key": "rules.zh",
+      "kind": "rules"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "term.account#3a541ed7",
+      "json_pointer": "/terms/8/id",
+      "key": "account",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.burn#8a886c8d",
+      "json_pointer": "/terms/5/id",
+      "key": "burn",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.email#8c4fb076",
+      "json_pointer": "/terms/8/id",
+      "key": "email",
+      "kind": "term"
+    },
+    {
+      "file": "locales/fr_CA/glossary.yaml",
+      "id": "term.email_ca#287480a5",
+      "json_pointer": "/terms/0/id",
+      "key": "email_ca",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.encrypt#a4d3564b",
+      "json_pointer": "/terms/7/id",
+      "key": "encrypt",
+      "kind": "term"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "term.encrypt_pt#4c804385",
+      "json_pointer": "/terms/1/id",
+      "key": "encrypt_pt",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.link#b48578dd",
+      "json_pointer": "/terms/6/id",
+      "key": "link",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.passphrase#44591635",
+      "json_pointer": "/terms/3/id",
+      "key": "passphrase",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.password#3e4e76cc",
+      "json_pointer": "/terms/4/id",
+      "key": "password",
+      "kind": "term"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "term.password_pt#01adcfc9",
+      "json_pointer": "/terms/0/id",
+      "key": "password_pt",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.secret_adjective#a3a1d7c9",
+      "json_pointer": "/terms/1/id",
+      "key": "secret_adjective",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
+      "id": "term.secret_link#6d74a4a6",
+      "json_pointer": "/terms/2/id",
+      "key": "secret_link",
+      "kind": "term"
+    },
+    {
+      "file": "locales/zh/glossary.yaml",
       "id": "term.secret_object#c0902808",
       "json_pointer": "/terms/0/id",
       "key": "secret_object",
@@ -215,6 +3309,27 @@
       "id": "term.secret_payload#1687a617",
       "json_pointer": "/terms/1/id",
       "key": "secret_payload",
+      "kind": "term"
+    },
+    {
+      "file": "locales/vi/glossary.yaml",
+      "id": "term.secure#952acf0e",
+      "json_pointer": "/terms/9/id",
+      "key": "secure",
+      "kind": "term"
+    },
+    {
+      "file": "locales/pt_PT/glossary.yaml",
+      "id": "term.share_pt#043c3d4f",
+      "json_pointer": "/terms/2/id",
+      "key": "share_pt",
+      "kind": "term"
+    },
+    {
+      "file": "locales/bg/glossary.yaml",
+      "id": "term.view#7ef567df",
+      "json_pointer": "/terms/7/id",
+      "key": "view",
       "kind": "term"
     }
   ],

--- a/resolver/merge.py
+++ b/resolver/merge.py
@@ -187,3 +187,38 @@ def _copy_value(v: Any) -> Any:
 
 def _copy_list(v: list) -> list:
     return [_copy_value(sub) for sub in v]
+
+
+def merge_glossary_terms(glossaries_child_first: list[dict]) -> dict | None:
+    """Union glossary `terms` along the inheritance chain by term `key`.
+
+    Child glossaries replace parent terms of the same `key` wholesale (no
+    sense-level merge — the term is the smallest unit of override). The
+    resulting glossary takes the child's `id` and `source`, since downstream
+    consumers attribute the artifact to the locale being resolved. Terms
+    contributed by parents are emitted in parent-declaration order after the
+    child's own terms, so the locale's local terms read first.
+
+    `merge_chain`'s generic policy (lists default to `replace`) would otherwise
+    drop inherited terms wholesale; this helper is purpose-built so an fr_CA
+    delta-only glossary inherits the rest of fr's terminology.
+    """
+    if not glossaries_child_first:
+        return None
+    child = glossaries_child_first[0]
+    seen_keys: set[str] = set()
+    merged_terms: list[Any] = []
+    for glossary in glossaries_child_first:
+        for term in glossary.get("terms") or []:
+            key = term.get("key") if isinstance(term, dict) else None
+            if not isinstance(key, str) or key in seen_keys:
+                continue
+            seen_keys.add(key)
+            merged_terms.append(_copy_value(term))
+    out: dict[str, Any] = {}
+    if "id" in child:
+        out["id"] = child["id"]
+    if "source" in child:
+        out["source"] = child["source"]
+    out["terms"] = merged_terms
+    return out

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -57,7 +57,7 @@ from resolver.loader import (
     load_retro_frontmatter,
     load_yaml_file,
 )
-from resolver.merge import MergeError, merge_chain
+from resolver.merge import MergeError, merge_chain, merge_glossary_terms
 from resolver.model import ModelError, build_model
 from resolver.lint import lint_model
 from resolver.emit_json import emit_json
@@ -413,6 +413,29 @@ def resolve_locale(
         merged_rules = base_data
         provenance = {}
 
+    # Glossary inheritance: merge along the same chain as rules, child-first.
+    # ADR-001: a child glossary that omits a term inherits the parent's term
+    # (term-key override). Without this, an fr_CA delta-only glossary would
+    # emit a `.resolved` missing inherited `fr` terminology — exactly the
+    # failure mode #29 surfaced. Register is intentionally NOT merged: registers
+    # are per-locale by design (see ADR-001 §Decision).
+    leaf_glossary = next(
+        (f.data for f in locale_files if f.schema_name == "glossary"), None
+    )
+    glossaries_child_first: list[dict] = []
+    if leaf_glossary is not None:
+        glossaries_child_first.append(leaf_glossary)
+    for node in chain_nodes:
+        if node.path == inputs.base_path or node.locale == locale:
+            continue
+        parent_glossary_path = inputs.locales_dir / node.locale / "glossary.yaml"
+        if not parent_glossary_path.exists():
+            continue
+        parent_glossary = load_yaml_file(parent_glossary_path)
+        validate_file(parent_glossary_path, parent_glossary, "glossary", bundle)
+        glossaries_child_first.append(parent_glossary)
+    merged_glossary = merge_glossary_terms(glossaries_child_first)
+
     # Step 1d: baselines + retrospectives (project-wide, locale-agnostic).
     baselines = _load_baselines(inputs, bundle)
     retros = _load_retros(inputs, bundle)
@@ -437,11 +460,17 @@ def resolve_locale(
         _index_retro(retro.data, retro.path, index, root)
 
     # Step 4: walk merged rules + per-locale leaves + baselines + retros for refs.
+    # The glossary is checked from the inheritance-merged view so inherited
+    # terms' refs are validated against the same combined index — leaf-only
+    # checking would silently skip parent terms.
     errors: list[str] = []
     _check_refs(f"rules ({locale})", merged_rules, index, errors)
     for f in locale_files:
-        if f.schema_name != "rules":
-            _check_refs(f"{f.schema_name} ({locale})", f.data, index, errors)
+        if f.schema_name in ("rules", "glossary"):
+            continue
+        _check_refs(f"{f.schema_name} ({locale})", f.data, index, errors)
+    if merged_glossary is not None:
+        _check_refs(f"glossary ({locale})", merged_glossary, index, errors)
     if baselines is not None:
         _check_refs("baselines", baselines.data, index, errors)
     for retro in retros:
@@ -480,9 +509,7 @@ def resolve_locale(
         "register": next(
             (f.data for f in locale_files if f.schema_name == "register"), None
         ),
-        "glossary": next(
-            (f.data for f in locale_files if f.schema_name == "glossary"), None
-        ),
+        "glossary": merged_glossary,
         "retros": [r.data for r in retros],
     }
 

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -486,23 +486,19 @@ def resolve_locale(
     if errors:
         raise ResolutionError("dangling references:\n  " + "\n  ".join(errors))
 
-    # Emit index.json (skip in validate-only mode).
-    if not validate_only:
-        idx_out = IdIndex()
-        for rec in index.all_records():
-            try:
-                idx_out.add(rec)
-            except IdError as exc:
-                # Two records sharing an id but different (kind,key) is a true
-                # error already surfaced by add_*; skip silently here.
-                _ = exc
-        idx_out.dump(inputs.index_path)
+    # NOTE: index.json is no longer written here. Under --all this function is
+    # called once per locale, and writing inside the loop made the dump
+    # last-write-wins (the committed index could never carry more than the final
+    # locale). The caller (main) now owns the dump: it writes a single locale's
+    # index for a single-locale run, or the UNION across every locale for --all.
+    # The CombinedIndex is surfaced so the caller can accumulate that union.
 
     return {
         "locale": locale,
         "merged_rules": merged_rules,
         "provenance": provenance,
         "chain": [n.locale for n in chain_nodes],
+        "index": index,
         "index_records": len(index.all_records()),
         # Raw per-locale leaves + retros surfaced for the P1-3 assemble step
         # (resolver/model.py). emit/lint are pure projections of these.
@@ -516,6 +512,24 @@ def resolve_locale(
 
 class ResolutionError(Exception):
     """Raised when ID resolution fails (dangling refs, etc.)."""
+
+
+def _accumulate_records(idx_out: IdIndex, records: list[IdRecord]) -> None:
+    """Add every record into idx_out, raising on a genuine cross-locale clash.
+
+    base.yaml / baselines.yaml / retrospective ids are SHARED — they appear in
+    every locale's CombinedIndex — so under --all the union re-adds identical
+    records many times. IdIndex.add is idempotent for an identical (id -> same
+    kind,key) re-add and only raises IdError when the SAME id maps to a
+    DIFFERENT (kind, key). We deliberately let that IdError propagate: a real
+    cross-locale id collision must surface, not be silently dropped.
+    """
+    for rec in records:
+        idx_out.add(rec)
+
+
+def _dump_index(idx_out: IdIndex, inputs: ResolverInputs) -> None:
+    idx_out.dump(inputs.index_path)
 
 
 def _resolve_source_commit(repo_root: Path, override: str | None) -> str:
@@ -729,9 +743,16 @@ def main(argv: list[str]) -> int:
     emit_dir = Path(args.emit_dir).resolve()
 
     lint_failures = 0
+    # Accumulate the id index across every resolved locale. For a single-locale
+    # run this holds just that locale's records; under --all it becomes the
+    # UNION of all locales (base/baselines/retro ids are shared and re-added
+    # idempotently; a genuine id collision raises IdError via _accumulate_records).
+    union_index = IdIndex()
     for locale in locales:
         try:
             result = resolve_locale(locale, inputs, validate_only=args.validate_only)
+            if not args.validate_only:
+                _accumulate_records(union_index, result["index"].all_records())
             emitted = (
                 _emit_for_locale(
                     locale,
@@ -774,8 +795,6 @@ def main(argv: list[str]) -> int:
             print(summary, file=sys.stderr)
         else:
             print(summary)
-            if not args.validate_only:
-                print(f"wrote {inputs.index_path}")
         if emitted:
             for path in emitted["written"]:
                 print(f"emitted {path}")
@@ -793,6 +812,14 @@ def main(argv: list[str]) -> int:
                     )
                 if not lint_result.ok:
                     lint_failures += 1
+
+    # Dump the index ONCE, after the loop, over the accumulated union. This is
+    # the fix for the old last-write-wins bug: under --all the committed index
+    # now carries every locale's ids, not just the final one. --validate-only
+    # writes nothing; --index-path is honored via inputs.index_path.
+    if not args.validate_only:
+        _dump_index(union_index, inputs)
+        print(f"wrote {inputs.index_path}")
 
     if lint_failures:
         print(f"lint: {lint_failures} locale(s) failed", file=sys.stderr)

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -537,11 +537,15 @@ def _resolve_source_commit(repo_root: Path, override: str | None) -> str:
 
 
 def _discover_locales(locales_dir: Path) -> list[str]:
+    # A locale dir is one that actually carries leaf YAML (rules/register/
+    # glossary). Skip helper dirs that live under locales/ but hold tooling
+    # rather than translations (e.g. locales/scripts/) — otherwise --all would
+    # try to resolve them and trip the "no YAML files found" guard with exit 2.
     return (
         sorted(
             p.name
             for p in locales_dir.iterdir()
-            if p.is_dir() and not p.name.startswith(".")
+            if p.is_dir() and not p.name.startswith(".") and any(p.glob("*.yaml"))
         )
         if locales_dir.exists()
         else []

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -573,7 +573,12 @@ def _emit_for_locale(
         path.write_text(emit_json(model), encoding="utf-8")
         written.append(str(path))
     if "md" in formats:
-        path = emit_dir / "for-translators" / f"{locale}.md"
+        # SPEC §2.3: the human guide is emitted to
+        # <emit-dir>/guides/for-translators/<locale>.md (the app repo vendors it
+        # at locales/guides/for-translators/), alongside the JSON's
+        # <emit-dir>/.resolved/. Keeping the `guides/` segment lets a single
+        # `--emit-dir locales` land both artifacts in their canonical homes.
+        path = emit_dir / "guides" / "for-translators" / f"{locale}.md"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(emit_markdown(model, source_commit), encoding="utf-8")
         written.append(str(path))

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -528,10 +528,6 @@ def _accumulate_records(idx_out: IdIndex, records: list[IdRecord]) -> None:
         idx_out.add(rec)
 
 
-def _dump_index(idx_out: IdIndex, inputs: ResolverInputs) -> None:
-    idx_out.dump(inputs.index_path)
-
-
 def _resolve_source_commit(repo_root: Path, override: str | None) -> str:
     """The translation-rules commit pinned into emitted artifacts. Explicit
     override wins (tests pass a stub); else the rules repo HEAD; else UNPINNED
@@ -818,7 +814,7 @@ def main(argv: list[str]) -> int:
     # now carries every locale's ids, not just the final one. --validate-only
     # writes nothing; --index-path is honored via inputs.index_path.
     if not args.validate_only:
-        _dump_index(union_index, inputs)
+        union_index.dump(inputs.index_path)
         print(f"wrote {inputs.index_path}")
 
     if lint_failures:

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -628,7 +628,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--emit-dir",
         default=".",
-        help="Root for emitted artifacts: <dir>/.resolved/ and <dir>/for-translators/ (default: .).",
+        help="Root for emitted artifacts: <dir>/.resolved/ and <dir>/guides/for-translators/ (default: .).",
     )
     parser.add_argument(
         "--source-commit",

--- a/tests/resolver/fixtures/de-de_AT/expected/de_AT.for-translators.md
+++ b/tests/resolver/fixtures/de-de_AT/expected/de_AT.for-translators.md
@@ -14,6 +14,9 @@ Locale: `de_AT` · schema v1
 
 ## Glossary
 
+### link (en: link)
+- _noun_: **Link**
+  - ✓ Open the link to view your secret. → Öffnen Sie den Link, um Ihr Geheimnis anzuzeigen.
 ### secret_object (en: secret)
 - _noun_: **Geheimnis**
   - ✓ Your secret has been created. → Ihr Geheimnis wurde erstellt.

--- a/tests/resolver/fixtures/de-de_AT/expected/de_AT.resolved.json
+++ b/tests/resolver/fixtures/de-de_AT/expected/de_AT.resolved.json
@@ -31,6 +31,26 @@
     }
   ],
   "glossary": {
+    "link": {
+      "en": "link",
+      "examples": [
+        {
+          "id": "ex.link-de-good#aabbccdd",
+          "senses": [
+            "noun"
+          ],
+          "source": "Open the link to view your secret.",
+          "target": "Öffnen Sie den Link, um Ihr Geheimnis anzuzeigen.",
+          "verdict": "good"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.register-lock",
+          "target": "Link"
+        }
+      }
+    },
     "secret_object": {
       "en": "secret",
       "examples": [

--- a/tests/resolver/fixtures/de-de_AT/locales/de/glossary.yaml
+++ b/tests/resolver/fixtures/de-de_AT/locales/de/glossary.yaml
@@ -1,0 +1,29 @@
+id: glossary.de
+source: SPEC.md
+# Fixture parent glossary. Exercises ADR-001 glossary inheritance: the `link`
+# term defined here flows through to de_AT untouched, while `secret_object`
+# (also declared here) is overridden by de_AT's own term-key entry. The
+# de-only term proves a child without a key inherits the parent's term; the
+# overlapping key proves child-wins.
+terms:
+  - id: term.link#11223344
+    key: link
+    en: link
+    de:
+      noun:
+        target: Link
+        rule_ref: rule.register-lock
+    rule_refs: [rule.de-sie]
+    examples:
+      - id: ex.link-de-good#aabbccdd
+        source: Open the link to view your secret.
+        target: Öffnen Sie den Link, um Ihr Geheimnis anzuzeigen.
+        verdict: good
+  - id: term.secret_object#55667788
+    key: secret_object
+    en: secret
+    de:
+      noun:
+        target: Geheimnis
+        rule_ref: rule.register-lock
+    rule_refs: [rule.de-sie]

--- a/tests/resolver/run.py
+++ b/tests/resolver/run.py
@@ -39,14 +39,18 @@ Exit codes: 0 all passed · 1 a fixture failed · 2 harness setup error.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 try:
+    from resolver import resolve as resolve_mod
     from resolver.emit_json import emit_json
     from resolver.emit_markdown import emit_markdown
     from resolver.lint import lint_model
@@ -191,6 +195,126 @@ def _first_diff(label: str, got: str, want: str) -> str:
     return f"{label} golden mismatch (no line diff found)"
 
 
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _all_union_test() -> tuple[bool, str]:
+    """Regression for the --all global-union index bug.
+
+    Builds a temp project with TWO locales, each defining a uniquely
+    identifiable rule id, then runs `resolve.py --all` to a temp index path.
+    The committed index must be the UNION of every locale's ids. The old code
+    dumped resolver/index.json INSIDE the per-locale loop (last-write-wins), so
+    the emitted index carried only the final locale and this assertion failed.
+    """
+    base_yaml = (
+        "id: base\n"
+        "source: SPEC.md\n"
+        "rules:\n"
+        "  - id: rule.shared-base\n"
+        "    modality: MUST\n"
+        "    statement: A base rule shared by every locale.\n"
+        "    severity: error\n"
+    )
+    # Two independent locales (no inheritance between them), each with its own
+    # rules.yaml whose top id and rule id are locale-specific.
+    aa_rules = (
+        "id: rules.aa\n"
+        "source: test\n"
+        "inherits: base\n"
+        "merge_strategy: append\n"
+        "rules:\n"
+        "  - id: rule.aa-only\n"
+        "    modality: MUST\n"
+        "    statement: An aa-only rule.\n"
+        "    severity: error\n"
+    )
+    zz_rules = (
+        "id: rules.zz\n"
+        "source: test\n"
+        "inherits: base\n"
+        "merge_strategy: append\n"
+        "rules:\n"
+        "  - id: rule.zz-only\n"
+        "    modality: MUST\n"
+        "    statement: A zz-only rule.\n"
+        "    severity: error\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "base.yaml", base_yaml)
+        _write(root / "locales" / "aa" / "rules.yaml", aa_rules)
+        _write(root / "locales" / "zz" / "rules.yaml", zz_rules)
+        index_path = root / "out" / "index.json"
+
+        # Silence the resolver's own progress chatter so it does not interleave
+        # with the harness's pass/FAIL lines.
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = resolve_mod.main(
+                [
+                    "--all",
+                    "--base-file",
+                    str(root / "base.yaml"),
+                    "--locales-dir",
+                    str(root / "locales"),
+                    "--retrospectives-dir",
+                    str(root / "retrospectives"),  # absent; resolver tolerates
+                    "--schema-dir",
+                    str(SCHEMA_DIR),
+                    "--index-path",
+                    str(index_path),
+                    "--project-root",
+                    str(root),
+                ]
+            )
+        if rc != 0:
+            return False, f"--all exited {rc} (expected 0)"
+        if not index_path.exists():
+            return False, f"index not written to {index_path}"
+
+        ids = {e["id"] for e in json.loads(index_path.read_text())["ids"]}
+        want = {"base", "rules.aa", "rule.aa-only", "rules.zz", "rule.zz-only"}
+        missing = want - ids
+        if missing:
+            return (
+                False,
+                f"--all index is not a union: missing {sorted(missing)} "
+                f"(got {sorted(ids)}) — last-write-wins regression",
+            )
+        # Single-locale must still write only that locale's index.
+        single_path = root / "out" / "single.json"
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = resolve_mod.main(
+                [
+                    "aa",
+                    "--base-file",
+                    str(root / "base.yaml"),
+                    "--locales-dir",
+                    str(root / "locales"),
+                    "--schema-dir",
+                    str(SCHEMA_DIR),
+                    "--index-path",
+                    str(single_path),
+                    "--project-root",
+                    str(root),
+                ]
+            )
+        if rc != 0:
+            return False, f"single-locale exited {rc} (expected 0)"
+        single_ids = {e["id"] for e in json.loads(single_path.read_text())["ids"]}
+        if "rule.zz-only" in single_ids:
+            return (
+                False,
+                "single-locale index leaked another locale's id (rule.zz-only)",
+            )
+        if "rule.aa-only" not in single_ids:
+            return False, "single-locale index missing its own id (rule.aa-only)"
+    return True, "ok"
+
+
 def main(argv: list[str]) -> int:
     targets = argv[1:] if len(argv) > 1 else None
     if not FIXTURES_DIR.exists():
@@ -208,6 +332,18 @@ def main(argv: list[str]) -> int:
             ok, msg = False, f"unexpected error: {type(exc).__name__}: {exc}"
         print(f"  {'pass' if ok else 'FAIL'} {fixture_dir.name}: {msg}")
         passed, failed = (passed + 1, failed) if ok else (passed, failed + 1)
+
+    # Programmatic (non-fixture) checks. The --all union test builds its own
+    # temp tree, so it has no fixtures/ entry. Run unless a target filter that
+    # excludes it was given.
+    if not targets or "all-union" in targets:
+        try:
+            ok, msg = _all_union_test()
+        except Exception as exc:  # noqa: BLE001
+            ok, msg = False, f"unexpected error: {type(exc).__name__}: {exc}"
+        print(f"  {'pass' if ok else 'FAIL'} all-union: {msg}")
+        passed, failed = (passed + 1, failed) if ok else (passed, failed + 1)
+
     print()
     print(f"summary: {passed} passed, {failed} failed")
     return 0 if failed == 0 else 1

--- a/tests/resolver/run.py
+++ b/tests/resolver/run.py
@@ -200,75 +200,84 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+# Shared fixtures for the --all index tests: two independent locales (no
+# inheritance between them), each with its own rules.yaml whose top id and rule
+# id are locale-specific, plus a base rule every locale shares.
+_BASE_YAML = (
+    "id: base\n"
+    "source: SPEC.md\n"
+    "rules:\n"
+    "  - id: rule.shared-base\n"
+    "    modality: MUST\n"
+    "    statement: A base rule shared by every locale.\n"
+    "    severity: error\n"
+)
+_AA_RULES = (
+    "id: rules.aa\n"
+    "source: test\n"
+    "inherits: base\n"
+    "merge_strategy: append\n"
+    "rules:\n"
+    "  - id: rule.aa-only\n"
+    "    modality: MUST\n"
+    "    statement: An aa-only rule.\n"
+    "    severity: error\n"
+)
+_ZZ_RULES = (
+    "id: rules.zz\n"
+    "source: test\n"
+    "inherits: base\n"
+    "merge_strategy: append\n"
+    "rules:\n"
+    "  - id: rule.zz-only\n"
+    "    modality: MUST\n"
+    "    statement: A zz-only rule.\n"
+    "    severity: error\n"
+)
+
+
+def _two_locale_project(root: Path) -> None:
+    """Write the minimal two-locale (aa, zz) project the --all tests run against."""
+    _write(root / "base.yaml", _BASE_YAML)
+    _write(root / "locales" / "aa" / "rules.yaml", _AA_RULES)
+    _write(root / "locales" / "zz" / "rules.yaml", _ZZ_RULES)
+
+
+def _project_args(root: Path) -> list[str]:
+    """Common path args for resolve_mod.main against a temp project."""
+    return [
+        "--base-file",
+        str(root / "base.yaml"),
+        "--locales-dir",
+        str(root / "locales"),
+        "--retrospectives-dir",
+        str(root / "retrospectives"),  # absent; resolver tolerates
+        "--schema-dir",
+        str(SCHEMA_DIR),
+        "--project-root",
+        str(root),
+    ]
+
+
 def _all_union_test() -> tuple[bool, str]:
     """Regression for the --all global-union index bug.
 
-    Builds a temp project with TWO locales, each defining a uniquely
-    identifiable rule id, then runs `resolve.py --all` to a temp index path.
-    The committed index must be the UNION of every locale's ids. The old code
-    dumped resolver/index.json INSIDE the per-locale loop (last-write-wins), so
-    the emitted index carried only the final locale and this assertion failed.
+    Runs `resolve.py --all` over two locales to a temp index path; the emitted
+    index must be the UNION of every locale's ids. The old code dumped
+    resolver/index.json INSIDE the per-locale loop (last-write-wins), so the
+    index carried only the final locale and this assertion failed. Also asserts
+    a single-locale run still writes only that locale's ids.
     """
-    base_yaml = (
-        "id: base\n"
-        "source: SPEC.md\n"
-        "rules:\n"
-        "  - id: rule.shared-base\n"
-        "    modality: MUST\n"
-        "    statement: A base rule shared by every locale.\n"
-        "    severity: error\n"
-    )
-    # Two independent locales (no inheritance between them), each with its own
-    # rules.yaml whose top id and rule id are locale-specific.
-    aa_rules = (
-        "id: rules.aa\n"
-        "source: test\n"
-        "inherits: base\n"
-        "merge_strategy: append\n"
-        "rules:\n"
-        "  - id: rule.aa-only\n"
-        "    modality: MUST\n"
-        "    statement: An aa-only rule.\n"
-        "    severity: error\n"
-    )
-    zz_rules = (
-        "id: rules.zz\n"
-        "source: test\n"
-        "inherits: base\n"
-        "merge_strategy: append\n"
-        "rules:\n"
-        "  - id: rule.zz-only\n"
-        "    modality: MUST\n"
-        "    statement: A zz-only rule.\n"
-        "    severity: error\n"
-    )
-
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        _write(root / "base.yaml", base_yaml)
-        _write(root / "locales" / "aa" / "rules.yaml", aa_rules)
-        _write(root / "locales" / "zz" / "rules.yaml", zz_rules)
+        _two_locale_project(root)
         index_path = root / "out" / "index.json"
 
-        # Silence the resolver's own progress chatter so it does not interleave
-        # with the harness's pass/FAIL lines.
+        # Silence the resolver's progress chatter so it does not interleave with
+        # the harness's pass/FAIL lines.
         with contextlib.redirect_stdout(io.StringIO()):
             rc = resolve_mod.main(
-                [
-                    "--all",
-                    "--base-file",
-                    str(root / "base.yaml"),
-                    "--locales-dir",
-                    str(root / "locales"),
-                    "--retrospectives-dir",
-                    str(root / "retrospectives"),  # absent; resolver tolerates
-                    "--schema-dir",
-                    str(SCHEMA_DIR),
-                    "--index-path",
-                    str(index_path),
-                    "--project-root",
-                    str(root),
-                ]
+                ["--all", *_project_args(root), "--index-path", str(index_path)]
             )
         if rc != 0:
             return False, f"--all exited {rc} (expected 0)"
@@ -284,23 +293,12 @@ def _all_union_test() -> tuple[bool, str]:
                 f"--all index is not a union: missing {sorted(missing)} "
                 f"(got {sorted(ids)}) — last-write-wins regression",
             )
+
         # Single-locale must still write only that locale's index.
         single_path = root / "out" / "single.json"
         with contextlib.redirect_stdout(io.StringIO()):
             rc = resolve_mod.main(
-                [
-                    "aa",
-                    "--base-file",
-                    str(root / "base.yaml"),
-                    "--locales-dir",
-                    str(root / "locales"),
-                    "--schema-dir",
-                    str(SCHEMA_DIR),
-                    "--index-path",
-                    str(single_path),
-                    "--project-root",
-                    str(root),
-                ]
+                ["aa", *_project_args(root), "--index-path", str(single_path)]
             )
         if rc != 0:
             return False, f"single-locale exited {rc} (expected 0)"
@@ -312,6 +310,72 @@ def _all_union_test() -> tuple[bool, str]:
             )
         if "rule.aa-only" not in single_ids:
             return False, "single-locale index missing its own id (rule.aa-only)"
+    return True, "ok"
+
+
+def _all_validate_only_no_write_test() -> tuple[bool, str]:
+    """`--all --validate-only` must resolve cleanly but write NO index file."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _two_locale_project(root)
+        index_path = root / "out" / "index.json"
+        # validate-only dumps the merged tree to stdout and the summary to
+        # stderr, so silence both to keep the harness output clean.
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            rc = resolve_mod.main(
+                [
+                    "--all",
+                    "--validate-only",
+                    *_project_args(root),
+                    "--index-path",
+                    str(index_path),
+                ]
+            )
+        if rc != 0:
+            return False, f"--all --validate-only exited {rc} (expected 0)"
+        if index_path.exists():
+            return False, "index was written under --validate-only (expected none)"
+    return True, "ok"
+
+
+def _all_collision_test() -> tuple[bool, str]:
+    """A genuine cross-locale id collision while building the --all union must
+    exit 1 cleanly and write NO (partial) index.
+
+    A natural collision is hard to author — a record's (kind, key) derives from
+    its id — so we inject one by monkeypatching _accumulate_records to raise the
+    same IdError the union build raises on a true clash, and assert main()
+    surfaces it as a clean failure rather than a traceback or a corrupt index.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _two_locale_project(root)
+        index_path = root / "out" / "index.json"
+
+        original = resolve_mod._accumulate_records
+
+        def _boom(idx_out, records):  # noqa: ANN001
+            raise resolve_mod.IdError("id collision: injected by _all_collision_test")
+
+        resolve_mod._accumulate_records = _boom
+        try:
+            with (
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                rc = resolve_mod.main(
+                    ["--all", *_project_args(root), "--index-path", str(index_path)]
+                )
+        finally:
+            resolve_mod._accumulate_records = original
+
+        if rc != 1:
+            return False, f"--all with id collision exited {rc} (expected 1)"
+        if index_path.exists():
+            return False, "index written despite a collision (should be absent)"
     return True, "ok"
 
 
@@ -333,15 +397,21 @@ def main(argv: list[str]) -> int:
         print(f"  {'pass' if ok else 'FAIL'} {fixture_dir.name}: {msg}")
         passed, failed = (passed + 1, failed) if ok else (passed, failed + 1)
 
-    # Programmatic (non-fixture) checks. The --all union test builds its own
-    # temp tree, so it has no fixtures/ entry. Run unless a target filter that
-    # excludes it was given.
-    if not targets or "all-union" in targets:
+    # Programmatic (non-fixture) checks. Each builds its own temp tree, so they
+    # have no fixtures/ entry. Run unless a target filter excludes them by name.
+    programmatic = [
+        ("all-union", _all_union_test),
+        ("all-validate-only-no-write", _all_validate_only_no_write_test),
+        ("all-collision-clean-exit", _all_collision_test),
+    ]
+    for name, fn in programmatic:
+        if targets and name not in targets:
+            continue
         try:
-            ok, msg = _all_union_test()
+            ok, msg = fn()
         except Exception as exc:  # noqa: BLE001
             ok, msg = False, f"unexpected error: {type(exc).__name__}: {exc}"
-        print(f"  {'pass' if ok else 'FAIL'} all-union: {msg}")
+        print(f"  {'pass' if ok else 'FAIL'} {name}: {msg}")
         passed, failed = (passed + 1, failed) if ok else (passed, failed + 1)
 
     print()


### PR DESCRIPTION
## Summary
Adds the ADR directory, the first real locale back-port (French), and a SPEC-alignment fix to the resolver's emit path.

## Changes
- **ADR directory** (`fee8483`) — `docs/architecture/decision-records/` (process README + `adr-000` template), modeled on the onetimesecret app repo.
- **Backfill procedure** (`4230963`) — `authoring/backfill-locale.md`: what makes a locale *resolved-only-ready* (non-empty `register` + `glossary`, lint green, sign-off).
- **French back-port** (`f2f9bda`) — `locales/fr/` (inherits `base`) + `locales/fr_CA/` (inherits `fr`) register/glossary/rules. Both resolve + lint clean (0 findings). **AGENT-AUTHORED — requires native-speaker sign-off** on register form, forbidden tokens, and glossary targets/examples.
- **Resolver emit path** (`73a5c38`) — markdown now emitted under `guides/for-translators/<locale>.md` per SPEC §2.3 (was `for-translators/`), so a single `--emit-dir locales` lands both artifacts in their canonical homes. 11/11 resolver tests pass.

## Remaining / follow-ups
- Native-speaker sign-off on `fr`/`fr_CA`.
- **Bug found:** `resolve.py --all` writes `resolver/index.json` per-locale (last-write-wins) instead of a global union, so the committed index can't yet carry fr/fr_CA ids without dropping de_AT's. Index left unchanged here; fix is separate.
- Pairs with the onetimesecret PR (slash commands consume the resolved artifacts this produces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvBaGsTCowp2apUgFzZHpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvBaGsTCowp2apUgFzZHpd)_