### PR TITLE
Document shift from submodule vendoring to on-demand derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ In the app, `<emit-dir>` is `generated/i18n/` (gitignored); see the app's
 `_meta.source_commit` in the JSON is **the translation-rules commit the output
 was derived from** — the ref the consumer pinned, resolved to a concrete commit
 at derive time (the action's `git rev-parse HEAD`, or an explicit
-`--source-commit`). With the deterministic `_meta.generated_at` (the pinned
-commit's committer date, UTC) it makes the output byte-reproducible for a given
-pin — which is what the regenerate-in-CI freshness gate relies on.
+`--source-commit`). With `_meta.generated_at` — set to the pinned commit's
+committer date (UTC) by the ADR-006 derive action (or by passing `--generated-at`
+to `resolve.py` directly; the bare CLI otherwise stamps the current time) — the
+output is byte-reproducible for a given pin, which is what the regenerate-in-CI
+freshness gate relies on.
 
 ### What enforces the contract
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CI gate that rejects translation PRs containing forbidden tokens.
     rules.yaml     ─┤─► resolver ──► for-translators/de_AT.md   (human guide)
     glossary.yaml  ─┘                .resolved/de_AT.json        (agent context)
   rules/locales/de/                         │
-    rules.yaml ────────────────────── submodule + CI gate
+    rules.yaml ────────────────────── pin + derive + CI gate
   rules/base.yaml                           │
                                             ▼
                                    PR touching de_AT strings?
@@ -72,44 +72,56 @@ Design notes (non-binding agent analysis, not part of the app-repo contract):
 
 ## Consuming this repo (the app-repo contract)
 
-The app repo vendors this repo as a git submodule and commits the resolver's
-output next to it (`SPEC.md` §2.3):
+A consumer **pins** this repo to a commit (ADR-004) and **derives on demand**.
+It does *not* vendor this repo as a submodule and does *not* commit the
+resolver's output (ADR-005). The derive is the single shared GitHub Action
+(ADR-006); output lands in a gitignored cache, regenerated each run and never
+committed:
 
-- `locales/guides/for-translators/<locale>.md` — human-readable guide.
-  Generated, headed `# GENERATED from translation-rules@<sha> — do not edit, do
-  not cite as source`.
-- `locales/.resolved/<locale>.json` — machine-readable model for translation
+- `<emit-dir>/.resolved/<locale>.json` — machine-readable model for translation
   agents.
+- `<emit-dir>/guides/for-translators/<locale>.md` — human-readable guide,
+  headed `# GENERATED from translation-rules@<sha> — do not edit, do not cite as
+  source`. Derived on demand only — no committed copy, no hosted browse channel
+  (ADR-007); read one by deriving it and opening it from the cache.
 
-`_meta.source_commit` in that JSON is **the translation-rules commit the
-artifacts were generated from** — the rules-repo `HEAD` at resolve time, or an
-explicit `--source-commit` override. It is *not* a copy of the app repo's
-submodule pointer (this repo cannot know its own future submodule SHA). The
-relationship runs the other way: the app-repo gate verifies
-`source_commit == submodule SHA`, which is what proves the committed artifacts
-were generated from the exact rules commit the submodule pins (`SPEC.md` §2.4).
+In the app, `<emit-dir>` is `generated/i18n/` (gitignored); see the app's
+`locales/scripts/derive-governance.sh` and its `resolved-derive-gate.yml` /
+`validate-register.yml` workflows.
+
+`_meta.source_commit` in the JSON is **the translation-rules commit the output
+was derived from** — the ref the consumer pinned, resolved to a concrete commit
+at derive time (the action's `git rev-parse HEAD`, or an explicit
+`--source-commit`). With the deterministic `_meta.generated_at` (the pinned
+commit's committer date, UTC) it makes the output byte-reproducible for a given
+pin — which is what the regenerate-in-CI freshness gate relies on.
 
 ### What enforces the contract
 
-- **Live** — the register forbidden-token gate. App-repo CI
-  (`validate-register.yml`, onetimesecret/onetimesecret#3432) runs
-  `bin/lint-register` from a read-only pinned checkout of this repo against
-  `locales/content/<locale>/*.json` on every content PR. Zero tolerance.
-- **Planned** (`SPEC.md` §2.4) — submodule-pointer freshness, the
-  `source_commit == submodule SHA` check above, and a byte-for-byte hash lock on
-  the generated markdown so hand edits are rejected.
+Both gates derive from a read-only pinned checkout of this repo (the ADR-006
+action) and commit nothing:
 
-Treat the planned items as not-yet-enforced: do not assume drift between rules
-and committed artifacts is caught until the `SPEC.md` §2.4 Status line says it
-is. That Status line, not this README, is the source of truth for what is wired.
+- **Register forbidden-token gate** — the consumer's `validate-register.yml`
+  (onetimesecret/onetimesecret#3432) derives the resolved registers and lints
+  changed `locales/content/<locale>/*.json` on every content PR. Zero tolerance.
+- **Regenerate-in-CI freshness/integrity gate** — the consumer's
+  `resolved-derive-gate.yml` re-derives the full corpus at the pin and lints it,
+  so a consumer cannot pin to a commit whose governance does not lint clean.
+  This replaces the retired byte-hash gate (old `resolved-freshness.yml`): with
+  no committed corpus there is nothing to hash, so the "no hand-edited
+  governance" guarantee is preserved by deriving from scratch instead
+  (ADR-005; onetimesecret/onetimesecret#3510, #36).
+
+`SPEC.md` §2.4 carries the historical gate snapshot; the ADRs above are the
+current source of truth for the consumer model.
 
 ## Release tags
 
 `.github/workflows/publish.yml` tags every merge to `main` as `v0.0.N`, where
 `N` is the total commit count on `main` — a monotonic build number, not semver.
-The tag is a convenience pin only; the binding is always the commit SHA. Pin the
-submodule to a tag when you want a named, browsable release, or to a SHA
-otherwise. Tags are cut on merge to `main` and never re-pointed — neither moved
+The tag is a convenience pin only; the binding is always the commit SHA. Pin to
+a tag when you want a named, browsable release, or to a SHA otherwise. Tags are
+cut on merge to `main` and never re-pointed — neither moved
 with `git tag -f` nor deleted and recreated at a different commit. New governance
 content gets a new tag, because re-pointing an existing tag either way would
 silently change the derived governance for every consumer pinning it and break

--- a/SPEC.md
+++ b/SPEC.md
@@ -201,9 +201,9 @@ Schemas forbid `null` where an empty list or explicit absence field is required.
 4. **Resolve IDs.** Build UUID→path→key index. Dangling refs fail here.
 5. **Attach retros.** Applied retrospectives fold metadata into referenced rules.
 6. **Lint.** Examples must pass their own register lint. Forbidden tokens must be absent from embedded docs. Every example's target must match its sense's target (substring/morphological).
-7. **Emit.** Two outputs:
-   - Markdown: `onetimesecret/locales/guides/for-translators/<locale>.md`, headed `# GENERATED from translation-rules@<sha> — do not edit, do not cite as source`
-   - JSON: `onetimesecret/locales/.resolved/<locale>.json` — stable key order, `_meta.source_commit` carries the pin
+7. **Emit.** Two outputs, written under the caller's `--emit-dir` (a gitignored cache; ADR-005):
+   - Markdown: `<emit-dir>/guides/for-translators/<locale>.md`, headed `# GENERATED from translation-rules@<sha> — do not edit, do not cite as source`
+   - JSON: `<emit-dir>/.resolved/<locale>.json` — stable key order, `_meta.source_commit` carries the pin
 
 **Resolved JSON shape is indexed for agent consumption** — partitioned by the decisions an agent makes at translation time, not by severity:
 
@@ -229,15 +229,15 @@ The `rules`/`context`/`rationale` partition is the surface-level cue that preven
 
 **Status (2026-06-12).** Implemented today in this repo: `schema-validation.yml` (schema, inheritance, resolver merge/lint/emit tests; retro lifecycle, review findings-manifest, and real-tree resolver lint gates), `lint-register.yml` (a `--dry-run` plumbing self-test plus `tests/lint-register.sh`), `python-qc.yml` (ruff lint/format, pyright), the §3 retrospective lifecycle gates (`lib/resolver/retro_lifecycle.py`: 7-day orphan timeout, applied-transition diff check), the §3 review findings-manifest check (`lib/resolver/review_manifest.py`; pre-existing reviews grandfathered — see `_references/reviews/README.md`), the forbidden-token lint over embedded examples and rationale docs (`lib/resolver/lint.py`, run against the repo tree by `schema-validation.yml`; backtick-quoted token mentions in docs are allowed, bare-prose uses fail), and the `rules/_archive/` firewall (`lib/resolver/archive_firewall.py` + `archive-firewall.yml`: moving or copying a file out of `rules/_archive/` or `rules/retrospectives/_archive/` — or deleting one — requires the `prescriptive-promotion` label).
 
-**App repo:** the `forbidden_tokens` grep against `locales/content/<locale>/*.json` is **live** (`validate-register.yml` via onetimesecret/onetimesecret#3432 — `bin/lint-register` from a read-only pinned checkout of this repo, every governed locale). Still planned: submodule pointer freshness on locale-content PRs; `.resolved/<locale>.json`'s `_meta.source_commit` equals submodule SHA; `for-translators/*.md` hash matches resolver output — hand edits rejected.
+**App repo:** the `forbidden_tokens` grep against `locales/content/<locale>/*.json` is **live** (`validate-register.yml` via onetimesecret/onetimesecret#3432 — `bin/lint-register` from a read-only pinned checkout of this repo, every governed locale). *(Originally planned here: submodule-pointer freshness; `.resolved` `_meta.source_commit` == submodule SHA; `for-translators/*.md` hash match — all **retired**, see the superseded note below.)*
 
-**Cross-repo pipeline gate (planned).** A locale content PR is blocked unless the submodule is current, resolved JSON was regenerated in the same PR, and lint passes. This is what mechanically prevents the next class of "bypass by direct edit."
+**Cross-repo pipeline gate (originally planned; retired — see note below).** A locale content PR is blocked unless the submodule is current, resolved JSON was regenerated in the same PR, and lint passes. This is what mechanically prevents the next class of "bypass by direct edit."
 
 > **Superseded by [ADR-005](docs/architecture/decision-records/adr-005-no-vendored-derived-output.md) / [ADR-006](docs/architecture/decision-records/adr-006-shared-derive-action.md).** The submodule-pointer and byte-hash gates above are retired together with the committed corpus (there is nothing to hash). The guarantee — no hand-edited governance reaches translation — is preserved by **regenerating from scratch at the pin in CI** and linting: the consumer's `resolved-derive-gate.yml` re-derives the full corpus via the shared derive action and fails if the pinned commit's governance does not lint clean, and `validate-register.yml` derives the registers read-only to lint changed content. Both commit nothing. There is no git submodule — the consumer pins a commit (ADR-004) and derives at it. See onetimesecret/onetimesecret#3510 and #36.
 
 **How the 2026-04 failure mode is mechanically prevented (by design — see Status above for what is wired today):**
 1. Change-log-style prose physically lives in `rules/_archive/` or `rules/retrospectives/` — neither is compiled into output.
-2. `for-translators/*.md` is generated and hash-locked. A report cannot be pasted in.
+2. `for-translators/*.md` is derived on demand (never committed) and regenerated from scratch at the pin in CI, then linted — a report cannot be pasted in (ADR-005 replaces the earlier byte-hash lock).
 3. Rules are YAML with schema. Prose cannot reach the `rules` partition without authoring a schema-valid file.
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,7 +44,7 @@ The single smallest implementation that would have blocked the 2026-04-12 de_AT 
                                                ② artifacts
                                                   .resolved/<loc>.json     (agent context)
                                                   for-translators/<loc>.md (human guide)
-                                                       │  vendored as submodule, pinned by SHA
+                                                       │  derived on demand at the pin (ADR-005)
                                                        ▼
                                                ③ agents translate · app repo
                                                   consume .resolved → write content/<loc>/*.json
@@ -191,6 +191,8 @@ Schemas forbid `null` where an empty list or explicit absence field is required.
 
 **Output commit policy:** Generated artifacts (`for-translators/<locale>.md` and `.resolved/<locale>.json`) are committed to the app repo, not CI-generated-only. This is required for the file-hash CI check in §2.4 to have a baseline to compare against, and so translators and external reviewers can browse the current guide without running the resolver.
 
+> **Superseded by [ADR-005](docs/architecture/decision-records/adr-005-no-vendored-derived-output.md) and [ADR-007](docs/architecture/decision-records/adr-007-guides-derived-on-demand.md).** Consumers no longer commit derived output. `.resolved/*.json` and the `for-translators/*.md` guides are derived **on demand** into a gitignored cache (in the app, `generated/i18n/`), never committed; the guides have no hosted browse channel — a human reads one by deriving it (see [ADR-006](docs/architecture/decision-records/adr-006-shared-derive-action.md)). The §2.4 file-hash baseline this policy fed is retired (see the §2.4 note). The emit paths in step 7 below describe the on-disk *layout* under `--emit-dir`, not committed locations.
+
 `lib/resolver/resolve.py <locale> [--lint] [--emit=md,json] [--all]` drives everything:
 
 1. **Load + schema-validate.** Reject malformed input at this boundary.
@@ -230,6 +232,8 @@ The `rules`/`context`/`rationale` partition is the surface-level cue that preven
 **App repo:** the `forbidden_tokens` grep against `locales/content/<locale>/*.json` is **live** (`validate-register.yml` via onetimesecret/onetimesecret#3432 — `bin/lint-register` from a read-only pinned checkout of this repo, every governed locale). Still planned: submodule pointer freshness on locale-content PRs; `.resolved/<locale>.json`'s `_meta.source_commit` equals submodule SHA; `for-translators/*.md` hash matches resolver output — hand edits rejected.
 
 **Cross-repo pipeline gate (planned).** A locale content PR is blocked unless the submodule is current, resolved JSON was regenerated in the same PR, and lint passes. This is what mechanically prevents the next class of "bypass by direct edit."
+
+> **Superseded by [ADR-005](docs/architecture/decision-records/adr-005-no-vendored-derived-output.md) / [ADR-006](docs/architecture/decision-records/adr-006-shared-derive-action.md).** The submodule-pointer and byte-hash gates above are retired together with the committed corpus (there is nothing to hash). The guarantee — no hand-edited governance reaches translation — is preserved by **regenerating from scratch at the pin in CI** and linting: the consumer's `resolved-derive-gate.yml` re-derives the full corpus via the shared derive action and fails if the pinned commit's governance does not lint clean, and `validate-register.yml` derives the registers read-only to lint changed content. Both commit nothing. There is no git submodule — the consumer pins a commit (ADR-004) and derives at it. See onetimesecret/onetimesecret#3510 and #36.
 
 **How the 2026-04 failure mode is mechanically prevented (by design — see Status above for what is wired today):**
 1. Change-log-style prose physically lives in `rules/_archive/` or `rules/retrospectives/` — neither is compiled into output.
@@ -271,11 +275,11 @@ The critical ask. Every edge labeled machine-enforced or human-in-the-loop.
                         │ [CI-ENFORCED: retro → applied on merge]
                         ▼
                 ┌────────────────┐
-                │ app repo bump  │  submodule advances;
+                │ app repo bump  │  pin advances;
                 │ PR (scheduled) │  resolver regenerates artifacts
                 └────────────────┘  [MACHINE opens, HUMAN approves]
                         │ [CI: full lint against current locale
-                        │  content; hash match on generated files]
+                        │  content; regenerate + lint at the pin]
                         ▼
                 ┌────────────────┐
                 │ resolved       │  for-translators/<locale>.md
@@ -370,6 +374,12 @@ Neither is part of this repo's design. Both are execution substrate. No cross-re
 
 ## 7. Migration Path
 
+> **Historical plan.** This section is the original migration plan as written
+> before implementation. Steps that "add the submodule" or regenerate committed
+> artifacts were superseded by [ADR-004](docs/architecture/decision-records/adr-004-consumers-pin-to-commit.md)
+> (pin to a commit, no submodule) and [ADR-005](docs/architecture/decision-records/adr-005-no-vendored-derived-output.md)
+> (no vendored output; derive on demand). Kept for provenance.
+
 **Phase 0 (this week).** Four `register.yaml` files, one shell lint, one retrospective. See §1.
 
 **Phase 1 (MVP end-to-end for de_AT).**
@@ -418,4 +428,4 @@ Flagged for honesty, not solved.
 - **Changes to English source strings** bypass this repo entirely. A new interpolation variable only surfaces at resolver run in the app repo.
 - **Retrospective fatigue.** If every finding requires a retro, friction discourages filing. Short-form retros (three sentences) are the answer; adoption depends on ergonomic `bin/mint-retro` tooling not specified here.
 - **Cross-rule interaction bugs.** Lint asserts per-rule. Interactions ("if register is formal AND term has a legal variant, use the legal variant") require a richer lint language.
-- **Submodule update lag.** Between rule merge and app repo bump, there's a window where lint runs against stale rules. Scheduled bump PRs reduce but do not eliminate it.
+- **Pin update lag.** Between rule merge and app repo pin bump, there's a window where lint runs against stale rules. Scheduled bump PRs reduce but do not eliminate it.

--- a/lib/resolver/emit_json.py
+++ b/lib/resolver/emit_json.py
@@ -6,9 +6,11 @@ greppable by human-readable name (SPEC §6.1). The only non-deterministic field,
 `_meta.generated_at`, is injected by the caller, so a fixed value yields a
 reproducible file for golden tests.
 
-Per Q3 (2026-05-29) the JSON is NOT content-hash-checked the way the markdown
-is — the app-repo CI gate checks `_meta.source_commit == submodule SHA` only
-(SPEC §2.4). Determinism here exists for the golden test, not a hash gate.
+Determinism matters beyond golden tests: under the no-vendor model (ADR-005)
+consumers derive this file on demand and CI regenerates it from scratch at the
+pin, so byte-stable output is what lets the regenerate-in-CI freshness gate
+pass. There is no committed copy and no content-hash / `source_commit ==
+submodule-SHA` gate — both retired with the vendored corpus (ADR-005).
 """
 
 from __future__ import annotations

--- a/lib/resolver/emit_markdown.py
+++ b/lib/resolver/emit_markdown.py
@@ -1,10 +1,12 @@
 """Emit `for-translators/<locale>.md`. SPEC.md §2.3 step 7a.
 
-A pure projection of the assembled model into human-readable reference. The
-file is hash-locked in the app repo (SPEC §2.4): the resolver's output must
-match byte-for-byte or CI rejects hand edits. The only variable is the
-`@<sha>` source-commit pin in the header (injected by the caller); there is no
-`generated_at`, so a pinned sha yields a fully reproducible file.
+A pure projection of the assembled model into human-readable reference. Under
+the no-vendor model (ADR-005/ADR-007) the guide is derived on demand and never
+committed; the byte-hash lock is retired, and its guarantee (no hand-edited
+governance) is preserved by regenerating from scratch at the pin in CI. The
+only variable is the `@<sha>` source-commit pin in the header (injected by the
+caller); there is no `generated_at`, so a pinned sha yields a fully
+reproducible file.
 
 The header is the SPEC §2.3 literal — do not paraphrase it; it is what marks
 the file as generated and uncitable as a rule source.

--- a/lib/resolver/resolve.py
+++ b/lib/resolver/resolve.py
@@ -615,10 +615,11 @@ def _emit_for_locale(
         written.append(str(path))
     if "md" in formats:
         # SPEC §2.3: the human guide is emitted to
-        # <emit-dir>/guides/for-translators/<locale>.md (the app repo vendors it
-        # at locales/guides/for-translators/), alongside the JSON's
-        # <emit-dir>/.resolved/. Keeping the `guides/` segment lets a single
-        # `--emit-dir locales` land both artifacts in their canonical homes.
+        # <emit-dir>/guides/for-translators/<locale>.md, alongside the JSON's
+        # <emit-dir>/.resolved/. Consumers derive on demand into a gitignored
+        # cache (ADR-005/ADR-007) -- never committed -- so <emit-dir> is a
+        # throwaway location (the app uses generated/i18n/). Keeping the `guides/`
+        # segment lets a single `--emit-dir` land both artifacts together.
         path = emit_dir / "guides" / "for-translators" / f"{locale}.md"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(emit_markdown(model, source_commit), encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR updates documentation and code comments to reflect the architectural shift from vendoring translation-rules as a git submodule with committed derived artifacts to a model where consumers pin to a commit and derive outputs on demand into gitignored caches.

## Related

- **Tracking issue:** onetimesecret/onetimesecret#3510 — *[i18n-arch] Migrate the app to the no-vendor translation model (ADR-005)*
- **App-repo counterpart:** onetimesecret/onetimesecret#3565 — restores the app's on-demand derive script, adds the pin-contract test, and wires it into CI. The two PRs land independently but belong to one migration; cross-linked for posterity.

## Key Changes

- **README.md**: Updated the consuming contract to describe the new pin-and-derive model (ADR-004, ADR-005, ADR-006) instead of submodule vendoring. Clarified that derived outputs (`.resolved/*.json` and `for-translators/*.md` guides) are no longer committed and are regenerated on each CI run. Corrected the `_meta.generated_at` note (the ADR-006 action stamps the committer date; the bare CLI needs `--generated-at`).

- **SPEC.md**:
  - Added supersession notes referencing ADRs 005, 006, and 007 for the output commit policy and cross-repo pipeline gate sections
  - Updated §2.3 step-7 emit paths to `<emit-dir>/...` (the resolver's actual output), and the pipeline diagram to "pin advances" / "regenerate + lint at the pin"
  - Marked the residual "still planned" submodule/hash gate text and the "hash-locked" bullet as retired
  - Added a "Historical plan" header to §7 (Migration Path); renamed the "Submodule update lag" known issue to "Pin update lag"

- **lib/resolver/{resolve,emit_json,emit_markdown}.py**: Updated comments/docstrings to the derive-on-demand model (no committed copy, no `source_commit == submodule-SHA` / byte-hash gate; ADR-005/007).

## Implementation Details

Docs/comments only — resolver behavior is unchanged. Resolver tests 14/0; ruff clean.

https://claude.ai/code/session_0129jPo7aa9EKagjReUxyjHo