### PR TITLE
docs(derive-action): make the consumer contract explicit (tag immutability + action/data-ref back-compat)

### DIFF
--- a/.github/actions/derive/action.yml
+++ b/.github/actions/derive/action.yml
@@ -33,10 +33,11 @@ inputs:
   ref:
     description: >-
       translation-rules commit SHA (or tag) to derive at — the consumer's
-      canonical data pin. In steady state this is the same ref you pinned
-      `uses: .../derive@<ref>` to (action code and governing data at one
-      release); it MAY differ to dry-run a candidate translation-rules release
-      against the corpus before bumping the action SHA. See ADR-006.
+      canonical data pin. In steady state it resolves to the same commit you
+      pinned `uses: .../derive@<pin>` to (action code and governing data at one
+      release — `uses:` is typically a SHA, this `ref:` may be a tag); it MAY
+      differ to dry-run a candidate translation-rules release against the corpus
+      before bumping the action SHA. See ADR-006.
     required: true
   locales:
     description: >-

--- a/.github/actions/derive/action.yml
+++ b/.github/actions/derive/action.yml
@@ -8,9 +8,16 @@
 #
 #   - uses: onetimesecret/translation-rules/.github/actions/derive@<pin>
 #     with:
-#       ref: <pin>            # SAME commit as @<pin> above
+#       ref: <pin>            # steady state = same release as @<pin>; MAY differ
 #       locales: de_AT fr_CA  # or "all"
 #       emit-dir: .derived    # gitignored — a cache, never committed (ADR-005)
+#
+# The two pins are independent: @<pin> selects the action CODE, `ref:` selects
+# the rules+resolver DATA it checks out. Steady state pins both to the same
+# release; the override path lets a maintainer point `ref:` at a candidate
+# translation-rules release (a different commit/tag) to dry-run it against the
+# corpus BEFORE bumping the action SHA. This stays safe because release tags are
+# immutable and the consumer contract is back-compatible — see ADR-006.
 #
 # The output is byte-reproducible for a given pin: _meta.source_commit is the
 # pin and _meta.generated_at is the pin's committer date (UTC), so a freshness
@@ -26,8 +33,10 @@ inputs:
   ref:
     description: >-
       translation-rules commit SHA (or tag) to derive at — the consumer's
-      canonical pin. Use the SAME ref you pinned `uses: .../derive@<ref>` to,
-      so the action code and the governing data are one commit.
+      canonical data pin. In steady state this is the same ref you pinned
+      `uses: .../derive@<ref>` to (action code and governing data at one
+      release); it MAY differ to dry-run a candidate translation-rules release
+      against the corpus before bumping the action SHA. See ADR-006.
     required: true
   locales:
     description: >-

--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ is. That Status line, not this README, is the source of truth for what is wired.
 `N` is the total commit count on `main` — a monotonic build number, not semver.
 The tag is a convenience pin only; the binding is always the commit SHA. Pin the
 submodule to a tag when you want a named, browsable release, or to a SHA
-otherwise. Tags are cut on merge to `main` and never moved — new governance
-content gets a new tag, because re-pointing an existing tag would silently change
-the derived governance for every consumer pinning it and break their
-reproducibility and freshness gates.
+otherwise. Tags are cut on merge to `main` and never re-pointed — neither moved
+with `git tag -f` nor deleted and recreated at a different commit. New governance
+content gets a new tag, because re-pointing an existing tag either way would
+silently change the derived governance for every consumer pinning it and break
+their reproducibility and freshness gates.
 
 ## Working in this repo
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ is. That Status line, not this README, is the source of truth for what is wired.
 `N` is the total commit count on `main` — a monotonic build number, not semver.
 The tag is a convenience pin only; the binding is always the commit SHA. Pin the
 submodule to a tag when you want a named, browsable release, or to a SHA
-otherwise.
+otherwise. Tags are cut on merge to `main` and never moved — new governance
+content gets a new tag, because re-pointing an existing tag would silently change
+the derived governance for every consumer pinning it and break their
+reproducibility and freshness gates.
 
 ## Working in this repo
 

--- a/docs/architecture/decision-records/adr-006-shared-derive-action.md
+++ b/docs/architecture/decision-records/adr-006-shared-derive-action.md
@@ -43,6 +43,61 @@ hosted place, which ADR-005 rejects). Composite rather than `workflow_call`
 because derivation is a step *inside* a consumer's existing job (its gate, its
 translation run), which needs the output in that job's workspace.
 
-Caller contract: pass `ref` equal to the commit you pinned `@` to, and gitignore
-`emit-dir`. A freshness gate asserts the run used the committed pin by comparing
-it to the action's `source-commit` output (#36).
+Caller contract: in steady state pass `ref` equal to the commit you pinned `@`
+to, and gitignore `emit-dir`. A freshness gate asserts the run used the committed
+pin by comparing it to the action's `source-commit` output (#36).
+
+## Consequences
+
+The action pins its CODE (`uses: .../derive@<pin>`, a SHA digest) and its DATA
+(`with: { ref: <pin> }`, the rules+resolver it checks out) *separately*. The
+sample above is the steady state — both at the same release. They MAY also
+differ deliberately: the override path lets a maintainer point `ref:` at a
+candidate translation-rules release and dry-run it against the corpus *before*
+bumping the action SHA (the decoupling onetimesecret#3541 adopts). This is
+ref-type agnostic — a SHA or a tag in `ref:` both work, no code change needed —
+because `ref` is checked out *first*, then collapsed to a concrete SHA by
+`git rev-parse HEAD` of the checkout. In the action path that rev-parse is the
+wrapper's `resolve-ref` step, which feeds the SHA to the resolver as
+`--source-commit`; run bare, the resolver's own `_resolve_source_commit` does the
+same rev-parse. Either way the SHA is derived post-checkout, so whatever `ref`
+names resolves correctly. Two conventions make that override safe:
+
+**Release tags are immutable.** `v0.0.N` tags (`.github/workflows/publish.yml`,
+cut on every merge to `main`) are never moved — no `git tag -f`, no re-point.
+New governance content means a new tag. Re-pointing a tag would silently change
+the derived governance for every consumer pinning that tag and break the
+per-pin byte-reproducibility this ADR relies on (`_meta.source_commit` /
+`_meta.generated_at`, ADR-005). So a `ref:` pinned by tag name is as stable as
+one pinned by SHA.
+
+**The consumer contract is back-compatible across releases.** Because a run may
+execute the action wrapper (`uses:`) and the resolver/data (`ref:`) at *different*
+releases, the surface where the wrapper meets the resolver must not change
+incompatibly without a deliberate major release. That frozen surface is:
+
+- action inputs: `ref`, `locales`, `emit`, `lint`, `emit-dir`, `checkout-path`
+- action outputs: `emit-dir`, `source-commit`, `generated-at`
+- resolver CLI flags: `--emit`, `--emit-dir`, `--source-commit`, `--generated-at`,
+  `--lint`
+- the `rules/` directory layout the resolver runs against (ADR-002)
+- the pinned resolver dep set (`jsonschema`, `referencing`, `pyyaml`), declared
+  in lockstep across `pyproject.toml`, this `action.yml`, and the CI/resolver
+  pins it mirrors — a divergence here is the same hazard
+
+A mismatch — e.g. an older action wrapper invoking a renamed resolver flag — must
+fail LOUDLY (non-zero exit), never produce wrong-but-green output. Documenting
+the contract is what lets us keep that promise deliberately rather than by luck.
+
+Caveat on "major release": the release automation only ever emits `v0.0.N`,
+where `N` is the monotonic commit count on `main` (see README "Release tags");
+the major and minor are permanently `0`. There is no automated path to a major
+bump, so honouring this contract is a deliberate human gate — a major release
+would itself be a manual change to the release process, not something the tagger
+produces. Semver is aspirational here, not yet adopted; the guarantee is the
+intent to not break the listed surface silently, not a scheme the automation
+enforces.
+
+Consumers pin to a commit (ADR-004) and never vendor the derived output
+(ADR-005); both conventions above exist to keep those two guarantees intact when
+the CODE and DATA pins are allowed to diverge.

--- a/docs/architecture/decision-records/adr-006-shared-derive-action.md
+++ b/docs/architecture/decision-records/adr-006-shared-derive-action.md
@@ -64,12 +64,13 @@ same rev-parse. Either way the SHA is derived post-checkout, so whatever `ref`
 names resolves correctly. Two conventions make that override safe:
 
 **Release tags are immutable.** `v0.0.N` tags (`.github/workflows/publish.yml`,
-cut on every merge to `main`) are never moved — no `git tag -f`, no re-point.
-New governance content means a new tag. Re-pointing a tag would silently change
-the derived governance for every consumer pinning that tag and break the
-per-pin byte-reproducibility this ADR relies on (`_meta.source_commit` /
-`_meta.generated_at`, ADR-005). So a `ref:` pinned by tag name is as stable as
-one pinned by SHA.
+cut on every merge to `main`) are never re-pointed — not by `git tag -f`, and
+not by deleting and recreating a tag at a different commit (which has the same
+effect for any consumer pinning by tag name). New governance content means a new
+tag. Moving a tag either way would silently change the derived governance for
+every consumer pinning that tag and break the per-pin byte-reproducibility this
+ADR relies on (`_meta.source_commit` / `_meta.generated_at`, ADR-005). So a
+`ref:` pinned by tag name is as stable as one pinned by SHA.
 
 **The consumer contract is back-compatible across releases.** Because a run may
 execute the action wrapper (`uses:`) and the resolver/data (`ref:`) at *different*


### PR DESCRIPTION
## What & why

Docs-only. The shared derive action (`.github/actions/derive`, ADR-006) is pinned
by consumers **twice** — the action CODE (`uses: .../derive@<sha>`) and the
rules+resolver DATA (`with: { ref: }`). onetimesecret#3541 **decouples** these so
a candidate translation-rules release can be dry-run against the corpus *before*
the action SHA is bumped — meaning the two pins may deliberately point at
different releases for a run.

Two guarantees that override path relies on were **implicit**. This makes them
explicit. **No code change** — the resolver already derives the SHA via
`git rev-parse HEAD` (ref-type agnostic), so a tag in `ref:` already works.

## Changes (3 files, +74/−7)

- **`.github/actions/derive/action.yml`** — header comment and the `ref` input
  `description:` no longer assert `ref:` == the `uses:` pin. They now state: same
  release in steady state, MAY differ to dry-run a candidate. (`required: true`
  intact; no behavioral YAML touched.)
- **`docs/architecture/decision-records/adr-006-shared-derive-action.md`** — new
  `## Consequences` recording both conventions:
  1. **Tag immutability** — `v0.0.N` tags are cut on merge, never moved;
     re-pointing would break ADR-005 byte-reproducibility (`_meta.source_commit` /
     `_meta.generated_at`).
  2. **Back-compat consumer contract** — the surface where the action wrapper
     meets the resolver (inputs, outputs, resolver CLI flags, `rules/` layout, dep
     set) must not change incompatibly without a deliberate major release;
     mismatch fails loud, never wrong-but-green.
  - Honest caveat: the release automation only emits `v0.0.N` (major/minor
    permanently `0`), so a "major release" is a human gate, not something the
    tagger produces. Semver is aspirational, not asserted.
- **`README.md`** — one sentence in "Release tags": tags are cut on merge, never
  moved; new content ⇒ new tag.

## Acceptance criteria (issue #48)

- [x] `action.yml` notes `ref:` MAY differ from the `uses:` pin + what's guaranteed
- [x] ADR-006 records both conventions
- [x] (optional) README release-immutability note

## Verification

- `action.yml` parses as valid YAML (`ref` still `required: true`, no spurious default).
- Repo test suites green (schema 34, resolver 14, + inheritance / lint_content /
  retro_lifecycle / archive_firewall / review_manifest) — confirms docs edits
  broke nothing. Tests prove structure, not prose; wording accuracy was checked by
  reading the diff against source (every input/output/flag name confirmed in
  `action.yml` and `lib/resolver/resolve.py`).

## Related

- Closes #48
- Consumer-side motivation: onetimesecret/onetimesecret#3541
