### PR TITLE
Add ADR-003/004/005: cross-repo translation architecture (authority, pinning, no-vendor)

### DIFF
--- a/docs/architecture/decision-records/adr-003-single-authority.md
+++ b/docs/architecture/decision-records/adr-003-single-authority.md
@@ -1,0 +1,55 @@
+---
+id: 003
+status: accepted
+title: ADR-003: translation-rules is the single authority for translation knowledge and derivation
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-22
+
+## Context
+The translation infrastructure serves multiple consumers: the application
+(`onetimesecret`), the docs site, and potentially marketing. Each consumer needs
+two things — the domain *knowledge* (locale YAML: registers, glossaries, rules)
+and the *derivation logic* (the resolver that turns that knowledge into usable
+per-locale output). This ADR settles where those two things live and who owns
+them.
+
+It formalizes a stance the repo already took inline (SPEC §2.3 / §2.4) once that
+stance became load-bearing for the decisions in ADR-004 and ADR-005.
+
+## Decision
+Both the knowledge (YAML source) and the derivation logic (resolver) live in
+translation-rules. Consumers own neither. A consumer references translation-rules
+and derives its outputs from it.
+
+Why: derivation is tightly coupled to the knowledge schema, and the relationship
+is one-to-many. Centralizing both means a schema or rule change happens once, in
+one place, and propagates outward — rather than requiring coordinated edits
+across every consumer.
+
+## Alternatives considered
+**Knowledge here, derivation in each consumer.** Each repo implements its own
+resolver against shared YAML. Rejected: derivation is tightly coupled to the
+schema, so multiple resolvers drift, and a schema change forces coordinated
+updates across every consumer.
+
+**No single authority.** Each consumer maintains its own knowledge and derivation
+independently. Rejected: this is the state that produced 18k-line vendored diffs
+and quality signal buried in noise — duplication with no coordination.
+
+**Split knowledge by domain.** App-specific translations in the app repo,
+docs-specific in the docs repo, shared terms in translation-rules. Rejected: the
+boundary between "shared" and "domain-specific" shifts over time, and the
+resolver needs a coherent corpus to produce consistent output.
+
+## Consequences
+- Consumers need a mechanism to reference translation-rules at a specific point
+  in time — see **ADR-004** (pin to a commit).
+- Consumers must not vendor derived output, since they don't own the derivation —
+  see **ADR-005** (derive on demand).
+- Changes to knowledge or derivation logic happen in one place and propagate
+  outward through the pin.

--- a/docs/architecture/decision-records/adr-004-consumers-pin-to-commit.md
+++ b/docs/architecture/decision-records/adr-004-consumers-pin-to-commit.md
@@ -1,0 +1,58 @@
+---
+id: 004
+status: accepted
+title: ADR-004: Consumers pin translation-rules to a specific commit
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-22
+
+## Context
+ADR-003 makes consumers derive their output from translation-rules. A consumer
+must therefore select *which version* of the authority it derives against.
+translation-rules is one-to-many (app, docs, marketing) and evolves on its own
+timeline. Two options: float against a moving ref (e.g. `main`), or pin to a
+specific commit.
+
+## Decision
+Each consumer references translation-rules at a pinned commit SHA, not a floating
+branch.
+
+Why pinning over floating: it decouples each consumer's CI and translation runs
+from the authority's timeline. A change upstream cannot make an *unrelated*
+consumer's gate fail, nor silently alter a translation run; adopting new
+governance becomes a deliberate, reviewable pin bump. A derivation at a pin is a
+pure function of that commit, so "what governance produced this output?" is always
+answerable by SHA. This matches the stance already recorded inline for the
+register gate (SPEC §2.4: a read-only pinned checkout, "not a submodule").
+
+The pin is the *only* translation-rules state a consumer commits — ADR-005 keeps
+the derived output itself out. It must live in a single canonical location per
+consumer: the app already drifted to two gates pinned at two different SHAs, and
+consolidating to one pin is what prevents that.
+
+## Trade-offs
+- **We lose**: automatic propagation of upstream changes — a consumer must bump to
+  adopt new governance.
+- **We gain**: decoupling (unrelated PRs aren't hostage to upstream timing) and
+  reproducibility (a SHA names exactly the governance used).
+
+## Consequences
+### Negative
+- A pin goes stale if nothing bumps it. Hand-editing a SHA is not a sustainable
+  workflow and already drifted in practice — so the bump is automated (see
+  Implementation Notes).
+
+## Implementation Notes
+
+### Automated pin bump (2026-06-22)
+The pin is kept fresh by automation, not by hand: a scheduled job / Renovate-style
+bot opens a "bump translation-rules → `<sha>`" PR when the authority advances, and
+a human merges it on green. The *decision* in this ADR is pinning; the automation
+is how the pin stays current without manual toil. Floating would remove the bump
+step entirely but is rejected for the decoupling reason above. The automation is
+not independently reversible from the pin decision, so it is recorded here rather
+than as its own ADR.

--- a/docs/architecture/decision-records/adr-005-no-vendored-derived-output.md
+++ b/docs/architecture/decision-records/adr-005-no-vendored-derived-output.md
@@ -1,0 +1,68 @@
+---
+id: 005
+status: accepted
+title: ADR-005: Consumers do not vendor derived output
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-22
+
+## Context
+ADR-003 puts derivation in the authority; ADR-004 pins the version a consumer
+derives against. One question remains: does a consumer commit the resolver's
+*output* — `.resolved/<locale>.json` and the generated translator guides — into
+its own repo, or derive it on demand?
+
+The current app state vendors it. A single locale set produced a +14k-line diff,
+and that corpus would be replicated into every consumer.
+
+This ADR revises the earlier inline stance (SPEC §2.3 "Output commit policy:
+... committed to the app repo, not CI-generated-only"), which the ADR README
+explicitly anticipates revisiting as a numbered record.
+
+## Decision
+Consumers do not commit derived output. A consumer commits only the pin (ADR-004)
+and derives `.resolved` / guides on demand — in the translation orchestration and
+in CI — from a read-only checkout at the pin, into an ignored or temporary
+location.
+
+Why: the derived corpus is a cache, not a source. Nothing in a consumer's build or
+runtime reads it; the only readers are translation-time agents and CI, both of
+which can derive at the pin. The app already proves the pattern —
+`validate-register.yml` runs the register gate from a read-only pinned checkout
+and commits nothing. Vendoring instead copies the authority's output into every
+consumer: N caches to keep fresh, N× the diff noise, and the actual quality signal
+(the register/glossary/rule decisions, reviewed in translation-rules YAML) diluted
+into thousands of unreviewable generated lines in repos whose reviewers don't own
+locale knowledge.
+
+The "committed copy is an anti-tamper baseline" argument (SPEC §2.4) does not
+survive: output that is never written to disk cannot be hand-edited, and
+regenerate-from-scratch is the recovery. The guarantee is preserved more cheaply
+by "agents read only freshly-derived output; CI regenerates; the authority's own
+validation is the firewall."
+
+## Trade-offs
+- **We lose**: in-repo browsability of guides, and the byte-for-byte freshness
+  gate.
+- **We gain**: a near-zero consumer footprint, no cache to rot, and review
+  concentrated in the authority.
+
+## Consequences
+### Positive
+- Onboarding a consumer is "add a pin + call the shared derive step," not "vendor
+  a corpus." The current +14k app branch collapses to a pin + gitignore + a derive
+  step.
+
+### Negative
+- The orchestration and CI gain a dependency on a translation-rules checkout + the
+  resolver toolchain at derive time (already true for `validate-register.yml`).
+- The §2.4 byte-hash freshness gate is retired and must be replaced
+  (regenerate-in-CI + assert-pin-is-current); tracked as a separate open item.
+
+### Neutral
+- Separable from ADR-004: one could pin-and-vendor, or float-and-derive. This ADR
+  fixes only the vendor axis.


### PR DESCRIPTION
## Summary

Three foundational ADRs formalizing the cross-repo translation architecture settled in discussion. **Docs-only — no code or behavior change.**

- **ADR-003** — translation-rules is the single authority for both the *knowledge* (locale YAML) and the *derivation* (resolver); consumers own neither.
- **ADR-004** — consumers pin translation-rules to a specific commit (pinning over floating, for decoupling + reproducibility); the bump is automated, not hand-maintained.
- **ADR-005** — consumers do **not** vendor derived output; they commit only the pin and derive `.resolved`/guides on demand. Revises the inline SPEC §2.3 "Output commit policy".

Numbered 003/004/005 because 000 (template), 001 (glossary inheritance), and 002 (rules-root layout, merged via #33) were already taken. ADR-003 cross-references 004/005; each ADR follows the house format (one decision, courteous length).

## Open items (tracked as issues)

- #35 — one-to-many delivery mechanism (shared reusable workflow vs per-repo)
- #36 — replace the byte-hash freshness gate (regenerate-in-CI + pin-freshness)
- #37 — guide handling under the no-vendor model
- #38 — implement the automated pin bump (ADR-004)
- onetimesecret#3510 — migrate the app to the no-vendor model (ADR-005)

## Follow-up

ADR-005 supersedes the inline SPEC §2.3 "artifacts committed to the app repo, not CI-generated-only" stance; the SPEC prose should be repointed at ADR-005 in a separate docs change (kept out of this PR to leave it purely additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186q12mEGqivLw8aKFLuHLH

---
_Generated by [Claude Code](https://claude.ai/code/session_0186q12mEGqivLw8aKFLuHLH)_