### PR TITLE
fix(ja,nl): drop substring tokens that false-positive on polite/abbrev content (onetimesecret#3530)

### DIFF
--- a/rules/locales/ja/register.yaml
+++ b/rules/locales/ja/register.yaml
@@ -21,11 +21,20 @@ source: onetimesecret/locales/guides/for-translators/ja.md
 # (which key off alphanumeric chars) do NOT segment Japanese — every kana/kanji
 # is a "word char", so a casual marker mid-sentence has no left boundary. We
 # therefore use `substring` for the casual markers, but ONLY for ones that do
-# NOT collide with polite text. Each token below was verified against the full
-# live ja content to have ZERO occurrences (no false positives):
+# NOT collide with polite text. The tokens below were checked against live ja
+# content; the safe set (zero false positives on the current corpus):
 #   しろ / するな (casual imperative & prohibition), だろう / だろ (casual
-#   conjecture), かい (casual question particle), ぞ / ぜ (casual emphatics),
-#   じゃない (casual negation), してくれ (casual request).
+#   conjecture), かい (casual question particle), ぞ (casual emphatic),
+#   じゃない (casual negation).
+# REMOVED 2026-06-25 (onetimesecret#3530) — these two DID false-positive on
+# polite live content, so they are NOT safely substring-tokenizable; they are
+# now enforced via register_spec.forbidden_forms + the rule instead (joining
+# だ / である):
+#   ぜ      — matches なぜ ("why") and ぜひ ("by all means");
+#   してくれ — matches the polite benefactive してくれました / してくれます
+#             (the 〜ました / 〜ます ending is teineigo-compliant; only the bare
+#             casual request してくれ is a violation, which substring cannot
+#             isolate from the polite forms).
 # DELIBERATELY LEFT OUT (cannot be safely tokenized — would false-positive on
 # polite text): the plain copula だ — it is a substring of the very common polite
 # request form ください (100+ hits) plus いただく / 一度だけ / まだ; and である —
@@ -44,9 +53,7 @@ forbidden_tokens:
   - { token: だろ,     context: substring, severity: error, note: "casual conjecture/tag, shortened; — zero live hits" }
   - { token: かい,     context: substring, severity: error, note: "casual yes/no question particle; polite form is ですか — zero live hits" }
   - { token: じゃない, context: substring, severity: error, note: "casual negation; polite form is ではありません / ではない(です) — zero live hits" }
-  - { token: してくれ, context: substring, severity: error, note: "casual request (do ~ for me); polite form is してください — zero live hits" }
   - { token: ぞ,       context: substring, severity: error, note: "casual masculine emphatic sentence-final particle — zero live hits" }
-  - { token: ぜ,       context: substring, severity: error, note: "casual masculine emphatic sentence-final particle — zero live hits" }
 exceptions: []
 rule_ref: rule.ja-register-teineigo
 # register_spec — the FREE-FORM extension where the real keigo policy lives (the
@@ -68,7 +75,8 @@ register_spec:
     casual_conjecture: [だろう, だろ]      # also tokenized
     casual_question: [かい]               # also tokenized
     casual_negation: [じゃない]            # also tokenized
-    casual_emphatic: [ぞ, ぜ]             # also tokenized
+    casual_emphatic: [ぞ, ぜ]             # ぞ tokenized; ぜ spec-only (FP on なぜ/ぜひ — onetimesecret#3530)
+    casual_request: [してくれ]            # spec-only (FP on polite してくれました/してくれます — onetimesecret#3530)
   voice_by_context:
     buttons_and_actions: "命令形 / imperative noun-form (例: 保存, 削除, 送信) — concise label form, not casual speech."
     status_and_notifications: "受動態/完了形 — passive/declarative polite (例: 保存されました, 削除済み)."
@@ -77,6 +85,9 @@ register_spec:
     The plain copula だ / である is the primary casual marker but is unsafe to
     substring-match against polite Japanese (だ is inside ください, である inside
     である必要があります). It is enforced via rule.ja-register-teineigo and this
-    spec rather than forbidden_tokens. Imperative noun-forms on buttons (保存,
+    spec rather than forbidden_tokens. As of onetimesecret#3530, ぜ and してくれ
+    join だ/である in the spec-only set: ぜ false-positives on なぜ/ぜひ and
+    してくれ on the polite benefactive してくれました/してくれます, so neither can
+    be safely substring-matched. Imperative noun-forms on buttons (保存,
     削除) are the prescribed UI voice, NOT a register violation.
 baseline_ref: baselines.ja

--- a/rules/locales/ja/register.yaml
+++ b/rules/locales/ja/register.yaml
@@ -27,9 +27,14 @@ source: onetimesecret/locales/guides/for-translators/ja.md
 #   conjecture), かい (casual question particle), ぞ (casual emphatic),
 #   じゃない (casual negation).
 # REMOVED 2026-06-25 (onetimesecret#3530) — these two DID false-positive on
-# polite live content, so they are NOT safely substring-tokenizable; they are
-# now enforced via register_spec.forbidden_forms + the rule instead (joining
-# だ / である):
+# polite live content, so they are NOT safely substring-tokenizable. They are
+# dropped from forbidden_tokens and recorded in register_spec.forbidden_forms +
+# rule.ja-register-teineigo instead (joining だ / である). IMPORTANT: register_spec
+# is documentation only — the resolver does not emit it into .resolved/ja.json and
+# neither lint_content nor the example lint scan it (both read only forbidden_tokens),
+# so these two forms are NO LONGER machine-detected; they now rely on native-speaker
+# review (the register-lock label). This is a deliberate trade: a substring token
+# here false-positives on polite text more often than it catches a real casual lapse.
 #   ぜ      — matches なぜ ("why") and ぜひ ("by all means");
 #   してくれ — matches the polite benefactive してくれました / してくれます
 #             (the 〜ました / 〜ます ending is teineigo-compliant; only the bare
@@ -39,9 +44,10 @@ source: onetimesecret/locales/guides/for-translators/ja.md
 # polite text): the plain copula だ — it is a substring of the very common polite
 # request form ください (100+ hits) plus いただく / 一度だけ / まだ; and である —
 # it appears mid-sentence in the polite construction である必要があります. Those
-# two plain forms are locked via `register_spec.forbidden_forms` + the rule
-# rule.ja-register-teineigo instead. SPEC §2.3 lint only scans `good` examples,
-# and all `good` examples here are verified clean against this token list.
+# two plain forms are recorded in `register_spec.forbidden_forms` + the rule
+# rule.ja-register-teineigo — as policy for native-speaker review, NOT as a machine
+# check (the linters scan only forbidden_tokens). SPEC §2.3 lint only scans `good`
+# examples, and all `good` examples here are verified clean against this token list.
 #
 # AGENT-AUTHORED; requires native-speaker (JA) sign-off — see PR label.
 form: other
@@ -70,13 +76,13 @@ register_spec:
     verb_endings: [ます, ません, ました, ましょう]
     negative_polite: [ません, ありません, ではありません]
   forbidden_forms:
-    plain_copula: [だ, である]            # plain/常体 copula — see note: NOT in forbidden_tokens (false-positives on ください/必要); locked here + by rule.
-    casual_imperative: [しろ, するな]      # also tokenized (zero false positives)
-    casual_conjecture: [だろう, だろ]      # also tokenized
-    casual_question: [かい]               # also tokenized
-    casual_negation: [じゃない]            # also tokenized
-    casual_emphatic: [ぞ, ぜ]             # ぞ tokenized; ぜ spec-only (FP on なぜ/ぜひ — onetimesecret#3530)
-    casual_request: [してくれ]            # spec-only (FP on polite してくれました/してくれます — onetimesecret#3530)
+    plain_copula: [だ, である]            # plain/常体 copula — NOT in forbidden_tokens (FP on ください/必要); doc-only, review-enforced, not machine-detected.
+    casual_imperative: [しろ, するな]      # also in forbidden_tokens — machine-detected (zero false positives)
+    casual_conjecture: [だろう, だろ]      # also in forbidden_tokens — machine-detected
+    casual_question: [かい]               # also in forbidden_tokens — machine-detected
+    casual_negation: [じゃない]            # also in forbidden_tokens — machine-detected
+    casual_emphatic: [ぞ, ぜ]             # ぞ in forbidden_tokens (machine-detected); ぜ doc-only, not machine-detected (FP on なぜ/ぜひ — onetimesecret#3530)
+    casual_request: [してくれ]            # doc-only, not machine-detected (FP on polite してくれました/してくれます — onetimesecret#3530)
   voice_by_context:
     buttons_and_actions: "命令形 / imperative noun-form (例: 保存, 削除, 送信) — concise label form, not casual speech."
     status_and_notifications: "受動態/完了形 — passive/declarative polite (例: 保存されました, 削除済み)."
@@ -84,10 +90,14 @@ register_spec:
   notes: >-
     The plain copula だ / である is the primary casual marker but is unsafe to
     substring-match against polite Japanese (だ is inside ください, である inside
-    である必要があります). It is enforced via rule.ja-register-teineigo and this
-    spec rather than forbidden_tokens. As of onetimesecret#3530, ぜ and してくれ
-    join だ/である in the spec-only set: ぜ false-positives on なぜ/ぜひ and
-    してくれ on the polite benefactive してくれました/してくれます, so neither can
-    be safely substring-matched. Imperative noun-forms on buttons (保存,
-    削除) are the prescribed UI voice, NOT a register violation.
+    である必要があります). It is therefore documented here and in
+    rule.ja-register-teineigo as policy for native-speaker review rather than
+    placed in forbidden_tokens — register_spec is NOT consumed by the resolver or
+    the content linter (which scan only forbidden_tokens), so it is not a machine
+    check. As of onetimesecret#3530, ぜ and してくれ join だ/である in this
+    review-only set: ぜ false-positives on なぜ/ぜひ and してくれ on the polite
+    benefactive してくれました/してくれます, so neither can be safely
+    substring-matched, and automated detection of them is intentionally dropped.
+    Imperative noun-forms on buttons (保存, 削除) are the prescribed UI voice,
+    NOT a register violation.
 baseline_ref: baselines.ja

--- a/rules/locales/nl/register.yaml
+++ b/rules/locales/nl/register.yaml
@@ -21,6 +21,14 @@ forbidden_tokens:
   - { token: uw,    context: standalone_word, severity: error, note: "formal possessive" }
   - { token: uwe,   context: standalone_word, severity: error, note: "formal possessive, inflected/archaic form" }
   - { token: uzelf, context: standalone_word, severity: error, note: "formal reflexive pronoun" }
-exceptions: []
+exceptions:
+  # 'u' in the relative-time string "Nog {hours}u" abbreviates 'uur' (hours),
+  # not the formal pronoun. The standalone-word 'u' lock false-positives on the
+  # trailing 'u' after the interpolation; allowlist that exact span. The
+  # register header already flags this collision ("'u' is also the abbreviation
+  # for 'uur'"). (onetimesecret#3530)
+  - token: "{hours}u"
+    reason: "'u' = 'uur' (hours) abbreviation in 'Nog {hours}u', not the formal pronoun"
+    scope: web.organizations.invitations.expires_in_hours
 rule_ref: rule.register-lock
 baseline_ref: baselines.nl


### PR DESCRIPTION
## What

Two register **false positives** surfaced by the consumer-content gate (onetimesecret#3530 / #42), both verified against the live app content with `lib/resolver/lint_content.py`.

### ja — remove `ぜ` and `してくれ` from `forbidden_tokens`
The header asserted every token had *"ZERO occurrences (no false positives)"*. Two do not:

| token | matches (polite/neutral) | meaning |
|---|---|---|
| `ぜ` | `なぜ`, `ぜひ` | "why", "by all means" |
| `してくれ` | `してくれました`, `してくれます` | polite benefactive — `〜ました/〜ます` **is** teineigo |

`してくれ` as a casual *request* is a real violation, but substring matching cannot isolate it from the polite benefactive. Both are unsafe for exactly the reason `だ` / `である` already are, so they move to `register_spec.forbidden_forms` + `rule.ja-register-teineigo`:
- `casual_emphatic: [ぞ, ぜ]` (ぜ now spec-only)
- `casual_request: [してくれ]` (new)

### nl — add one `exceptions` entry for `{hours}u`
In `"Nog {hours}u"` the trailing `u` abbreviates **`uur`** (hours), not the formal pronoun. The `standalone_word` `u` lock false-positives on it; the register header already names this `u`/`uur` collision. Narrow span allowlist.

## Verification (resolver engine, not byte-grep)
Regenerated `.resolved/{ja,nl}.json` from these edits, then linted the **app's** shipped content:

```
ja: OK   — 0 hit(s) / 2209 strings   (was 2: なぜ, 寄付してくれました)
nl: FAIL — 12 hit(s) / 2209 strings  (was 13; {hours}u now suppressed)
```

Test suites: `tests/resolver` 14/14 · `tests/lint_content` 16/16 · `tests/schema` 34/34.

## Deliberately NOT in this PR — the nl B2B carve-out (the remaining 12 hits)
The remaining 12 nl hits are the documented **formal B2B / legal / marketing carve-out** (feature-regions legal text; billing / homepage / translations marketing). The app maintainer's decision (onetimesecret#3530) is to keep those formal.

This PR does **not** encode that carve-out, because the current `exceptions` mechanism cannot express it cleanly:
- `_exception_spans` matches each exception `token` as **`substring`** only and suppresses a forbidden hit that falls *inside* an exception span (the "du-in-Duden" coincidence). It is designed for a token that *coincidentally* sits inside an unrelated word — not for a *legitimate, policy-blessed* use of the forbidden token itself.
- The `exception.scope` field exists in `register.schema.json` but is **not read** by the engine, so it provides no key/file scoping today.

Encoding the carve-out would require either phrase/string-anchored exceptions (couples this register to nl wording, fragile) or a proper **key-scoped carve-out** — which is what the deferred robust gate (#42) is for.

**Resolved (2026-06-25):** rather than abuse the allowlist or block the gate on a deferred feature, the 12 nl strings were brought to the locale's declared informal lock (`form: informal`) in the app (onetimesecret#3537). So this PR stays scoped to the two genuine false positives (ja tokens + `{hours}u`), and cs/ja/nl now **all scan clean** against the resolver engine. A real per-surface formal tone, if ever wanted, can return cleanly via #42 key-scoping — as a deliberate feature, not drift.

## Note (out of scope here)
The other ja substring tokens (`かい`, `しろ`, `するな`, `ぞ`) carry the same latent risk against polite vocabulary (`階`/`回`/`会`, `面白い`/`うしろ`, `するなら`, `どうぞ`) — currently zero live hits, but worth a follow-up to migrate CJK enforcement off substring tokens toward `register_spec`/rule.

🤖 Agent-authored (onetimesecret#3530); requires native-speaker JA + NL sign-off per the register-lock label.
