### PR TITLE
Fix locale discovery to skip non-translation helper directories

### DIFF
--- a/locales/scripts/backfill-baselines.py
+++ b/locales/scripts/backfill-baselines.py
@@ -18,6 +18,7 @@ Usage (from the translation-rules repo root):
 
 Verify after:  uv run resolver/resolve.py <L> --lint --validate-only
 """
+
 from __future__ import annotations
 
 import subprocess

--- a/resolver/resolve.py
+++ b/resolver/resolve.py
@@ -537,11 +537,15 @@ def _resolve_source_commit(repo_root: Path, override: str | None) -> str:
 
 
 def _discover_locales(locales_dir: Path) -> list[str]:
+    # A locale dir is one that actually carries leaf YAML (rules/register/
+    # glossary). Skip helper dirs that live under locales/ but hold tooling
+    # rather than translations (e.g. locales/scripts/) — otherwise --all would
+    # try to resolve them and trip the "no YAML files found" guard with exit 2.
     return (
         sorted(
             p.name
             for p in locales_dir.iterdir()
-            if p.is_dir() and not p.name.startswith(".")
+            if p.is_dir() and not p.name.startswith(".") and any(p.glob("*.yaml"))
         )
         if locales_dir.exists()
         else []


### PR DESCRIPTION
## Summary
Updated the locale discovery logic to properly filter out helper directories (like `locales/scripts/`) that contain tooling rather than translation files, preventing resolution errors when using the `--all` flag.

## Key Changes
- Modified `_discover_locales()` in `resolver/resolve.py` to check for the presence of YAML files (*.yaml) when identifying valid locale directories
- Added explanatory comment documenting why helper directories need to be excluded
- Fixed a formatting issue in `locales/scripts/backfill-baselines.py` by adding a blank line after the docstring

## Implementation Details
The locale discovery now uses `any(p.glob("*.yaml"))` to verify that a directory actually contains translation files (rules, register, or glossary YAML files) before including it in the list of locales. This prevents the resolver from attempting to process helper directories and triggering the "no YAML files found" guard with exit code 2 when running with the `--all` flag.

https://claude.ai/code/session_012vePrnWENTMVxqw13TeieF