### PR TITLE
Clarity: plain-language README + SPEC §2 architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,65 @@
 # translation-rules
 
-Authority repo for translation guidance — the rules, registers, and glossaries
-that the companion app repo (`onetimesecret/onetimesecret`) consumes as
-generated artifacts. Its job is to prevent the change-log-as-guidance failure
-mode: only schema-validated, human-authored YAML can bind translator behavior.
+This repo defines the translation rules for Onetime Secret — which register
+(formal or informal address), which terms to use for which concepts, and which
+words are forbidden — and enforces them mechanically in the app repo's CI.
+
+**The problem it solves.** In April 2026, the de_AT (Austrian German) locale
+was silently flipped from formal (`Sie`) to informal (`du`) across email and UI
+strings. The cause: an agent read a conversational change-log as prescriptive
+guidance. This repo makes that class of error impossible by requiring all
+binding guidance to live in structured YAML that cites an accepted source,
+passes schema and reference validation, and is CI-enforced — so a rule can
+never originate from unreviewed prose, whoever or whatever drafts it.
+
+**How it works.** Rules live as structured YAML in `rules/locales/<locale>/`,
+drafted from accepted sources — in practice by an agent — and audited by a
+maintainer, never free-written. A resolver reads those files, validates them,
+and emits two artifacts per locale: a human-readable guide
+(`for-translators/<locale>.md`) and a machine-readable model
+(`.resolved/<locale>.json`). The app repo consumes those artifacts and runs a
+CI gate that rejects translation PRs containing forbidden tokens.
+
+**Glossary of terms used in this repo:**
+- *Register* — formality level (e.g. formal `Sie` vs informal `du` in German).
+- *Merge* — the inheritance chain (de_AT → de → base) collapsed into one flat rule set.
+- *Resolved* — merged, with every cross-reference verified to exist.
+- *Baseline* — a git commit SHA pinned as the last known-good state for a locale.
+
+**Authoring flow — how a rule gets from YAML into enforcement:**
+
+```
+  this repo                          app repo (onetimesecret)
+  ─────────────────────────────      ──────────────────────────────────────
+  rules/locales/de_AT/
+    register.yaml  ─┐
+    rules.yaml     ─┤─► resolver ──► for-translators/de_AT.md   (human guide)
+    glossary.yaml  ─┘                .resolved/de_AT.json        (agent context)
+  rules/locales/de/                         │
+    rules.yaml ────────────────────── submodule + CI gate
+  rules/base.yaml                           │
+                                            ▼
+                                   PR touching de_AT strings?
+                                   forbidden token found → FAIL
+```
+
+**Inheritance — how de_AT gets its rules:**
+
+```
+  rules/base.yaml    universal rules (brand names, interpolation, pluralization...)
+      │
+  rules/locales/de/  German-specific rules (formal Sie form)
+  rules.yaml
+      │
+  rules/locales/de_AT/  Austrian overrides + register lock + glossary
+  rules.yaml
+  register.yaml      form: formal, pronoun: Sie, forbidden: [du, dein, deine...]
+  glossary.yaml      secret object → Geheimnis / secret message → Nachricht
+```
+
+**The end-to-end picture** — the authoring→enforcement loop, the agent/human
+split, the authoring discipline, and decide-once enforcement — is diagrammed in
+[`SPEC.md`](SPEC.md) §2 (Target Architecture).
 
 **Design, rationale, and the current state of every gate live in
 [`SPEC.md`](SPEC.md).** This README documents only the contract the app repo

--- a/SPEC.md
+++ b/SPEC.md
@@ -28,6 +28,65 @@ The single smallest implementation that would have blocked the 2026-04-12 de_AT 
 
 ## 2. Target Architecture
 
+**The loop, end to end.** Rules are authored here, compiled to enforceable artifacts, and consumed by translation agents in the app repo; the human role is audit, not authorship. These three diagrams are the conceptual model — §2.1–§2.4 specify each stage.
+
+```
+  SOURCES — already decided, frozen            ROLES
+  ─────────────────────────────────           ──────────────────────────────────
+  _references/local-guides/*.md  ┐  provenance
+  shipped JSON @ baseline commit ┘──────────►  ① agents author rules · this repo
+                                                  rules/base.yaml · rules · register · glossary
+                                                  every value cites a source
+                                                       │
+                              resolve.py — closure + schema; dangling ref → REJECTED
+                                                       │  green
+                                                       ▼
+                                               ② artifacts
+                                                  .resolved/<loc>.json     (agent context)
+                                                  for-translators/<loc>.md (human guide)
+                                                       │  vendored as submodule, pinned by SHA
+                                                       ▼
+                                               ③ agents translate · app repo
+                                                  consume .resolved → write content/<loc>/*.json
+                                                       │  every content PR
+                                                       ▼
+                                               ④ bin/lint-register gate (live)
+                                                  forbidden token → FAIL · clean → merge
+
+  Humans don't author ①–④. The human role is QC: review the agent's reasoning,
+  ask it to explain, triangulate the provenance — then accept, probe, or reject.
+```
+
+**Inside ① — what makes agent-authoring safe.** The schema gate (§2.2) checks *structure*, not *sourcing*: a well-formed `du` rule passes schema. The barrier against a well-formed-but-wrongly-sourced rule is the authoring discipline — mandatory provenance plus maintainer audit — not the author's humanity.
+
+```
+  agent drafts a rule
+       │
+       ▼
+  [ cites accepted provenance? ]──no─► reject   (no source = no rule;
+       │ yes                                      never from running prose)
+       ▼
+  [ closes? — resolve.py ]──────no─► reject   (dangling ref / bad schema)
+       │ yes
+       ▼
+  [ survives maintainer QC? ]───no─► back to agent   (can't defend it → no ship)
+       │ yes
+       ▼
+  minted · committed ──────────────────────────────────────────────► ②
+```
+
+**Decide once, enforce forever.** A rule authored once binds every later translation task through the register gate (§2.4); the decision is not re-litigated per task.
+
+```
+  one rule, authored once (provenance: de.md's du/Sie success row):
+     register.de_AT.formality  →  lock Sie / Ihr,  forbid du-form
+
+  …then applied to every later translation task automatically, no one re-asked:
+     "Your secret has been created."  (de_AT)
+        ├─ agent writes  "Dein Geheimnis…"  ─► lint ─► ✗  du-form 'Dein' forbidden
+        └─ agent writes  "Ihr Geheimnis…"   ─► lint ─► ✓  merges
+```
+
 ### 2.1 Directory layout
 
 ```
@@ -84,7 +143,7 @@ Two `_archive/` directories with distinct purposes. `rules/retrospectives/_archi
 
 ### 2.2 File formats
 
-**YAML as source, JSON Schema as contract.** Schema is authoritative; YAML is the human-authored surface validated at resolver entry. Alternatives rejected: JSON-as-source (too noisy for prose fields), YAML-without-schema (implicit coercion is exactly the drift vector the system exists to prevent).
+**YAML as source, JSON Schema as contract.** Schema is authoritative; YAML is the authored surface validated at resolver entry. Alternatives rejected: JSON-as-source (too noisy for prose fields), YAML-without-schema (implicit coercion is exactly the drift vector the system exists to prevent).
 
 Minimal `register.yaml`:
 
@@ -162,7 +221,7 @@ declined_index: [...]                        # per-locale decline summaries
 anti_patterns_ref: [...]
 ```
 
-The `rules`/`context`/`rationale` partition is the surface-level cue that prevents the change-log-as-guidance failure. Only `rules` and `register` bind behavior. Conversational prose cannot reach the `rules` partition without passing through a human-authored YAML file with a schema.
+The `rules`/`context`/`rationale` partition is the surface-level cue that prevents the change-log-as-guidance failure. Only `rules` and `register` bind behavior. Conversational prose cannot reach the `rules` partition without passing through a schema-validated, provenance-citing YAML file, audited at merge.
 
 ### 2.4 CI gates
 


### PR DESCRIPTION
## Summary

**PR B** of the rules-root stack — the "clarity" documentation work that gives `fix/clarity` its name, finally landed. Stacked on **#33** (PR A, the structural reorg); this PR's diff is README/SPEC prose only. Retarget to `main` once #33 merges.

The plain-language prose and ASCII architecture diagrams were authored on `fix/clarity` but never merged (the branch went stale). Rather than merge it — which would delete the `docs/agent-authored-rules.md` (#26) and `Reviews vs retrospectives` (#28) blocks that postdate it — the content was **ported by hand**, reconciled onto the current tree and re-rooted to the rules-root layout.

## Changes (markdown only — README.md, SPEC.md)

**README.md** — replaces the terse/jargon opening with:
- a one-line "what it is", **The problem it solves** (the 2026-04 de_AT flip; "a rule can never originate from unreviewed prose, whoever or whatever drafts it"), **How it works**, and a **Glossary** (Register / Merge / Resolved / Baseline);
- **Diagram A** (authoring flow) and **Diagram B** (inheritance), in new paths (`rules/locales/…`, `rules/base.yaml`, `lib/resolver/…`);
- a pointer to SPEC §2.

**SPEC.md** — under §2, before §2.1, three conceptual diagrams + framing: **"The loop, end to end"**, **"Inside ① — what makes agent-authoring safe"**, **"Decide once, enforce forever"** (this-repo paths re-rooted; app-repo artifact identities `.resolved/<loc>.json` / `for-translators/<loc>.md` / `content/<loc>/*.json` kept as consumed-artifact names). Plus the authoring-wording fixes: §2.2 "human-authored surface" → "authored surface"; §2.3 "…without passing through a **schema-validated, provenance-citing YAML file, audited at merge.**"

## Preserved (not deleted)

- README: the `docs/agent-authored-rules.md` design-notes link (#26), the `Consuming this repo` contract section, and the `Reviews vs retrospectives` section with its `_references/reviews/README.md#review-vs-retrospective` link (#28).
- SPEC: the Status-block `Related (non-binding)` #26 paragraph.

## Validation

Markdown-only, so behavior is unchanged — full gate suite green at parity: schema 34 / inheritance 9 / resolver 14 / archive 20 / retro 19 / review 23; `resolve --all --lint` 0 findings; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfrZBJpaWnM9YR5bZztAuR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfrZBJpaWnM9YR5bZztAuR)_