### PR TITLE
i18n-arch: resolver-engine consumer-content register lint, all locales (#42)

### DIFF
--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Run resolver emit + lint fixture suite
         run: python tests/resolver/run.py
 
+      - name: Run consumer-content lint suite (ADR-008)
+        # lint_content.py reuses the resolver matcher to scan shipped app
+        # content across every governed locale (translation-rules#42). The
+        # suite pins the false-positive avoidance (Hôte/te, bài/bà), CJK
+        # substring catch, exception span-containment, and exit-code contract.
+        run: python tests/lint_content/run.py
+
       - name: Run retro lifecycle test suite
         run: python tests/retro_lifecycle/run.py
 

--- a/docs/architecture/decision-records/adr-008-consumer-content-lint-engine.md
+++ b/docs/architecture/decision-records/adr-008-consumer-content-lint-engine.md
@@ -1,0 +1,91 @@
+---
+id: 008
+status: accepted
+title: ADR-008: Consumer content is linted by the resolver engine, across every governed locale
+---
+
+## Status
+Accepted
+
+## Date
+2026-06-25
+
+## Context
+The project exists to prevent the register-flip class **across locales**
+(translation-rules#2). Yet the only gate that scanned **shipped app content**
+for forbidden register tokens — onetimesecret `validate-register.yml` →
+`bin/lint-register` — ran for **de_AT only**. The other ~28 governed locales
+shipped unchecked.
+
+`bin/lint-register` cannot simply be pointed at them: it is a Phase-0
+`LC_ALL=C` byte-grep built for German/ASCII-ish word boundaries. Measured
+against live app content it **hard-errors** on the CJK `substring` rules
+(ja/ko/zh: `error: unknown context 'substring'`) and **floods false positives**
+elsewhere — 291 on Vietnamese (`bà` inside `bài`), 59/57 on French (`te` inside
+`Hôte`) — while simultaneously *mis*-counting the locales it can read (cs 15≠13,
+nl 26≠34) because byte `\b` drifts under UTF-8. It is the wrong tool for 30
+scripts.
+
+The resolver already owns the right matcher. `resolver.matching.find_spans` is
+Unicode-correct, casefolded over NFC, `substring`-capable, and the lint layer's
+`_exception_spans`/`_hit_allowed` honour the register `exceptions` allowlist by
+span containment (`du` inside `Duden` is spared; a standalone `du` beside it is
+not). But `resolver.lint.lint_model` points that engine at the **authority's**
+resolved model (good examples + embedded docs) — not at consumer content.
+
+## Decision
+Lint consumer content with the **same engine**, never a second matcher.
+`lib/resolver/lint_content.py` reuses `find_spans` + `_exception_spans` +
+`_hit_allowed` and:
+
+1. takes each locale's **resolved** register (post-inheritance) from the derived
+   `.resolved/<locale>.json` — the shared derive action's output (ADR-006) — so
+   the gate enforces exactly what the authority resolved, not a re-parse of raw
+   YAML;
+2. walks **rendered** content strings, reporting `{file, key, token, context,
+   snippet}` with a clear pass/fail exit (SPEC §6.2), mirroring `bin/lint-register`'s
+   exit codes (0 clean · 1 hit · 2 config · 3 empty-glob) for drop-in CI use;
+3. is wired into the app's content gate for **every** governed locale via the
+   derive action, replacing the de_AT-only byte-grep path.
+
+**Scan surface (`SKIP_KEYS`).** The register governs rendered, end-user-facing
+copy, so only those string values are scanned. The content schema's
+non-rendered keys are skipped — `source_hash` (a hash), `renderer` (a mode tag),
+`skip` (a flag), `context`/`note` (translator guidance, never shown), and any
+`_`-prefixed metadata block. This avoids false positives on English translator
+notes and is a named module constant, not a buried heuristic, so the surface
+stays reviewable.
+
+This is deliberately the engine the authority-model lint already trusts: one
+matcher, two callers (authority model + consumer content), so the gate can never
+disagree with the rules it derives from.
+
+## Measured exposure (evidence)
+Scanning every `onetimesecret/locales/content/<locale>/*.json` against the
+resolved register with this engine: **49 genuine violations, zero false
+positives**, all in three locales — the rest of the ~28 are clean, *including*
+every locale the byte-grep flagged.
+
+| locale | hits | tokens | nature |
+|---|---|---|---|
+| **cs** | 13 | `vámi, vaši, vašem, vašimi` | formal `váš`-family in informal-locked Czech — the exact formal-in-informal flip translation-rules#2 exists to catch |
+| **ja** | 2 | `してくれ, ぜ` | informal/rough forms in keigo-locked Japanese — `substring`-only; **no grep gate could ever see these** |
+| **nl** | 34 | `u, uw` | formal V-forms in informal-locked Dutch — overlaps the register's noted B2B/marketing carve-out; **needs a maintainer policy call** |
+
+Full per-hit remediation list: onetimesecret#3530 (native-speaker review;
+cs/ja are clear regressions, nl needs the carve-out decision first). Reproduce
+with the derive action (or `resolve.py --all --emit=json`) then
+`lint_content.py --resolved .derived/.resolved/<locale>.json <content-glob>`.
+
+## Consequences
+- The gate now **blocks** a forbidden register token entering *any* governed
+  locale's content, not just de_AT — closing the cross-locale gap that left the
+  founding bug-class invisible.
+- Flipping to blocking surfaces the existing 49 as failures rather than burying
+  them. cs/ja must be fixed to their locked register; **nl's B2B-formal
+  carve-out must be encoded as register `exceptions` (or a `register_spec`)**
+  before its 34 stop blocking — recording the policy where the engine reads it,
+  which is the point. Remediation is tracked in onetimesecret#3530.
+- `bin/lint-register` is not deleted: it remains the dependency-free Phase-0
+  smoke check (its `lint-register.yml` `--dry-run` self-test still proves every
+  register parses). The engine-based gate is the load-bearing one for content.

--- a/lib/resolver/lint_content.py
+++ b/lib/resolver/lint_content.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Lint *consumer content* against a locale's resolved register. SPEC.md §6.2.
+
+The sibling of resolver/lint.py. `lint_model` checks the **authority's** own
+resolved model (good examples + embedded rationale docs); this checks the
+**shipped app content** — onetimesecret `locales/content/<locale>/*.json` — for
+the same forbidden register tokens, using the *same* matching engine.
+
+Why this exists (translation-rules#42): the only gate that scanned shipped
+content, the app's `validate-register.yml` -> `bin/lint-register`, was a
+Phase-0 `LC_ALL=C` byte-grep that only worked for de_AT. It hard-errors on CJK
+`substring` rules (ja/ko/zh) and false-positives on word boundaries elsewhere
+(Vietnamese `bà` inside `bài`, French `te` inside `Hôte`), so it could not be
+pointed at the other ~28 governed locales. This module reuses the resolver's
+Unicode-correct, `substring`-capable, exception-honouring matcher instead, so
+one engine covers every locale.
+
+What it reuses (no second matcher, by construction):
+  - resolver.matching.find_spans   — the four context modes, casefolded + NFC
+  - resolver.lint._exception_spans — allowlisted `exceptions` occurrences
+  - resolver.lint._hit_allowed     — a hit inside an exception span (du-in-Duden)
+
+Which strings are scanned (deliberate, reviewable policy — SKIP_KEYS):
+The register governs **rendered, end-user-facing copy**, so only those string
+values are scanned. The content schema's non-rendered keys are skipped:
+`source_hash` (a content hash), `renderer` (a render-mode tag), `skip` (a
+control flag), `context`/`note` (translator guidance, never shown to users),
+and any `_`-prefixed key (metadata blocks such as `_meta`,
+`_translation_guidelines`). This both avoids false positives on English
+translator notes and reproduces the onetimesecret#3530 baseline exactly
+(13 cs / 2 ja / 34 nl = 49). The set is a module constant so it stays a
+reviewable decision, not a buried heuristic.
+
+The resolved register is obtained post-inheritance from a derived
+`.resolved/<locale>.json` (the shared derive action's output) via
+`register_from_resolved` — never re-parsed from raw YAML — so what the gate
+enforces is exactly what the authority resolved.
+
+Output is structured ({file, key, token, context, snippet}) with a clear
+pass/fail exit (SPEC §6.2), so CI and agents know when a locale's content is
+clean. Exit codes mirror bin/lint-register for drop-in CI familiarity:
+
+    0  clean (or the locale carries no forbidden_tokens — nothing to lint)
+    1  one or more error-severity forbidden-token hits
+    2  usage / config error (bad args, unreadable/registerless resolved JSON)
+    3  a content glob expanded to zero files (likely a misconfigured CI path)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+# Allow running as a script (`python lib/resolver/lint_content.py`) or as a
+# module (`from resolver.lint_content import ...`), mirroring resolve.py.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from resolver.matching import find_spans
+from resolver.lint import _exception_spans, _hit_allowed
+
+FATAL = {"error"}
+
+# Content-schema keys whose string values are NOT rendered to end users and so
+# are out of register scope (see module docstring). Any `_`-prefixed key is also
+# skipped (metadata blocks). Kept as a constant so the scan surface is explicit.
+SKIP_KEYS = frozenset({"source_hash", "renderer", "skip", "context", "note"})
+
+# Characters of original text shown on each side of a hit in `snippet`.
+SNIPPET_WINDOW = 32
+
+
+@dataclass
+class ContentFinding:
+    """One forbidden-token hit in a content string. `key` is the dotted JSON
+    path to the offending string value (e.g. `web.login.button.text`); `snippet`
+    is a windowed excerpt of the *original* text around the hit."""
+
+    check: str
+    severity: str
+    file: str
+    key: str
+    token: str
+    context: str
+    snippet: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "check": self.check,
+            "severity": self.severity,
+            "file": self.file,
+            "key": self.key,
+            "token": self.token,
+            "context": self.context,
+            "snippet": self.snippet,
+        }
+
+
+@dataclass
+class ContentLintResult:
+    locale: str
+    findings: list[ContentFinding] = field(default_factory=list)
+    files_scanned: int = 0
+    strings_scanned: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.severity in FATAL for f in self.findings)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "locale": self.locale,
+            "ok": self.ok,
+            "files_scanned": self.files_scanned,
+            "strings_scanned": self.strings_scanned,
+            "findings": [f.as_dict() for f in self.findings],
+        }
+
+
+def _fold_map(value: str) -> tuple[str, list[int], str]:
+    """Return (folded, fold_to_orig, nfc) for `value`.
+
+    `folded` equals resolver.matching._casefold(value) — NFC then casefold — so
+    spans from find_spans index into it directly. `fold_to_orig[i]` is the index
+    into `nfc` of the original character that produced folded[i], letting a
+    folded span be projected back onto the *original* text for a faithful
+    snippet even when casefolding changes length (German ß -> ss, ligatures).
+    Unicode case folding is a context-free per-code-point mapping, so folding
+    char-by-char yields the same string as folding the whole — the offsets line
+    up with find_spans by construction."""
+    nfc = unicodedata.normalize("NFC", value)
+    parts: list[str] = []
+    fold_to_orig: list[int] = []
+    for i, ch in enumerate(nfc):
+        folded_ch = ch.casefold()
+        parts.append(folded_ch)
+        fold_to_orig.extend([i] * len(folded_ch))
+    return "".join(parts), fold_to_orig, nfc
+
+
+def _snippet(nfc: str, fold_to_orig: list[int], span: tuple[int, int]) -> str:
+    """A single-line excerpt of the original (NFC) text around a folded span."""
+    fs, fe = span
+    start = fold_to_orig[fs]
+    end = fold_to_orig[fe - 1] + 1 if fe > fs else start
+    lo = max(0, start - SNIPPET_WINDOW)
+    hi = min(len(nfc), end + SNIPPET_WINDOW)
+    excerpt = nfc[lo:hi].replace("\n", " ").replace("\r", " ").strip()
+    return f"{'…' if lo > 0 else ''}{excerpt}{'…' if hi < len(nfc) else ''}"
+
+
+def iter_content_strings(data: Any, prefix: str = "") -> Iterator[tuple[str, str]]:
+    """Yield (dotted_key, string_value) for every rendered string in a content
+    document, skipping SKIP_KEYS and `_`-prefixed (metadata) keys. Recurses into
+    nested objects and lists; list indices join with `.` like object keys."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key in SKIP_KEYS or key.startswith("_"):
+                continue
+            yield from iter_content_strings(value, f"{prefix}.{key}" if prefix else key)
+    elif isinstance(data, list):
+        for i, value in enumerate(data):
+            yield from iter_content_strings(
+                value, f"{prefix}.{i}" if prefix else str(i)
+            )
+    elif isinstance(data, str):
+        yield prefix, data
+
+
+def _normalize_register(
+    register: dict[str, Any] | None,
+) -> tuple[list[dict], list[dict]]:
+    """Pull (forbidden_tokens, exceptions) out of a resolved register, defaulting
+    each to an empty list (a registerless or token-free locale scans clean)."""
+    register = register or {}
+    return (
+        register.get("forbidden_tokens") or [],
+        register.get("exceptions") or [],
+    )
+
+
+def register_from_resolved(resolved: dict[str, Any]) -> dict[str, Any] | None:
+    """The `register` block of a derived `.resolved/<locale>.json`. None when the
+    locale carries no register (nothing to enforce)."""
+    return resolved.get("register")
+
+
+def lint_value(
+    forbidden: list[dict[str, Any]],
+    exceptions: list[dict[str, Any]],
+    file: str,
+    key: str,
+    value: str,
+) -> list[ContentFinding]:
+    """Forbidden-token findings for one content string. A hit is suppressed only
+    when it falls inside an allowlisted exception occurrence (du-in-Duden), never
+    merely because the exception appears elsewhere in the same string."""
+    findings: list[ContentFinding] = []
+    exc_spans = _exception_spans(value, exceptions)
+    # Built lazily on the first real hit (most strings are clean) and reused
+    # across this value's hits. None until needed; a 3-tuple once computed.
+    fold: tuple[str, list[int], str] | None = None
+    for ft in forbidden:
+        token = ft.get("token", "")
+        mode = ft.get("context", "any")
+        hits = find_spans(value, token, mode)
+        for hit in hits:
+            if _hit_allowed(hit, exc_spans):
+                continue
+            if fold is None:
+                fold = _fold_map(value)
+            _folded, fold_to_orig, nfc = fold
+            findings.append(
+                ContentFinding(
+                    check="forbidden_token_content",
+                    severity=ft.get("severity", "error"),
+                    file=file,
+                    key=key,
+                    token=token,
+                    context=mode,
+                    snippet=_snippet(nfc, fold_to_orig, hit),
+                )
+            )
+    return findings
+
+
+def lint_content(
+    locale: str,
+    register: dict[str, Any] | None,
+    files: Iterable[tuple[str, Any]],
+) -> ContentLintResult:
+    """Lint each (file_label, parsed_json) against the resolved register. Pure:
+    callers supply already-parsed content so this stays free of I/O."""
+    forbidden, exceptions = _normalize_register(register)
+    result = ContentLintResult(locale=locale)
+    for file_label, data in files:
+        result.files_scanned += 1
+        if not forbidden:
+            continue
+        for key, value in iter_content_strings(data):
+            result.strings_scanned += 1
+            result.findings.extend(
+                lint_value(forbidden, exceptions, file_label, key, value)
+            )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _load_resolved(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise _Usage(f"resolved model not found: {path}") from exc
+    except (json.JSONDecodeError, OSError) as exc:
+        raise _Usage(f"resolved model is not readable JSON: {path}: {exc}") from exc
+
+
+class _Usage(Exception):
+    """A usage/config error -> exit 2."""
+
+
+def _expand_globs(root: Path, globs: list[str]) -> list[Path]:
+    out: list[Path] = []
+    for pattern in globs:
+        out.extend(sorted(root.glob(pattern)))
+    # De-dup while preserving order (overlapping globs are a CI footgun).
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for p in out:
+        if p not in seen and p.is_file():
+            seen.add(p)
+            deduped.append(p)
+    return deduped
+
+
+def _emit_text(result: ContentLintResult, github: bool) -> None:
+    for f in result.findings:
+        line = (
+            f"{f.file}: {f.key}: forbidden token {f.token!r} ({f.context}) "
+            f"— {f.snippet}"
+        )
+        if github:
+            print(f"::error file={f.file}::{result.locale}: {line}")
+        else:
+            print(line)
+    status = "OK" if result.ok else "FAIL"
+    summary = (
+        f"{status}: {result.locale} — {len(result.findings)} hit(s) across "
+        f"{result.files_scanned} file(s), {result.strings_scanned} string(s) scanned"
+    )
+    print(summary, file=sys.stderr if not result.ok else sys.stdout)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="lint_content.py",
+        description="Lint consumer content against a locale's resolved register.",
+    )
+    parser.add_argument(
+        "--resolved",
+        required=True,
+        help="Path to the derived .resolved/<locale>.json whose `register` block "
+        "supplies forbidden_tokens + exceptions.",
+    )
+    parser.add_argument(
+        "--locale",
+        default=None,
+        help="Locale label for output (default: inferred from --resolved filename "
+        "or the model's _meta.locale).",
+    )
+    parser.add_argument(
+        "--content-root",
+        default=".",
+        help="Directory the content globs are resolved against (default: cwd).",
+    )
+    parser.add_argument(
+        "globs",
+        nargs="+",
+        help="One or more globs of content JSON to scan, relative to "
+        "--content-root (e.g. 'locales/content/cs/*.json').",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "github"),
+        default="text",
+        help="text (default) or github (::error:: annotations).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the structured result as JSON to stdout instead of text.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        resolved_path = Path(args.resolved)
+        resolved = _load_resolved(resolved_path)
+        register = register_from_resolved(resolved)
+        locale = (
+            args.locale or resolved.get("_meta", {}).get("locale") or resolved_path.stem
+        )
+
+        files = _expand_globs(Path(args.content_root), args.globs)
+        if not files:
+            print(
+                f"error: no files matched: {args.globs} (under {args.content_root})",
+                file=sys.stderr,
+            )
+            print(
+                "  (a CI gate that scans nothing silently is worse than no gate; "
+                "check the path)",
+                file=sys.stderr,
+            )
+            return 3
+
+        parsed: list[tuple[str, Any]] = []
+        for p in files:
+            try:
+                parsed.append((str(p), json.loads(p.read_text(encoding="utf-8"))))
+            except (json.JSONDecodeError, OSError) as exc:
+                raise _Usage(f"content file is not readable JSON: {p}: {exc}") from exc
+
+        result = lint_content(locale, register, parsed)
+    except _Usage as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result.as_dict(), ensure_ascii=False, indent=2))
+    else:
+        _emit_text(result, github=args.format == "github")
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/resolver/lint_content.py
+++ b/lib/resolver/lint_content.py
@@ -65,7 +65,7 @@ from typing import Any, Iterable, Iterator
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from resolver.matching import find_spans
+from resolver.matching import VALID_MODES, find_spans
 from resolver.lint import _exception_spans, _hit_allowed
 
 FATAL = {"error"}
@@ -272,6 +272,33 @@ class _Usage(Exception):
     """A usage/config error -> exit 2."""
 
 
+def _check_register_modes(register: dict[str, Any] | None) -> None:
+    """Fail as a config error (exit 2), not a traceback, when a forbidden token
+    carries an unknown `context`. find_spans would raise ValueError mid-scan on
+    a stale/hand-built .resolved file; surface it inside the documented contract
+    instead, before scanning."""
+    forbidden, _ = _normalize_register(register)
+    for ft in forbidden:
+        mode = ft.get("context", "any")
+        if mode not in VALID_MODES:
+            raise _Usage(
+                f"forbidden token {ft.get('token', '')!r} has unknown context "
+                f"{mode!r}; valid: {sorted(VALID_MODES)}"
+            )
+
+
+def _gh_escape_data(s: str) -> str:
+    """Escape a GitHub workflow-command message body (% and line breaks).
+    `%` must go first so the inserted escapes are not re-escaped."""
+    return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _gh_escape_prop(s: str) -> str:
+    """Escape a GitHub workflow-command property value (e.g. `file=`); these
+    additionally reserve ':' and ','."""
+    return _gh_escape_data(s).replace(":", "%3A").replace(",", "%2C")
+
+
 def _expand_globs(root: Path, globs: list[str]) -> list[Path]:
     out: list[Path] = []
     for pattern in globs:
@@ -293,7 +320,10 @@ def _emit_text(result: ContentLintResult, github: bool) -> None:
             f"— {f.snippet}"
         )
         if github:
-            print(f"::error file={f.file}::{result.locale}: {line}")
+            print(
+                f"::error file={_gh_escape_prop(f.file)}::"
+                f"{_gh_escape_data(f'{result.locale}: {line}')}"
+            )
         else:
             print(line)
     status = "OK" if result.ok else "FAIL"
@@ -349,6 +379,7 @@ def main(argv: list[str]) -> int:
         resolved_path = Path(args.resolved)
         resolved = _load_resolved(resolved_path)
         register = register_from_resolved(resolved)
+        _check_register_modes(register)
         locale = (
             args.locale or resolved.get("_meta", {}).get("locale") or resolved_path.stem
         )

--- a/tests/lint_content/run.py
+++ b/tests/lint_content/run.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Tests for lib/resolver/lint_content.py — the consumer-content register linter.
+
+Two layers, mirroring tests/resolver/run.py's fixture+programmatic split:
+
+  - Pure-API cases call lint_content()/lint_value() with inline registers and
+    content dicts. They pin the behaviours the issue (translation-rules#42)
+    calls out: the resolver engine must NOT false-positive where the legacy
+    byte-grep did (French `te` in `Hôte`, Vietnamese `bà` in `bài`), MUST catch
+    CJK `substring` hits no grep can see, must honour `exceptions` by span
+    containment (du-in-Duden), and must scan only rendered strings (SKIP_KEYS).
+
+  - CLI cases drive main() against a temp tree (resolved JSON + content files)
+    to lock the exit-code contract (0 clean / 1 hit / 2 config / 3 empty glob).
+
+No third-party deps: lint_content imports nothing outside the stdlib + the
+sibling resolver modules, so this runs anywhere Python 3.11 does.
+
+Exit codes: 0 all passed · 1 a case failed · 2 harness setup error.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "lib"))
+
+try:
+    from resolver import lint_content as lc
+    from resolver.lint_content import (
+        SKIP_KEYS,
+        iter_content_strings,
+        lint_content,
+        register_from_resolved,
+    )
+except ImportError as exc:  # pragma: no cover - setup failure
+    print(f"setup: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+
+def _reg(forbidden, exceptions=None):
+    return {"forbidden_tokens": forbidden, "exceptions": exceptions or []}
+
+
+def _tok(token, context="standalone_word", severity="error"):
+    return {"token": token, "context": context, "severity": severity}
+
+
+# --------------------------------------------------------------------------- #
+# Pure-API cases. Each returns (ok, message).
+# --------------------------------------------------------------------------- #
+
+
+def case_clean_formal():
+    reg = _reg([_tok("du"), _tok("dein", "word_prefix")])
+    files = [("f.json", {"k": {"text": "Geben Sie Ihre Daten ein"}})]
+    r = lint_content("de_AT", reg, files)
+    if not r.ok or r.findings:
+        return False, f"expected clean, got {r.as_dict()}"
+    if r.strings_scanned != 1 or r.files_scanned != 1:
+        return False, f"scan counters off: {r.files_scanned}f/{r.strings_scanned}s"
+    return True, "ok"
+
+
+def case_real_hit():
+    reg = _reg([_tok("du")])
+    files = [("f.json", {"greeting": {"text": "Hast du Zeit?"}})]
+    r = lint_content("de_AT", reg, files)
+    if r.ok or len(r.findings) != 1:
+        return False, f"expected 1 hit, got {[f.as_dict() for f in r.findings]}"
+    f = r.findings[0]
+    if f.token != "du" or f.key != "greeting.text" or f.context != "standalone_word":
+        return False, f"finding fields wrong: {f.as_dict()}"
+    if "du" not in f.snippet:
+        return False, f"snippet missing token: {f.snippet!r}"
+    return True, "ok"
+
+
+def case_fp_french_te():
+    # The legacy byte-grep cried 57x over `te` inside `Hôte`. The engine must not.
+    reg = _reg([_tok("te")])
+    files = [("f.json", {"k": {"text": "Bienvenue, Hôte"}})]
+    r = lint_content("fr_FR", reg, files)
+    if not r.ok or r.findings:
+        return False, f"`te`-in-`Hôte` false positive returned: {r.as_dict()}"
+    # But a standalone `te` IS a real hit.
+    r2 = lint_content("fr_FR", reg, [("f.json", {"k": {"text": "je te vois"}})])
+    if r2.ok or len(r2.findings) != 1:
+        return False, f"standalone `te` should hit: {r2.as_dict()}"
+    return True, "ok"
+
+
+def case_fp_vietnamese_ba():
+    # Legacy grep cried 291x over `bà` inside `bài`. Engine must not.
+    reg = _reg([_tok("bà")])
+    files = [("f.json", {"k": {"text": "bài viết của bạn"}})]
+    r = lint_content("vi", reg, files)
+    if not r.ok or r.findings:
+        return False, f"`bà`-in-`bài` false positive returned: {r.as_dict()}"
+    return True, "ok"
+
+
+def case_cjk_substring():
+    # No grep gate can scan these; `substring` is required.
+    reg = _reg([_tok("你", "substring")])
+    files = [("f.json", {"k": {"text": "你的账户"}})]
+    r = lint_content("zh", reg, files)
+    if r.ok or len(r.findings) != 1:
+        return False, f"expected 1 CJK substring hit, got {r.as_dict()}"
+    if r.findings[0].token != "你":
+        return False, f"wrong token: {r.findings[0].as_dict()}"
+    return True, "ok"
+
+
+def case_exception_span_containment():
+    # `du` inside the allowlisted `Duden` is suppressed; a standalone `du` in the
+    # same string is NOT spared just because `Duden` appears.
+    reg = _reg([_tok("du")], exceptions=[{"token": "Duden"}])
+    inside = lint_content(
+        "de_AT", reg, [("f.json", {"k": {"text": "Das Duden hilft"}})]
+    )
+    if not inside.ok or inside.findings:
+        return False, f"du-in-Duden should be suppressed: {inside.as_dict()}"
+    both = lint_content("de_AT", reg, [("f.json", {"k": {"text": "Duden und du"}})])
+    if both.ok or len(both.findings) != 1:
+        return False, f"standalone du beside Duden must hit: {both.as_dict()}"
+    return True, "ok"
+
+
+def case_metadata_skipped():
+    # A forbidden token sitting only in non-rendered keys must NOT be flagged;
+    # the same token in `text` must be. Proves the SKIP_KEYS policy.
+    reg = _reg([_tok("du")])
+    doc = {
+        "entry": {
+            "text": "Geben Sie acht",  # clean rendered copy
+            "source_hash": "du99",  # hash — skipped
+            "renderer": "markdown",
+            "context": "shown when du presses submit",  # translator note — skipped
+            "note": "du note",  # skipped
+        },
+        "_meta": {"purpose": "du appears here but it's metadata"},  # skipped block
+    }
+    r = lint_content("de_AT", reg, [("f.json", doc)])
+    if not r.ok or r.findings:
+        return False, f"metadata keys should be skipped, got {r.as_dict()}"
+    # Now move `du` into the rendered text.
+    doc["entry"]["text"] = "Hast du das gesehen"
+    r2 = lint_content("de_AT", reg, [("f.json", doc)])
+    if r2.ok or len(r2.findings) != 1:
+        return False, f"rendered `du` must hit: {r2.as_dict()}"
+    return True, "ok"
+
+
+def case_snippet_umlaut_faithful():
+    # Casefolding ß->ss changes length; the snippet must still show original text.
+    reg = _reg([_tok("du")])
+    r = lint_content(
+        "de_AT", reg, [("f.json", {"k": {"text": "Straße, hast du recht"}})]
+    )
+    if len(r.findings) != 1:
+        return False, f"expected 1 hit, got {r.as_dict()}"
+    snip = r.findings[0].snippet
+    if "Straße" not in snip or "du" not in snip:
+        return False, f"snippet not faithful to original: {snip!r}"
+    return True, "ok"
+
+
+def case_severity_warning_non_fatal():
+    reg = _reg([_tok("du", severity="warning")])
+    r = lint_content("de_AT", reg, [("f.json", {"k": {"text": "hast du"}})])
+    if not r.ok:
+        return False, "warning-severity hit must keep ok=True"
+    if len(r.findings) != 1 or r.findings[0].severity != "warning":
+        return False, f"expected 1 warning finding, got {r.as_dict()}"
+    return True, "ok"
+
+
+def case_nested_and_list_paths():
+    reg = _reg([_tok("du")])
+    doc = {
+        "a": {"b": {"text": "du hier"}},
+        "list": [{"text": "kein Treffer"}, {"text": "auch du"}],
+    }
+    r = lint_content("de_AT", reg, [("f.json", doc)])
+    keys = sorted(f.key for f in r.findings)
+    if keys != ["a.b.text", "list.1.text"]:
+        return False, f"path traversal wrong: {keys}"
+    return True, "ok"
+
+
+def case_registerless_is_clean():
+    # A locale whose resolved model carries no register (or no forbidden_tokens)
+    # scans clean — nothing to enforce.
+    r = lint_content("xx", None, [("f.json", {"k": {"text": "anything du goes"}})])
+    if not r.ok or r.findings:
+        return False, f"registerless locale should be clean: {r.as_dict()}"
+    r2 = lint_content("xx", _reg([]), [("f.json", {"k": {"text": "du du du"}})])
+    if not r2.ok or r2.findings:
+        return False, f"empty forbidden_tokens should be clean: {r2.as_dict()}"
+    return True, "ok"
+
+
+def case_iter_skips_and_register_helper():
+    doc = {"k": {"text": "hi", "source_hash": "x"}, "_m": {"text": "skip"}}
+    got = dict(iter_content_strings(doc))
+    if got != {"k.text": "hi"}:
+        return False, f"iter_content_strings leaked keys: {got}"
+    if "source_hash" not in SKIP_KEYS:
+        return False, "SKIP_KEYS missing source_hash"
+    resolved = {"_meta": {"locale": "de_AT"}, "register": {"form": "formal"}}
+    if register_from_resolved(resolved) != {"form": "formal"}:
+        return False, "register_from_resolved did not return the register block"
+    if register_from_resolved({"_meta": {}}) is not None:
+        return False, "register_from_resolved should be None when absent"
+    return True, "ok"
+
+
+# --------------------------------------------------------------------------- #
+# CLI exit-code cases. Each returns (ok, message).
+# --------------------------------------------------------------------------- #
+
+
+def _write(path: Path, obj) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
+
+
+def _run_cli(argv):
+    with (
+        contextlib.redirect_stdout(io.StringIO()),
+        contextlib.redirect_stderr(io.StringIO()),
+    ):
+        return lc.main(argv)
+
+
+def case_cli_exit_codes():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        resolved = root / ".resolved" / "de_AT.json"
+        _write(
+            resolved,
+            {
+                "_meta": {"locale": "de_AT"},
+                "register": {"forbidden_tokens": [_tok("du")]},
+            },
+        )
+        _write(
+            root / "content" / "de_AT" / "clean.json", {"k": {"text": "Sie sind da"}}
+        )
+        _write(root / "content" / "de_AT" / "dirty.json", {"k": {"text": "hast du"}})
+
+        # exit 0 — clean only
+        rc = _run_cli(
+            [
+                "--resolved",
+                str(resolved),
+                "--content-root",
+                str(root),
+                "content/de_AT/clean.json",
+            ]
+        )
+        if rc != 0:
+            return False, f"clean glob exit {rc}, expected 0"
+
+        # exit 1 — a violation present
+        rc = _run_cli(
+            [
+                "--resolved",
+                str(resolved),
+                "--content-root",
+                str(root),
+                "content/de_AT/*.json",
+            ]
+        )
+        if rc != 1:
+            return False, f"violation glob exit {rc}, expected 1"
+
+        # exit 3 — empty glob
+        rc = _run_cli(
+            [
+                "--resolved",
+                str(resolved),
+                "--content-root",
+                str(root),
+                "content/de_AT/none*.json",
+            ]
+        )
+        if rc != 3:
+            return False, f"empty glob exit {rc}, expected 3"
+
+        # exit 2 — missing resolved model
+        rc = _run_cli(
+            [
+                "--resolved",
+                str(root / "nope.json"),
+                "--content-root",
+                str(root),
+                "content/de_AT/*.json",
+            ]
+        )
+        if rc != 2:
+            return False, f"missing-resolved exit {rc}, expected 2"
+
+        # registerless resolved scans clean (exit 0) even over dirty content
+        regless = root / ".resolved" / "xx.json"
+        _write(regless, {"_meta": {"locale": "xx"}})
+        rc = _run_cli(
+            [
+                "--resolved",
+                str(regless),
+                "--content-root",
+                str(root),
+                "content/de_AT/*.json",
+            ]
+        )
+        if rc != 0:
+            return False, f"registerless exit {rc}, expected 0"
+    return True, "ok"
+
+
+def case_cli_json_output():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        resolved = root / "de_AT.json"
+        _write(
+            resolved,
+            {
+                "_meta": {"locale": "de_AT"},
+                "register": {"forbidden_tokens": [_tok("du")]},
+            },
+        )
+        _write(root / "c" / "dirty.json", {"k": {"text": "hast du"}})
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = lc.main(
+                [
+                    "--resolved",
+                    str(resolved),
+                    "--content-root",
+                    str(root),
+                    "c/*.json",
+                    "--json",
+                ]
+            )
+        if rc != 1:
+            return False, f"json-mode exit {rc}, expected 1"
+        payload = json.loads(buf.getvalue())
+        if payload["locale"] != "de_AT" or payload["ok"] is not False:
+            return False, f"json payload header wrong: {payload}"
+        if len(payload["findings"]) != 1 or payload["findings"][0]["token"] != "du":
+            return False, f"json findings wrong: {payload['findings']}"
+    return True, "ok"
+
+
+CASES = [
+    ("clean-formal", case_clean_formal),
+    ("real-hit", case_real_hit),
+    ("fp-french-te-in-hote", case_fp_french_te),
+    ("fp-vietnamese-ba-in-bai", case_fp_vietnamese_ba),
+    ("cjk-substring", case_cjk_substring),
+    ("exception-span-containment", case_exception_span_containment),
+    ("metadata-skipped", case_metadata_skipped),
+    ("snippet-umlaut-faithful", case_snippet_umlaut_faithful),
+    ("severity-warning-non-fatal", case_severity_warning_non_fatal),
+    ("nested-and-list-paths", case_nested_and_list_paths),
+    ("registerless-is-clean", case_registerless_is_clean),
+    ("iter-skips-and-register-helper", case_iter_skips_and_register_helper),
+    ("cli-exit-codes", case_cli_exit_codes),
+    ("cli-json-output", case_cli_json_output),
+]
+
+
+def main(argv: list[str]) -> int:
+    targets = set(argv[1:]) if len(argv) > 1 else None
+    passed = failed = 0
+    for name, fn in CASES:
+        if targets and name not in targets:
+            continue
+        try:
+            ok, msg = fn()
+        except Exception as exc:  # noqa: BLE001
+            ok, msg = False, f"unexpected error: {type(exc).__name__}: {exc}"
+        print(f"  {'pass' if ok else 'FAIL'} {name}: {msg}")
+        passed, failed = (passed + 1, failed) if ok else (passed, failed + 1)
+    print()
+    print(f"summary: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/lint_content/run.py
+++ b/tests/lint_content/run.py
@@ -363,6 +363,82 @@ def case_cli_json_output():
     return True, "ok"
 
 
+def case_cli_bad_context_is_config_error():
+    # A stale/hand-built .resolved with an unknown forbidden_tokens[].context
+    # must exit 2 (config error) — not a ValueError traceback from find_spans.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        resolved = root / "de_AT.json"
+        _write(
+            resolved,
+            {
+                "_meta": {"locale": "de_AT"},
+                "register": {
+                    "forbidden_tokens": [
+                        {"token": "du", "context": "bogus_mode", "severity": "error"}
+                    ]
+                },
+            },
+        )
+        _write(root / "c" / "x.json", {"k": {"text": "hast du"}})
+        err = io.StringIO()
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(err):
+            rc = lc.main(
+                ["--resolved", str(resolved), "--content-root", str(root), "c/*.json"]
+            )
+        if rc != 2:
+            return False, f"bad-context exit {rc}, expected 2"
+        if "unknown context" not in err.getvalue():
+            return False, f"missing diagnostic: {err.getvalue()!r}"
+    return True, "ok"
+
+
+def case_cli_github_annotation_escaping():
+    # GitHub workflow commands need % and line breaks escaped in the message,
+    # and ':'/',' escaped in the file= property — else annotations malform.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        resolved = root / "de_AT.json"
+        _write(
+            resolved,
+            {
+                "_meta": {"locale": "de_AT"},
+                "register": {"forbidden_tokens": [_tok("du")]},
+            },
+        )
+        # '%' adjacent to the hit lands in the snippet; the file path carries ':'.
+        _write(root / "weird" / "a:b.json", {"k": {"text": "100% sure, hast du"}})
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(io.StringIO()):
+            rc = lc.main(
+                [
+                    "--resolved",
+                    str(resolved),
+                    "--content-root",
+                    str(root),
+                    "weird/*.json",
+                    "--format",
+                    "github",
+                ]
+            )
+        if rc != 1:
+            return False, f"escaping case exit {rc}, expected 1"
+        out = buf.getvalue()
+        annotation = next(
+            (ln for ln in out.splitlines() if ln.startswith("::error")), ""
+        )
+        if not annotation:
+            return False, f"no annotation emitted: {out!r}"
+        # message body: raw '%' escaped to %25 (so "100%25 sure" not "100% sure").
+        if "100%25 sure" not in annotation or "100% sure" in annotation:
+            return False, f"message '%' not escaped: {annotation!r}"
+        # file= property: ':' escaped to %3A, so no raw 'a:b.json' segment.
+        prop = annotation.split("::", 2)[1]  # "error file=..."
+        if "a%3Ab.json" not in prop or "a:b.json" in prop:
+            return False, f"file property ':' not escaped: {prop!r}"
+    return True, "ok"
+
+
 CASES = [
     ("clean-formal", case_clean_formal),
     ("real-hit", case_real_hit),
@@ -378,6 +454,8 @@ CASES = [
     ("iter-skips-and-register-helper", case_iter_skips_and_register_helper),
     ("cli-exit-codes", case_cli_exit_codes),
     ("cli-json-output", case_cli_json_output),
+    ("cli-bad-context-is-config-error", case_cli_bad_context_is_config_error),
+    ("cli-github-annotation-escaping", case_cli_github_annotation_escaping),
 ]
 
 


### PR DESCRIPTION
## Summary

Closes the cross-locale gap in #42: the only gate that scanned **shipped app content** for forbidden register tokens ran for **de_AT only**, leaving ~28 governed locales unchecked. This adds the engine that covers them all.

`lib/resolver/lint_content.py` is the sibling of `resolver/lint.py`. `lint_model` checks the **authority's** resolved model (good examples + embedded docs); `lint_content` checks **shipped consumer content** (`onetimesecret/locales/content/<locale>/*.json`) using the **same matcher** — `find_spans` + `_exception_spans` + `_hit_allowed` — so the gate can never disagree with the rules it derives from.

### Why the byte-grep couldn't do this
`bin/lint-register` is a Phase-0 `LC_ALL=C` byte-grep built for de_AT/German boundaries. Measured against live content it **hard-errors** on the CJK `substring` rules (ja/ko/zh) and **floods false positives** elsewhere (291 on vi `bà`-in-`bài`, 59/57 on fr `te`-in-`Hôte`), while *mis*-counting the locales it can read (cs 15≠13, nl 26≠34). The resolver engine is Unicode-correct, `substring`-capable, and honours `exceptions` by span containment.

## Measured exposure (all governed locales)
**49 genuine violations, zero false positives** — every other locale clean:

| locale | hits | tokens |
|---|---|---|
| **cs** | 13 | `vámi, vaši, vašem, vašimi` (formal `váš`-family in informal-locked Czech) |
| **ja** | 2 | `してくれ, ぜ` (`substring`-only; no grep gate can see these) |
| **nl** | 34 | `u, uw` (formal V-forms; overlaps the register's noted B2B carve-out — needs a maintainer call) |

Per-hit remediation list: onetimesecret#3530. Recorded with the engine-reuse rationale in **ADR-008**.

## Changes
- `lib/resolver/lint_content.py` — structured findings `{file, key, token, context, snippet}`, pass/fail exit mirroring `bin/lint-register` (`0` clean / `1` hit / `2` config / `3` empty-glob). Reads the resolved register from a derived `.resolved/<locale>.json`; scans **rendered** strings only (documented `SKIP_KEYS`). Snippets stay faithful to original text even when casefolding changes length (ß→ss). Pure stdlib.
- `tests/lint_content/run.py` — 14 cases: FP avoidance (`Hôte`/`te`, `bài`/`bà`), CJK substring catch, exception span-containment, metadata-skip, CLI exit codes. Wired into `schema-validation.yml`.
- `docs/architecture/decision-records/adr-008-consumer-content-lint-engine.md` — records the decision + measurement.

`bin/lint-register` is **not** removed: it stays the dependency-free Phase-0 smoke check. The engine gate is the load-bearing one for content.

## Verification
- `ruff check` / `ruff format --check` / `pyright`: clean.
- All fixture suites pass, including the new 14-case `lint_content` suite.
- `lint_content.py` runs under bare `python3` 3.11 with **no third-party deps** (it's invoked that way in the app gate after the derive step).

Paired with **onetimesecret#3537**, which wires the app content gate to this engine across all governed locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015pFrmShFGYJ83vUtFMcxsi