### PR TITLE
i18n-arch: shared derive composite action (#35) + ADR-006/007

### DIFF
--- a/.github/actions/derive/action.yml
+++ b/.github/actions/derive/action.yml
@@ -1,0 +1,166 @@
+# The single shared "derive step" every consumer calls (ADR-003, ADR-005,
+# ADR-006). translation-rules owns both the knowledge (rules/) and the
+# derivation (lib/resolver); consumers neither vendor the output nor copy the
+# toolchain — they pin this repo and call this action. One implementation here,
+# N callers.
+#
+# A consumer uses it read-only at its canonical pin:
+#
+#   - uses: onetimesecret/translation-rules/.github/actions/derive@<pin>
+#     with:
+#       ref: <pin>            # SAME commit as @<pin> above
+#       locales: de_AT fr_CA  # or "all"
+#       emit-dir: .derived    # gitignored — a cache, never committed (ADR-005)
+#
+# The output is byte-reproducible for a given pin: _meta.source_commit is the
+# pin and _meta.generated_at is the pin's committer date (UTC), so a freshness
+# gate can regenerate and diff (replaces the retired SPEC §2.4 byte-hash gate;
+# see ADR-005 and issue #36).
+
+name: 'Derive translation governance'
+description: >-
+  Read-only derive of resolved locale governance (.resolved JSON + translator
+  guides) from onetimesecret/translation-rules at a pinned commit.
+
+inputs:
+  ref:
+    description: >-
+      translation-rules commit SHA (or tag) to derive at — the consumer's
+      canonical pin. Use the SAME ref you pinned `uses: .../derive@<ref>` to,
+      so the action code and the governing data are one commit.
+    required: true
+  locales:
+    description: >-
+      Space- or comma-separated locale codes to derive (e.g. "de_AT fr_CA"),
+      or "all" for every governed locale.
+    required: false
+    default: 'all'
+  emit:
+    description: 'Comma-separated artifacts to write: md,json.'
+    required: false
+    default: 'md,json'
+  lint:
+    description: >-
+      Run the resolver step-6 lint and fail (non-zero) on error findings.
+    required: false
+    default: 'true'
+  emit-dir:
+    description: >-
+      Directory (relative to the caller workspace) to write derived output into:
+      <emit-dir>/.resolved/<locale>.json and
+      <emit-dir>/guides/for-translators/<locale>.md. A derive cache — gitignore
+      it; never commit it (ADR-005).
+    required: false
+    default: '.derived'
+  checkout-path:
+    description: 'Where to check out the authority (read-only).'
+    required: false
+    default: '.translation-rules'
+
+outputs:
+  emit-dir:
+    description: 'Absolute path of the directory containing the derived .resolved/ and guides/.'
+    value: ${{ steps.derive.outputs.emit-dir }}
+  source-commit:
+    description: 'The resolved translation-rules commit the output was derived at.'
+    value: ${{ steps.resolve-ref.outputs.sha }}
+  generated-at:
+    description: 'The deterministic _meta.generated_at stamped into the output (committer date of the pinned commit, UTC).'
+    value: ${{ steps.resolve-ref.outputs.generated-at }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check out translation-rules (authority, read-only) at the pin
+      uses: actions/checkout@v4
+      with:
+        repository: onetimesecret/translation-rules
+        ref: ${{ inputs.ref }}
+        path: ${{ inputs.checkout-path }}
+        persist-credentials: false
+
+    - name: Resolve pin -> SHA + deterministic generated-at
+      id: resolve-ref
+      shell: bash
+      env:
+        # Pass caller input through env, never interpolated into the script body
+        # — avoids the ${{ }}-in-run: script-injection shape.
+        CHECKOUT_PATH: ${{ inputs.checkout-path }}
+      run: |
+        set -euo pipefail
+        rules="$CHECKOUT_PATH"
+        sha="$(git -C "$rules" rev-parse HEAD)"
+        # Deterministic stamp: the pinned commit's committer date in UTC.
+        # TZ=UTC + --date=format-local avoids %cI git-version skew, so the same
+        # pin always yields byte-identical output (freshness-gate friendly).
+        gen_at="$(TZ=UTC git -C "$rules" show -s \
+          --date=format-local:'%Y-%m-%dT%H:%M:%S+00:00' --format=%cd HEAD)"
+        echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+        echo "generated-at=${gen_at}" >> "$GITHUB_OUTPUT"
+        echo "Derive @ ${sha} (generated_at=${gen_at})"
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install pinned resolver deps
+      shell: bash
+      run: |
+        set -euo pipefail
+        # In lockstep with the authority's schema-validation.yml and the
+        # resolver PEP-723 header (lib/resolver/resolve.py).
+        python -m pip install --upgrade pip
+        python -m pip install \
+          "jsonschema>=4.21,<5" \
+          "referencing>=0.32,<1" \
+          "pyyaml>=6,<7"
+
+    - name: Derive (.resolved + guides) at the pin
+      id: derive
+      shell: bash
+      env:
+        DERIVE_LOCALES: ${{ inputs.locales }}
+        DERIVE_EMIT: ${{ inputs.emit }}
+        DERIVE_LINT: ${{ inputs.lint }}
+        DERIVE_EMIT_DIR: ${{ inputs.emit-dir }}
+        DERIVE_SOURCE_COMMIT: ${{ steps.resolve-ref.outputs.sha }}
+        DERIVE_GENERATED_AT: ${{ steps.resolve-ref.outputs.generated-at }}
+        CHECKOUT_PATH: ${{ inputs.checkout-path }}
+      run: |
+        set -euo pipefail
+        rules="$CHECKOUT_PATH"
+        # Resolve emit-dir to an absolute path in the CALLER workspace, so the
+        # resolver (run from inside the authority checkout) writes back out to it.
+        emit_dir="$(mkdir -p "$DERIVE_EMIT_DIR" && cd "$DERIVE_EMIT_DIR" && pwd)"
+
+        lint_flag=()
+        [ "$DERIVE_LINT" = "true" ] && lint_flag=(--lint)
+
+        common=(
+          --emit="$DERIVE_EMIT"
+          --emit-dir "$emit_dir"
+          --source-commit "$DERIVE_SOURCE_COMMIT"
+          --generated-at "$DERIVE_GENERATED_AT"
+          "${lint_flag[@]}"
+        )
+
+        # The resolver resolves rules/ paths relative to its own CWD; its
+        # defaults already point at the rules-root layout (rules/locales,
+        # rules/base.yaml), so run it from inside the authority checkout.
+        if [ "${DERIVE_LOCALES,,}" = "all" ]; then
+          ( cd "$rules" && python lib/resolver/resolve.py --all "${common[@]}" )
+        else
+          # Accept comma OR space separated.
+          read -r -a locs <<< "${DERIVE_LOCALES//,/ }"
+          for loc in "${locs[@]}"; do
+            [ -n "$loc" ] || continue
+            # `--` ends option parsing so a locale starting with '-' can't be
+            # mistaken for a flag; the resolver takes one positional (locale).
+            ( cd "$rules" && python lib/resolver/resolve.py "${common[@]}" -- "$loc" )
+          done
+        fi
+
+        echo "emit-dir=${emit_dir}" >> "$GITHUB_OUTPUT"
+        echo "Derived into ${emit_dir}:"
+        ls -R "$emit_dir" || true

--- a/docs/architecture/decision-records/adr-006-shared-derive-action.md
+++ b/docs/architecture/decision-records/adr-006-shared-derive-action.md
@@ -11,22 +11,15 @@ Accepted
 2026-06-25
 
 ## Context
-ADR-003 puts both the knowledge and the derivation in this authority; ADR-005
-says consumers don't vendor the output, they derive on demand at their pin
-(ADR-004). That leaves one open question (issue #35): *how* does the derive step
-reach each consumer? Three consumers are in view (the app, the docs site,
-marketing), and today none of them share derivation — the resolver is only ever
-invoked inline (the app's `resolved-freshness.yml`, this repo's
-`schema-validation.yml`).
-
-The options:
-- **(a) a reusable step published here** that each consumer calls;
-- **(b) each consumer wires its own checkout + resolve** (copy/paste);
-- **(c) this repo publishes resolved artifacts** as a release/package that
-  consumers pull at the pin.
+ADR-003 puts knowledge and derivation in this authority; ADR-005 has consumers
+derive on demand at their pin (ADR-004) instead of vendoring output. Open
+question (#35): *how* does the derive step reach each consumer? Today none share
+it — the resolver is invoked inline in the app's `resolved-freshness.yml` and
+this repo's `schema-validation.yml`. Three consumers are in view (app, docs,
+marketing).
 
 ## Decision
-Publish the derive step as a **reusable composite GitHub Action** in this repo at
+Publish the derive step as a **reusable composite GitHub Action** at
 `.github/actions/derive`. A consumer pins and calls it read-only:
 
 ```yaml
@@ -37,55 +30,19 @@ Publish the derive step as a **reusable composite GitHub Action** in this repo a
     emit-dir: .derived      # gitignored cache, never committed (ADR-005)
 ```
 
-The action checks out this repo read-only at `ref`, installs the pinned resolver
-deps, and runs `lib/resolver/resolve.py` — emitting `.resolved/<locale>.json` and
-`guides/for-translators/<locale>.md` into a caller-side cache, with
-`_meta.source_commit` = the pin and `_meta.generated_at` = the pin's committer
-date (UTC) so output is byte-reproducible for a given pin.
+It checks out this repo read-only at `ref`, runs `lib/resolver/resolve.py`, and
+emits `.resolved/<locale>.json` + `guides/for-translators/<locale>.md` into a
+caller-side cache, stamping `_meta.source_commit` = the pin and
+`_meta.generated_at` = the pin's committer date (UTC) so output is
+byte-reproducible per pin.
 
-Why a composite action over the alternatives:
-- **vs (b) copy/paste:** one implementation, N callers. The resolver invocation,
-  dep pins, and the deterministic-stamp logic live once, here, next to the schema
-  they derive from. Copy/paste is exactly the drift ADR-003 exists to prevent —
-  every consumer would carry a private, silently-aging derive recipe.
-- **vs (c) published artifact:** publishing a resolved corpus re-creates a
-  vendored-output coupling in a new place — a second freshness surface to keep in
-  sync, and the same "derived corpus masquerading as a source" problem ADR-005
-  rejects, just hosted instead of committed. The action keeps the cache ephemeral
-  and the pin the only shared state.
+A composite action — not per-consumer copy/paste (the drift ADR-003 exists to
+prevent: every consumer would carry a private, aging derive recipe), and not a
+published resolved artifact (that re-creates a vendored-output coupling in a new
+hosted place, which ADR-005 rejects). Composite rather than `workflow_call`
+because derivation is a step *inside* a consumer's existing job (its gate, its
+translation run), which needs the output in that job's workspace.
 
-A composite action (not a `workflow_call` reusable workflow) because derivation
-is a *step inside* a consumer's existing job (its CI gate, its translation
-orchestration), not a standalone job — the consumer needs the output in its own
-workspace to act on.
-
-## Trade-offs
-- **We lose:** consumers take a runtime dependency on a translation-rules
-  checkout + a Python resolver toolchain at derive time. The app already runs the
-  resolver in CI today (`resolved-freshness.yml`), and checks out the authority
-  read-only (`validate-register.yml`) — this action just makes that one shared
-  step instead of bespoke per-consumer wiring.
-- **We gain:** the derive recipe is single-sourced and versioned with the data it
-  derives; onboarding a consumer is "pin + call the action."
-
-## Consequences
-### Positive
-- The #36 replacement freshness gate and the #3510 app no-vendor migration both
-  become thin callers of this action rather than bespoke resolver wiring.
-- The action's `ref` input and `@<pin>` ref are the same commit, so "which rules
-  version did this run use" is unambiguous and assertable.
-
-### Negative
-- The action pins `actions/checkout`/`setup-python` by moving major tag (matching
-  this repo's existing style); hardening to SHA pins is a later, separate call.
-
-### Neutral
-- Separable from ADR-005: one could derive-on-demand with copy/paste. This ADR
-  fixes only the *delivery* axis.
-
-## Implementation Notes
-
-### Caller contract (2026-06-25)
-The consumer must pass `ref` equal to the commit it pinned `@` to, and should
-gitignore `emit-dir`. A freshness gate can assert the run used the consumer's
-committed pin by comparing its pin to the action's `source-commit` output.
+Caller contract: pass `ref` equal to the commit you pinned `@` to, and gitignore
+`emit-dir`. A freshness gate asserts the run used the committed pin by comparing
+it to the action's `source-commit` output (#36).

--- a/docs/architecture/decision-records/adr-006-shared-derive-action.md
+++ b/docs/architecture/decision-records/adr-006-shared-derive-action.md
@@ -1,0 +1,91 @@
+---
+id: 006
+status: accepted
+title: ADR-006: Deliver the derive step as a reusable composite action
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-25
+
+## Context
+ADR-003 puts both the knowledge and the derivation in this authority; ADR-005
+says consumers don't vendor the output, they derive on demand at their pin
+(ADR-004). That leaves one open question (issue #35): *how* does the derive step
+reach each consumer? Three consumers are in view (the app, the docs site,
+marketing), and today none of them share derivation — the resolver is only ever
+invoked inline (the app's `resolved-freshness.yml`, this repo's
+`schema-validation.yml`).
+
+The options:
+- **(a) a reusable step published here** that each consumer calls;
+- **(b) each consumer wires its own checkout + resolve** (copy/paste);
+- **(c) this repo publishes resolved artifacts** as a release/package that
+  consumers pull at the pin.
+
+## Decision
+Publish the derive step as a **reusable composite GitHub Action** in this repo at
+`.github/actions/derive`. A consumer pins and calls it read-only:
+
+```yaml
+- uses: onetimesecret/translation-rules/.github/actions/derive@<pin>
+  with:
+    ref: <pin>              # same commit as @<pin>
+    locales: de_AT fr_CA    # or "all"
+    emit-dir: .derived      # gitignored cache, never committed (ADR-005)
+```
+
+The action checks out this repo read-only at `ref`, installs the pinned resolver
+deps, and runs `lib/resolver/resolve.py` — emitting `.resolved/<locale>.json` and
+`guides/for-translators/<locale>.md` into a caller-side cache, with
+`_meta.source_commit` = the pin and `_meta.generated_at` = the pin's committer
+date (UTC) so output is byte-reproducible for a given pin.
+
+Why a composite action over the alternatives:
+- **vs (b) copy/paste:** one implementation, N callers. The resolver invocation,
+  dep pins, and the deterministic-stamp logic live once, here, next to the schema
+  they derive from. Copy/paste is exactly the drift ADR-003 exists to prevent —
+  every consumer would carry a private, silently-aging derive recipe.
+- **vs (c) published artifact:** publishing a resolved corpus re-creates a
+  vendored-output coupling in a new place — a second freshness surface to keep in
+  sync, and the same "derived corpus masquerading as a source" problem ADR-005
+  rejects, just hosted instead of committed. The action keeps the cache ephemeral
+  and the pin the only shared state.
+
+A composite action (not a `workflow_call` reusable workflow) because derivation
+is a *step inside* a consumer's existing job (its CI gate, its translation
+orchestration), not a standalone job — the consumer needs the output in its own
+workspace to act on.
+
+## Trade-offs
+- **We lose:** consumers take a runtime dependency on a translation-rules
+  checkout + a Python resolver toolchain at derive time. The app already runs the
+  resolver in CI today (`resolved-freshness.yml`), and checks out the authority
+  read-only (`validate-register.yml`) — this action just makes that one shared
+  step instead of bespoke per-consumer wiring.
+- **We gain:** the derive recipe is single-sourced and versioned with the data it
+  derives; onboarding a consumer is "pin + call the action."
+
+## Consequences
+### Positive
+- The #36 replacement freshness gate and the #3510 app no-vendor migration both
+  become thin callers of this action rather than bespoke resolver wiring.
+- The action's `ref` input and `@<pin>` ref are the same commit, so "which rules
+  version did this run use" is unambiguous and assertable.
+
+### Negative
+- The action pins `actions/checkout`/`setup-python` by moving major tag (matching
+  this repo's existing style); hardening to SHA pins is a later, separate call.
+
+### Neutral
+- Separable from ADR-005: one could derive-on-demand with copy/paste. This ADR
+  fixes only the *delivery* axis.
+
+## Implementation Notes
+
+### Caller contract (2026-06-25)
+The consumer must pass `ref` equal to the commit it pinned `@` to, and should
+gitignore `emit-dir`. A freshness gate can assert the run used the consumer's
+committed pin by comparing its pin to the action's `source-commit` output.

--- a/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
+++ b/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
@@ -7,61 +7,34 @@ title: ADR-007: Translator guides are derived on demand, not browsed from a host
 ## Status
 Proposed
 
-<!-- Decision content approved by the maintainer (issue #37, 2026-06-25:
-     "local / on-demand only"). Left Proposed pending an explicit accept
-     sign-off per the ADR lifecycle (this repo's ADR STOP-gate). -->
+<!-- Decision approved by the maintainer (#37, 2026-06-25: "local / on-demand
+     only"). Left Proposed pending an explicit accept sign-off. -->
 
 ## Date
 2026-06-25
 
 ## Context
 ADR-005 stops consumers vendoring derived output. That output is two things: the
-machine artifact (`.resolved/<locale>.json`, read by translation-time agents and
-CI) and the human-readable translator guide (`guides/for-translators/<locale>.md`).
-The machine artifact has obvious on-demand readers. The guide raised an open
-question (issue #37): with no committed copy, **where does a human browse the
-current guide?**
-
-Options considered: publish guides from this repo's CI (a docs site / artifact);
-derive them locally on demand only; or keep committing them. The app also still
-carries ~35 hand-authored guides, including legacy-named duplicates of canonical
-ones (`da.md`, `it.md`, `mi.md`, `sv.md`, `zh-cn.md`, `pt-br.md`, `fr.md`).
+machine artifact (`.resolved/<locale>.json`) and the human translator guide
+(`guides/for-translators/<locale>.md`). The machine artifact has obvious
+on-demand readers; the guide raised an open question (#37): with no committed
+copy, where does a human browse the current guide? The app also still carries
+~35 hand-authored guides, including legacy-named duplicates of canonical ones
+(`da.md`, `it.md`, `mi.md`, `sv.md`, `zh-cn.md`, `pt-br.md`, `fr.md`).
 
 ## Decision
 Guides are **derived on demand only** — no hosted browse channel, no committed
-copy. A human who needs to read a guide runs the same derive step CI uses
-(ADR-006's action, or `lib/resolver/resolve.py <locale> --emit=md --emit-dir .derived`
-locally) and reads it from the ignored cache.
+copy. A human reads a guide by deriving it the way CI does (the ADR-006 action,
+or `lib/resolver/resolve.py <locale> --emit=md --emit-dir .derived` locally) and
+opening it from the ignored cache.
 
-Why no hosted channel: a published guides site is a third place the derived
-corpus lives — it ages independently of the pin, needs its own freshness story,
-and re-creates the "browsable copy drifts from source" failure ADR-005 removes.
-The guide is a *view* of the governed YAML; the reviewable source of truth is the
-register/glossary/rules in `rules/locales/<locale>/`, not a rendered guide. The
-small cost is that browsing requires running one command; the saving is one fewer
-corpus to keep fresh.
+A published guides site would be a third place the derived corpus lives, aging
+independently of the pin — the "browsable copy drifts from source" failure
+ADR-005 removes. The reviewable source of truth is the YAML in
+`rules/locales/<locale>/`; the guide is only a rendered view of it. The cost is
+that browsing needs one command; the saving is one fewer corpus to keep fresh.
+If a web view ever becomes a real need, a CI-published artifact can be added
+later without reversing this — it would just be a cache of the same derive.
 
-Consequently the legacy hand-authored guides committed in the app
-(`locales/guides/for-translators/*.md`, including the duplicate pairs above) are
-**retired** as part of the app's no-vendor migration (onetimesecret#3510), not
-migrated.
-
-## Trade-offs
-- **We lose:** zero-setup "open a URL to read the guide." Browsing now needs a
-  checkout + one derive command.
-- **We gain:** no hosted/committed guide corpus to rot; the guide is always
-  exactly the pinned source, never a stale snapshot.
-
-## Consequences
-### Positive
-- The app migration deletes ~35 committed guides outright rather than rehoming
-  them; the guide question stops blocking #3510.
-
-### Negative
-- No at-a-glance web view of a locale's guidance for non-technical reviewers;
-  if that need becomes real, a CI-published artifact can be added later without
-  reversing this decision (it would just be a cache of the same derive).
-
-### Neutral
-- Independent of ADR-006's delivery mechanism: guides would be on-demand-only
-  regardless of how the derive step is delivered.
+Consequently the legacy hand-authored guides in the app (including the duplicate
+pairs above) are **retired**, not migrated, as part of onetimesecret#3510.

--- a/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
+++ b/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
@@ -1,14 +1,11 @@
 ---
 id: 007
-status: proposed
+status: accepted
 title: ADR-007: Translator guides are derived on demand, not browsed from a hosted channel
 ---
 
 ## Status
-Proposed
-
-<!-- Decision approved by the maintainer (#37, 2026-06-25: "local / on-demand
-     only"). Left Proposed pending an explicit accept sign-off. -->
+Accepted
 
 ## Date
 2026-06-25

--- a/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
+++ b/docs/architecture/decision-records/adr-007-guides-derived-on-demand.md
@@ -1,0 +1,67 @@
+---
+id: 007
+status: proposed
+title: ADR-007: Translator guides are derived on demand, not browsed from a hosted channel
+---
+
+## Status
+Proposed
+
+<!-- Decision content approved by the maintainer (issue #37, 2026-06-25:
+     "local / on-demand only"). Left Proposed pending an explicit accept
+     sign-off per the ADR lifecycle (this repo's ADR STOP-gate). -->
+
+## Date
+2026-06-25
+
+## Context
+ADR-005 stops consumers vendoring derived output. That output is two things: the
+machine artifact (`.resolved/<locale>.json`, read by translation-time agents and
+CI) and the human-readable translator guide (`guides/for-translators/<locale>.md`).
+The machine artifact has obvious on-demand readers. The guide raised an open
+question (issue #37): with no committed copy, **where does a human browse the
+current guide?**
+
+Options considered: publish guides from this repo's CI (a docs site / artifact);
+derive them locally on demand only; or keep committing them. The app also still
+carries ~35 hand-authored guides, including legacy-named duplicates of canonical
+ones (`da.md`, `it.md`, `mi.md`, `sv.md`, `zh-cn.md`, `pt-br.md`, `fr.md`).
+
+## Decision
+Guides are **derived on demand only** — no hosted browse channel, no committed
+copy. A human who needs to read a guide runs the same derive step CI uses
+(ADR-006's action, or `lib/resolver/resolve.py <locale> --emit=md --emit-dir .derived`
+locally) and reads it from the ignored cache.
+
+Why no hosted channel: a published guides site is a third place the derived
+corpus lives — it ages independently of the pin, needs its own freshness story,
+and re-creates the "browsable copy drifts from source" failure ADR-005 removes.
+The guide is a *view* of the governed YAML; the reviewable source of truth is the
+register/glossary/rules in `rules/locales/<locale>/`, not a rendered guide. The
+small cost is that browsing requires running one command; the saving is one fewer
+corpus to keep fresh.
+
+Consequently the legacy hand-authored guides committed in the app
+(`locales/guides/for-translators/*.md`, including the duplicate pairs above) are
+**retired** as part of the app's no-vendor migration (onetimesecret#3510), not
+migrated.
+
+## Trade-offs
+- **We lose:** zero-setup "open a URL to read the guide." Browsing now needs a
+  checkout + one derive command.
+- **We gain:** no hosted/committed guide corpus to rot; the guide is always
+  exactly the pinned source, never a stale snapshot.
+
+## Consequences
+### Positive
+- The app migration deletes ~35 committed guides outright rather than rehoming
+  them; the guide question stops blocking #3510.
+
+### Negative
+- No at-a-glance web view of a locale's guidance for non-technical reviewers;
+  if that need becomes real, a CI-published artifact can be added later without
+  reversing this decision (it would just be a cache of the same derive).
+
+### Neutral
+- Independent of ADR-006's delivery mechanism: guides would be on-demand-only
+  regardless of how the derive step is delivered.


### PR DESCRIPTION
## What

The one-to-many delivery substrate for the no-vendor model (ADR-003/005): consumers stop vendoring derived output and call a single shared derive step published by this authority.

- **`.github/actions/derive`** (#35) — reusable composite action taking `{ref, locales, emit, lint, emit-dir}`. Checks out this repo read-only at the pin, installs the pinned resolver deps, runs `lib/resolver/resolve.py`, and emits `.resolved/<locale>.json` + `guides/for-translators/<locale>.md` into a caller-side cache. Byte-reproducible per pin (`_meta.source_commit` = pin, `_meta.generated_at` = pin committer date, UTC). Caller input passed via `env:` (not `${{ }}`-in-`run:`); locale positional guarded with `--`.
- **ADR-006** (accepted) — deliver the derive step as a composite action vs per-consumer copy/paste (drift; ADR-003) or a published artifact (re-vendors; ADR-005).
- **ADR-007** (accepted, #37) — translator guides are derived on demand only, no hosted browse channel; legacy app guides retired in onetimesecret#3510.

## Verification

- `resolve.py --all --lint` exits 0 (31 locales, 0 findings) at this tree.
- The derive emits the correct layout for `--all` and per-locale; `action.yml` reviewed (GH-Actions correctness, defensive bash, ADR consistency).

## Why merge

Merging mints a `v0.0.*` tag (`publish.yml`) — the canonical, Renovate-trackable pin the app's new `resolved-derive-gate` (#36) and the no-vendor migration (onetimesecret#3510) consume. Closes #35; records #37 (closes when the app guides are retired in #3510).

Out of scope (tracked separately): the multi-locale **content** gate — `bin/lint-register` can't scale past de_AT (#42), and 49 live content violations are listed for native review in onetimesecret#3530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019SE8iFFtW9sPDkDU1Lru8R)_